### PR TITLE
Add delete action to MCP time handler

### DIFF
--- a/packages/mcp/src/handlers.test.ts
+++ b/packages/mcp/src/handlers.test.ts
@@ -265,6 +265,33 @@ describe('handlers', () => {
 
         expect(result.isError).toBe(true);
       });
+
+      it('should handle delete action', async () => {
+        mockApi.deleteTimeEntry.mockResolvedValue(undefined);
+
+        const result = await executeToolWithCredentials(
+          'productive',
+          { resource: 'time', action: 'delete', id: '789' },
+          credentials,
+        );
+
+        expect(result.isError).toBeUndefined();
+        const content = JSON.parse(result.content[0].text as string);
+        expect(content.success).toBe(true);
+        expect(content.deleted).toBe('789');
+        expect(mockApi.deleteTimeEntry).toHaveBeenCalledWith('789');
+      });
+
+      it('should return error for delete without id', async () => {
+        const result = await executeToolWithCredentials(
+          'productive',
+          { resource: 'time', action: 'delete' },
+          credentials,
+        );
+
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('id is required for delete');
+      });
     });
 
     describe('tasks resource', () => {

--- a/packages/mcp/src/handlers/help.ts
+++ b/packages/mcp/src/handlers/help.ts
@@ -141,6 +141,7 @@ const RESOURCE_HELP: Record<string, ResourceHelp> = {
       get: 'Get a single time entry by ID',
       create: 'Create a new time entry (requires person_id, service_id, date, time)',
       update: 'Update an existing time entry',
+      delete: 'Delete a time entry',
       resolve: 'Look up by human-friendly identifier (email, project number, name)',
     },
     filters: {

--- a/packages/mcp/src/handlers/time.ts
+++ b/packages/mcp/src/handlers/time.ts
@@ -10,6 +10,7 @@ import {
   getTimeEntry,
   createTimeEntry,
   updateTimeEntry,
+  deleteTimeEntry,
 } from '@studiometa/productive-core';
 
 import type { CommonArgs, HandlerContext, ToolResult } from './types.js';
@@ -20,7 +21,7 @@ import { getTimeEntryHints } from '../hints.js';
 import { handleResolve, type ResolvableResourceType } from './resolve.js';
 import { inputErrorResult, jsonResult } from './utils.js';
 
-const VALID_ACTIONS = ['list', 'get', 'create', 'update', 'resolve'];
+const VALID_ACTIONS = ['list', 'get', 'create', 'update', 'delete', 'resolve'];
 
 export async function handleTime(
   action: string,
@@ -97,6 +98,13 @@ export async function handleTime(
     );
 
     return jsonResult({ success: true, ...formatTimeEntry(result.data, formatOptions) });
+  }
+
+  if (action === 'delete') {
+    if (!id) return inputErrorResult(ErrorMessages.missingId('delete'));
+    const execCtx = ctx.executor();
+    await deleteTimeEntry({ id }, execCtx);
+    return jsonResult({ success: true, deleted: id });
   }
 
   if (action === 'list') {


### PR DESCRIPTION
Closes #43

The `delete` action for time entries was implemented in the API client and CLI but missing from the MCP handler. Added the handler, help docs, and tests.