### PR TITLE
Add command routing tests for all CLI resources

### DIFF
--- a/packages/cli/src/commands/bookings/command.test.ts
+++ b/packages/cli/src/commands/bookings/command.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleBookingsCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  bookingsList: vi.fn().mockResolvedValue(undefined),
+  bookingsGet: vi.fn().mockResolvedValue(undefined),
+  bookingsAdd: vi.fn().mockResolvedValue(undefined),
+  bookingsUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('bookings command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.bookingsList).mockClear();
+    vi.mocked(handlers.bookingsGet).mockClear();
+    vi.mocked(handlers.bookingsAdd).mockClear();
+    vi.mocked(handlers.bookingsUpdate).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "list" subcommand to bookingsList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleBookingsCommand('list', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.bookingsList).toHaveBeenCalled();
+  });
+
+  it('should route "ls" alias to bookingsList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleBookingsCommand('ls', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.bookingsList).toHaveBeenCalled();
+  });
+
+  it('should route "get" subcommand to bookingsGet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleBookingsCommand('get', ['123'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.bookingsGet).toHaveBeenCalledWith(['123'], expect.anything());
+  });
+
+  it('should route "add" subcommand to bookingsAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleBookingsCommand('add', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.bookingsAdd).toHaveBeenCalled();
+  });
+
+  it('should route "create" alias to bookingsAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleBookingsCommand('create', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.bookingsAdd).toHaveBeenCalled();
+  });
+
+  it('should route "update" subcommand to bookingsUpdate', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleBookingsCommand('update', ['456'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.bookingsUpdate).toHaveBeenCalledWith(['456'], expect.anything());
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handleBookingsCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown bookings subcommand: unknown'),
+    );
+  });
+});

--- a/packages/cli/src/commands/comments/command.test.ts
+++ b/packages/cli/src/commands/comments/command.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleCommentsCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  commentsList: vi.fn().mockResolvedValue(undefined),
+  commentsGet: vi.fn().mockResolvedValue(undefined),
+  commentsAdd: vi.fn().mockResolvedValue(undefined),
+  commentsUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('comments command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.commentsList).mockClear();
+    vi.mocked(handlers.commentsGet).mockClear();
+    vi.mocked(handlers.commentsAdd).mockClear();
+    vi.mocked(handlers.commentsUpdate).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "list" subcommand to commentsList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCommentsCommand('list', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.commentsList).toHaveBeenCalled();
+  });
+
+  it('should route "ls" alias to commentsList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCommentsCommand('ls', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.commentsList).toHaveBeenCalled();
+  });
+
+  it('should route "get" subcommand to commentsGet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCommentsCommand('get', ['123'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.commentsGet).toHaveBeenCalledWith(['123'], expect.anything());
+  });
+
+  it('should route "add" subcommand to commentsAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCommentsCommand('add', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.commentsAdd).toHaveBeenCalled();
+  });
+
+  it('should route "create" alias to commentsAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCommentsCommand('create', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.commentsAdd).toHaveBeenCalled();
+  });
+
+  it('should route "update" subcommand to commentsUpdate', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCommentsCommand('update', ['456'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.commentsUpdate).toHaveBeenCalledWith(['456'], expect.anything());
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handleCommentsCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown comments subcommand: unknown'),
+    );
+  });
+});

--- a/packages/cli/src/commands/companies/command.test.ts
+++ b/packages/cli/src/commands/companies/command.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleCompaniesCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  companiesList: vi.fn().mockResolvedValue(undefined),
+  companiesGet: vi.fn().mockResolvedValue(undefined),
+  companiesAdd: vi.fn().mockResolvedValue(undefined),
+  companiesUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('companies command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.companiesList).mockClear();
+    vi.mocked(handlers.companiesGet).mockClear();
+    vi.mocked(handlers.companiesAdd).mockClear();
+    vi.mocked(handlers.companiesUpdate).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "list" subcommand to companiesList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCompaniesCommand('list', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.companiesList).toHaveBeenCalled();
+  });
+
+  it('should route "ls" alias to companiesList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCompaniesCommand('ls', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.companiesList).toHaveBeenCalled();
+  });
+
+  it('should route "get" subcommand to companiesGet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCompaniesCommand('get', ['123'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.companiesGet).toHaveBeenCalledWith(['123'], expect.anything());
+  });
+
+  it('should route "add" subcommand to companiesAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCompaniesCommand('add', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.companiesAdd).toHaveBeenCalled();
+  });
+
+  it('should route "create" alias to companiesAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCompaniesCommand('create', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.companiesAdd).toHaveBeenCalled();
+  });
+
+  it('should route "update" subcommand to companiesUpdate', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleCompaniesCommand('update', ['456'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.companiesUpdate).toHaveBeenCalledWith(['456'], expect.anything());
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handleCompaniesCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown companies subcommand: unknown'),
+    );
+  });
+});

