### PR TITLE
Remove stale budget mocks from MCP handler tests

### DIFF
--- a/packages/mcp/src/handlers.test.ts
+++ b/packages/mcp/src/handlers.test.ts
@@ -44,8 +44,6 @@ vi.mock('@studiometa/productive-api', () => {
     getCompany: vi.fn(),
     createCompany: vi.fn(),
     updateCompany: vi.fn(),
-    getBudgets: vi.fn(),
-    getBudget: vi.fn(),
     getAttachments: vi.fn(),
     getAttachment: vi.fn(),
     deleteAttachment: vi.fn(),


### PR DESCRIPTION
Closes #45

The `getBudgets`/`getBudget` API methods were removed in #40 but mock entries remained.