### PR TITLE
Remove stale budgets reference in CLI error hint

### DIFF
--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -480,7 +480,7 @@ export class CommandError extends CliError {
   static unknownCommand(command: string): CommandError {
     return new CommandError(`Unknown command: ${command}`, command, undefined, [
       'Run: productive --help to see available commands',
-      'Available commands: projects, time, tasks, people, services, budgets, companies, comments, timers, deals, bookings, reports',
+      'Available commands: projects, time, tasks, people, services, companies, comments, timers, deals, bookings, reports',
     ]);
   }
 


### PR DESCRIPTION
Closes #44

The `budgets` command was removed in #40 but the hint string in `CommandError.unknownCommand()` still listed it.