--- a/packages/cli/src/commands/deals/command.test.ts
+++ b/packages/cli/src/commands/deals/command.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleDealsCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  dealsList: vi.fn().mockResolvedValue(undefined),
+  dealsGet: vi.fn().mockResolvedValue(undefined),
+  dealsAdd: vi.fn().mockResolvedValue(undefined),
+  dealsUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('deals command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.dealsList).mockClear();
+    vi.mocked(handlers.dealsGet).mockClear();
+    vi.mocked(handlers.dealsAdd).mockClear();
+    vi.mocked(handlers.dealsUpdate).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "list" subcommand to dealsList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleDealsCommand('list', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.dealsList).toHaveBeenCalled();
+  });
+
+  it('should route "ls" alias to dealsList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleDealsCommand('ls', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.dealsList).toHaveBeenCalled();
+  });
+
+  it('should route "get" subcommand to dealsGet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleDealsCommand('get', ['123'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.dealsGet).toHaveBeenCalledWith(['123'], expect.anything());
+  });
+
+  it('should route "add" subcommand to dealsAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleDealsCommand('add', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.dealsAdd).toHaveBeenCalled();
+  });
+
+  it('should route "create" alias to dealsAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleDealsCommand('create', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.dealsAdd).toHaveBeenCalled();
+  });
+
+  it('should route "update" subcommand to dealsUpdate', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleDealsCommand('update', ['456'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.dealsUpdate).toHaveBeenCalledWith(['456'], expect.anything());
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handleDealsCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown deals subcommand: unknown'),
+    );
+  });
+});

--- a/packages/cli/src/commands/people/command.test.ts
+++ b/packages/cli/src/commands/people/command.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handlePeopleCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  peopleList: vi.fn().mockResolvedValue(undefined),
+  peopleGet: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('people command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.peopleList).mockClear();
+    vi.mocked(handlers.peopleGet).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "list" subcommand to peopleList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handlePeopleCommand('list', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.peopleList).toHaveBeenCalled();
+  });
+
+  it('should route "ls" alias to peopleList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handlePeopleCommand('ls', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.peopleList).toHaveBeenCalled();
+  });
+
+  it('should route "get" subcommand to peopleGet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handlePeopleCommand('get', ['123'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.peopleGet).toHaveBeenCalledWith(['123'], expect.anything());
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handlePeopleCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown people subcommand: unknown'),
+    );
+  });
+});

--- a/packages/cli/src/commands/projects/command.test.ts
+++ b/packages/cli/src/commands/projects/command.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleProjectsCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  projectsList: vi.fn().mockResolvedValue(undefined),
+  projectsGet: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('projects command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.projectsList).mockClear();
+    vi.mocked(handlers.projectsGet).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "list" subcommand to projectsList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleProjectsCommand('list', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.projectsList).toHaveBeenCalled();
+  });
+
+  it('should route "ls" alias to projectsList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleProjectsCommand('ls', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.projectsList).toHaveBeenCalled();
+  });
+
+  it('should route "get" subcommand to projectsGet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleProjectsCommand('get', ['123'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.projectsGet).toHaveBeenCalledWith(['123'], expect.anything());
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handleProjectsCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown projects subcommand: unknown'),
+    );
+  });
+});

