### PR TITLE
Remove false get action from services help

### DIFF
--- a/packages/mcp/src/handlers/help.ts
+++ b/packages/mcp/src/handlers/help.ts
@@ -189,7 +189,6 @@ const RESOURCE_HELP: Record<string, ResourceHelp> = {
     description: 'Budget line items within projects',
     actions: {
       list: 'List services with optional filters',
-      get: 'Get a single service by ID',
     },
     filters: {
       project_id: 'Filter by project',


### PR DESCRIPTION
Closes #41

The help documentation for `services` advertised a `get` action that does not exist — there is no `getService(id)` in the API client, no core executor, and the handler only supports `list`.