### PR TITLE
Add empty-update validation to updateComment executor

### DIFF
--- a/packages/core/src/executors/comments/update.test.ts
+++ b/packages/core/src/executors/comments/update.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createTestExecutorContext } from '../../context/test-utils.js';
+import { ExecutorValidationError } from '../errors.js';
 import { updateComment } from './update.js';
 
 describe('updateComment', () => {
@@ -22,14 +23,12 @@ describe('updateComment', () => {
     expect(result.data).toEqual(mockComment);
   });
 
-  it('sends empty data when body is undefined', async () => {
-    const updateCommentApi = vi.fn().mockResolvedValue({ data: mockComment });
-    const ctx = createTestExecutorContext({
-      api: { updateComment: updateCommentApi },
-    });
+  it('should throw ExecutorValidationError when no updates provided', async () => {
+    const ctx = createTestExecutorContext();
 
-    await updateComment({ id: '1' }, ctx);
-
-    expect(updateCommentApi).toHaveBeenCalledWith('1', {});
+    await expect(updateComment({ id: '1' }, ctx)).rejects.toThrow(ExecutorValidationError);
+    await expect(updateComment({ id: '1' }, ctx)).rejects.toThrow(
+      'No updates specified. Provide at least one of: body',
+    );
   });
 });

--- a/packages/core/src/executors/comments/update.ts
+++ b/packages/core/src/executors/comments/update.ts
@@ -4,12 +4,21 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { UpdateCommentOptions } from './types.js';
 
+import { ExecutorValidationError } from '../errors.js';
+
 export async function updateComment(
   options: UpdateCommentOptions,
   ctx: ExecutorContext,
 ): Promise<ExecutorResult<ProductiveComment>> {
   const data: Record<string, string | undefined> = {};
   if (options.body !== undefined) data.body = options.body;
+
+  if (Object.keys(data).length === 0) {
+    throw new ExecutorValidationError(
+      'No updates specified. Provide at least one of: body',
+      'options',
+    );
+  }
 
   const response = await ctx.api.updateComment(options.id, data);
   return { data: response.data };


### PR DESCRIPTION
Closes #46

All other update executors throw `ExecutorValidationError` when no fields are provided. `updateComment` was missing this guard, sending an empty PATCH to the API.