--- a/packages/cli/src/commands/reports/command.test.ts
+++ b/packages/cli/src/commands/reports/command.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleReportsCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  reportsTime: vi.fn().mockResolvedValue(undefined),
+  reportsProject: vi.fn().mockResolvedValue(undefined),
+  reportsBudget: vi.fn().mockResolvedValue(undefined),
+  reportsPerson: vi.fn().mockResolvedValue(undefined),
+  reportsInvoice: vi.fn().mockResolvedValue(undefined),
+  reportsPayment: vi.fn().mockResolvedValue(undefined),
+  reportsService: vi.fn().mockResolvedValue(undefined),
+  reportsTask: vi.fn().mockResolvedValue(undefined),
+  reportsCompany: vi.fn().mockResolvedValue(undefined),
+  reportsDeal: vi.fn().mockResolvedValue(undefined),
+  reportsTimesheet: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('reports command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.reportsTime).mockClear();
+    vi.mocked(handlers.reportsProject).mockClear();
+    vi.mocked(handlers.reportsBudget).mockClear();
+    vi.mocked(handlers.reportsPerson).mockClear();
+    vi.mocked(handlers.reportsInvoice).mockClear();
+    vi.mocked(handlers.reportsPayment).mockClear();
+    vi.mocked(handlers.reportsService).mockClear();
+    vi.mocked(handlers.reportsTask).mockClear();
+    vi.mocked(handlers.reportsCompany).mockClear();
+    vi.mocked(handlers.reportsDeal).mockClear();
+    vi.mocked(handlers.reportsTimesheet).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "time" subcommand to reportsTime', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('time', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsTime).toHaveBeenCalled();
+  });
+
+  it('should route "project" subcommand to reportsProject', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('project', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsProject).toHaveBeenCalled();
+  });
+
+  it('should route "projects" alias to reportsProject', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('projects', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsProject).toHaveBeenCalled();
+  });
+
+  it('should route "budget" subcommand to reportsBudget', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('budget', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsBudget).toHaveBeenCalled();
+  });
+
+  it('should route "budgets" alias to reportsBudget', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('budgets', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsBudget).toHaveBeenCalled();
+  });
+
+  it('should route "person" subcommand to reportsPerson', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('person', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsPerson).toHaveBeenCalled();
+  });
+
+  it('should route "people" alias to reportsPerson', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('people', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsPerson).toHaveBeenCalled();
+  });
+
+  it('should route "invoice" subcommand to reportsInvoice', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('invoice', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsInvoice).toHaveBeenCalled();
+  });
+
+  it('should route "invoices" alias to reportsInvoice', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('invoices', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsInvoice).toHaveBeenCalled();
+  });
+
+  it('should route "payment" subcommand to reportsPayment', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('payment', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsPayment).toHaveBeenCalled();
+  });
+
+  it('should route "payments" alias to reportsPayment', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('payments', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsPayment).toHaveBeenCalled();
+  });
+
+  it('should route "service" subcommand to reportsService', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('service', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsService).toHaveBeenCalled();
+  });
+
+  it('should route "services" alias to reportsService', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('services', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsService).toHaveBeenCalled();
+  });
+
+  it('should route "task" subcommand to reportsTask', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('task', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsTask).toHaveBeenCalled();
+  });
+
+  it('should route "tasks" alias to reportsTask', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('tasks', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsTask).toHaveBeenCalled();
+  });
+
+  it('should route "company" subcommand to reportsCompany', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('company', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsCompany).toHaveBeenCalled();
+  });
+
+  it('should route "companies" alias to reportsCompany', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('companies', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsCompany).toHaveBeenCalled();
+  });
+
+  it('should route "deal" subcommand to reportsDeal', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('deal', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsDeal).toHaveBeenCalled();
+  });
+
+  it('should route "deals" alias to reportsDeal', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('deals', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsDeal).toHaveBeenCalled();
+  });
+
+  it('should route "timesheet" subcommand to reportsTimesheet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('timesheet', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsTimesheet).toHaveBeenCalled();
+  });
+
+  it('should route "timesheets" alias to reportsTimesheet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleReportsCommand('timesheets', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.reportsTimesheet).toHaveBeenCalled();
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handleReportsCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown reports subcommand: unknown'),
+    );
+  });
+});

