### PR TITLE
Add missing resolve action to help docs for 6 resources

### DIFF
--- a/packages/mcp/src/handlers/help.ts
+++ b/packages/mcp/src/handlers/help.ts
@@ -21,6 +21,7 @@ const RESOURCE_HELP: Record<string, ResourceHelp> = {
     actions: {
       list: 'List all projects with optional filters',
       get: 'Get a single project by ID with full details',
+      resolve: 'Look up by human-friendly identifier (email, project number, name)',
     },
     filters: {
       query: 'Text search on project name',
@@ -60,6 +61,7 @@ const RESOURCE_HELP: Record<string, ResourceHelp> = {
       get: 'Get a single task by ID with full details (description, comments, etc.)',
       create: 'Create a new task (requires title, project_id, task_list_id)',
       update: 'Update an existing task',
+      resolve: 'Look up by human-friendly identifier (email, project number, name)',
     },
     filters: {
       query: 'Text search on task title',
@@ -139,6 +141,7 @@ const RESOURCE_HELP: Record<string, ResourceHelp> = {
       get: 'Get a single time entry by ID',
       create: 'Create a new time entry (requires person_id, service_id, date, time)',
       update: 'Update an existing time entry',
+      resolve: 'Look up by human-friendly identifier (email, project number, name)',
     },
     filters: {
       person_id: 'Filter by person (use "me" for current user)',
@@ -220,6 +223,7 @@ const RESOURCE_HELP: Record<string, ResourceHelp> = {
       list: 'List people with optional filters',
       get: 'Get a single person by ID',
       me: 'Get the currently authenticated user',
+      resolve: 'Look up by human-friendly identifier (email, project number, name)',
     },
     filters: {
       query: 'Text search on name or email',
@@ -259,6 +263,7 @@ const RESOURCE_HELP: Record<string, ResourceHelp> = {
       get: 'Get a single company by ID',
       create: 'Create a new company (requires name)',
       update: 'Update an existing company',
+      resolve: 'Look up by human-friendly identifier (email, project number, name)',
     },
     filters: {
       query: 'Text search on company name',
@@ -389,6 +394,7 @@ const RESOURCE_HELP: Record<string, ResourceHelp> = {
       get: 'Get a single deal by ID',
       create: 'Create a new deal (requires name, company_id)',
       update: 'Update an existing deal',
+      resolve: 'Look up by human-friendly identifier (email, project number, name)',
     },
     filters: {
       query: 'Text search on deal name',


### PR DESCRIPTION
Closes #42

The `resolve` action (smart ID resolution by email, project number, name) was supported by 6 resource handlers but not documented in their help output. Agents using `action: "help"` could not discover this feature.

Added to: projects, tasks, time, deals, people, companies.