--- a/packages/cli/src/commands/resolve/command.test.ts
+++ b/packages/cli/src/commands/resolve/command.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleResolveCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  resolveIdentifier: vi.fn().mockResolvedValue(undefined),
+  detectType: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('resolve command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.resolveIdentifier).mockClear();
+    vi.mocked(handlers.detectType).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "detect" subcommand to detectType', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleResolveCommand('detect', ['test@example.com'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.detectType).toHaveBeenCalledWith(['test@example.com'], expect.anything());
+  });
+
+  it('should route query to resolveIdentifier', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleResolveCommand('test@example.com', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.resolveIdentifier).toHaveBeenCalledWith(
+      ['test@example.com'],
+      expect.anything(),
+    );
+  });
+
+  it('should combine subcommand and args as query for resolveIdentifier', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleResolveCommand('john', ['doe'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.resolveIdentifier).toHaveBeenCalledWith(['john', 'doe'], expect.anything());
+  });
+
+  it('should exit with error when no query provided', async () => {
+    await handleResolveCommand(undefined, [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Query argument is required'),
+    );
+  });
+});

--- a/packages/cli/src/commands/services/command.test.ts
+++ b/packages/cli/src/commands/services/command.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleServicesCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  servicesList: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('services command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.servicesList).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "list" subcommand to servicesList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleServicesCommand('list', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.servicesList).toHaveBeenCalled();
+  });
+
+  it('should route "ls" alias to servicesList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleServicesCommand('ls', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.servicesList).toHaveBeenCalled();
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handleServicesCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown services subcommand: unknown'),
+    );
+  });
+});

--- a/packages/cli/src/commands/tasks/command.test.ts
+++ b/packages/cli/src/commands/tasks/command.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleTasksCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  tasksList: vi.fn().mockResolvedValue(undefined),
+  tasksGet: vi.fn().mockResolvedValue(undefined),
+  tasksAdd: vi.fn().mockResolvedValue(undefined),
+  tasksUpdate: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('tasks command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.tasksList).mockClear();
+    vi.mocked(handlers.tasksGet).mockClear();
+    vi.mocked(handlers.tasksAdd).mockClear();
+    vi.mocked(handlers.tasksUpdate).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "list" subcommand to tasksList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTasksCommand('list', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.tasksList).toHaveBeenCalled();
+  });
+
+  it('should route "ls" alias to tasksList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTasksCommand('ls', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.tasksList).toHaveBeenCalled();
+  });
+
+  it('should route "get" subcommand to tasksGet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTasksCommand('get', ['123'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.tasksGet).toHaveBeenCalledWith(['123'], expect.anything());
+  });
+
+  it('should route "add" subcommand to tasksAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTasksCommand('add', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.tasksAdd).toHaveBeenCalled();
+  });
+
+  it('should route "create" alias to tasksAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTasksCommand('create', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.tasksAdd).toHaveBeenCalled();
+  });
+
+  it('should route "update" subcommand to tasksUpdate', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTasksCommand('update', ['456'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.tasksUpdate).toHaveBeenCalledWith(['456'], expect.anything());
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handleTasksCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown tasks subcommand: unknown'),
+    );
+  });
+});

--- a/packages/cli/src/commands/time/command.test.ts
+++ b/packages/cli/src/commands/time/command.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleTimeCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  timeList: vi.fn().mockResolvedValue(undefined),
+  timeGet: vi.fn().mockResolvedValue(undefined),
+  timeAdd: vi.fn().mockResolvedValue(undefined),
+  timeUpdate: vi.fn().mockResolvedValue(undefined),
+  timeDelete: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('time command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.timeList).mockClear();
+    vi.mocked(handlers.timeGet).mockClear();
+    vi.mocked(handlers.timeAdd).mockClear();
+    vi.mocked(handlers.timeUpdate).mockClear();
+    vi.mocked(handlers.timeDelete).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "list" subcommand to timeList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimeCommand('list', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timeList).toHaveBeenCalled();
+  });
+
+  it('should route "ls" alias to timeList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimeCommand('ls', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timeList).toHaveBeenCalled();
+  });
+
+  it('should route "get" subcommand to timeGet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimeCommand('get', ['123'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timeGet).toHaveBeenCalledWith(['123'], expect.anything());
+  });
+
+  it('should route "add" subcommand to timeAdd', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimeCommand('add', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timeAdd).toHaveBeenCalled();
+  });
+
+  it('should route "update" subcommand to timeUpdate', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimeCommand('update', ['456'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timeUpdate).toHaveBeenCalledWith(['456'], expect.anything());
+  });
+
+  it('should route "delete" subcommand to timeDelete', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimeCommand('delete', ['789'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timeDelete).toHaveBeenCalledWith(['789'], expect.anything());
+  });
+
+  it('should route "rm" alias to timeDelete', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimeCommand('rm', ['789'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timeDelete).toHaveBeenCalledWith(['789'], expect.anything());
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handleTimeCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown time subcommand: unknown'),
+    );
+  });
+});

--- a/packages/cli/src/commands/timers/command.test.ts
+++ b/packages/cli/src/commands/timers/command.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleTimersCommand } from './command.js';
+
+// Mock the handlers to avoid needing real API
+vi.mock('./handlers.js', () => ({
+  timersList: vi.fn().mockResolvedValue(undefined),
+  timersGet: vi.fn().mockResolvedValue(undefined),
+  timersStart: vi.fn().mockResolvedValue(undefined),
+  timersStop: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock config to avoid file system access
+vi.mock('../../config.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    apiToken: 'test-token',
+    organizationId: 'test-org',
+    baseUrl: 'https://api.productive.io/api/v2',
+  }),
+}));
+
+// Mock cache with full interface - factory must be inline
+vi.mock('../../utils/cache.js', () => {
+  const mockCacheObj = {
+    get: vi.fn(),
+    set: vi.fn(),
+    delete: vi.fn(),
+    setOrgId: vi.fn(),
+    getCachedPeople: vi.fn(),
+    getCachedProjects: vi.fn(),
+    getCachedTaskLists: vi.fn(),
+    findCachedPersonByEmail: vi.fn(),
+    findCachedProjectByNumber: vi.fn(),
+    findCachedTaskListByName: vi.fn(),
+  };
+  return {
+    getCache: vi.fn().mockReturnValue(mockCacheObj),
+    CacheStore: vi.fn().mockImplementation(() => mockCacheObj),
+  };
+});
+
+describe('timers command routing', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    // Reset mocks before each test
+    const handlers = await import('./handlers.js');
+    vi.mocked(handlers.timersList).mockClear();
+    vi.mocked(handlers.timersGet).mockClear();
+    vi.mocked(handlers.timersStart).mockClear();
+    vi.mocked(handlers.timersStop).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should route "list" subcommand to timersList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimersCommand('list', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timersList).toHaveBeenCalled();
+  });
+
+  it('should route "ls" alias to timersList', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimersCommand('ls', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timersList).toHaveBeenCalled();
+  });
+
+  it('should route "get" subcommand to timersGet', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimersCommand('get', ['123'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timersGet).toHaveBeenCalledWith(['123'], expect.anything());
+  });
+
+  it('should route "start" subcommand to timersStart', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimersCommand('start', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timersStart).toHaveBeenCalled();
+  });
+
+  it('should route "stop" subcommand to timersStop', async () => {
+    const handlers = await import('./handlers.js');
+
+    await handleTimersCommand('stop', ['456'], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(handlers.timersStop).toHaveBeenCalledWith(['456'], expect.anything());
+  });
+
+  it('should exit with error for unknown subcommand', async () => {
+    await handleTimersCommand('unknown', [], {
+      format: 'json',
+      token: 'test-token',
+      'org-id': 'test-org',
+    });
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown timers subcommand: unknown'),
+    );
+  });
+});


### PR DESCRIPTION
Closes #51

Adds `command.test.ts` for 12 CLI resources that were missing routing tests. Tests verify subcommand dispatching, aliases, and unknown subcommand handling.