### PR TITLE
Add tests for CSV, table, JSON, and kanban renderers

### DIFF
--- a/packages/cli/src/renderers/csv.test.ts
+++ b/packages/cli/src/renderers/csv.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import type { RenderContext } from './types.js';
+
+import { CsvRenderer, csvRenderer } from './csv.js';
+
+const ctx: RenderContext = { noColor: false, terminalWidth: 80 };
+
+describe('CsvRenderer', () => {
+  const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  afterEach(() => spy.mockClear());
+
+  describe('render array data', () => {
+    it('renders headers and rows', () => {
+      const renderer = new CsvRenderer();
+      renderer.render(
+        [
+          { id: '1', name: 'Alice', role: 'Dev' },
+          { id: '2', name: 'Bob', role: 'Designer' },
+        ],
+        ctx,
+      );
+
+      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenNthCalledWith(1, 'id,name,role');
+      expect(spy).toHaveBeenNthCalledWith(2, '1,Alice,Dev');
+      expect(spy).toHaveBeenNthCalledWith(3, '2,Bob,Designer');
+    });
+
+    it('renders empty array as nothing', () => {
+      new CsvRenderer().render([], ctx);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('render list with pagination wrapper', () => {
+    it('extracts data from { data: [...] } structure', () => {
+      const renderer = new CsvRenderer();
+      renderer.render(
+        {
+          data: [
+            { id: '1', title: 'Task A' },
+            { id: '2', title: 'Task B' },
+          ],
+          meta: { page: 1, total_pages: 1, total_count: 2 },
+        },
+        ctx,
+      );
+
+      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenNthCalledWith(1, 'id,title');
+      expect(spy).toHaveBeenNthCalledWith(2, '1,Task A');
+      expect(spy).toHaveBeenNthCalledWith(3, '2,Task B');
+    });
+  });
+
+  describe('render single object', () => {
+    it('wraps single object as one-row table', () => {
+      new CsvRenderer().render({ id: '42', name: 'Single Item' }, ctx);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenNthCalledWith(1, 'id,name');
+      expect(spy).toHaveBeenNthCalledWith(2, '42,Single Item');
+    });
+  });
+
+  describe('render primitive', () => {
+    it('outputs string as-is', () => {
+      new CsvRenderer().render('hello', ctx);
+      expect(spy).toHaveBeenCalledWith('hello');
+    });
+
+    it('outputs number as string', () => {
+      new CsvRenderer().render(123, ctx);
+      expect(spy).toHaveBeenCalledWith('123');
+    });
+  });
+
+  describe('CSV escaping', () => {
+    it('escapes values containing commas', () => {
+      new CsvRenderer().render([{ text: 'hello, world' }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(2, '"hello, world"');
+    });
+
+    it('escapes values containing quotes', () => {
+      new CsvRenderer().render([{ text: 'say "hello"' }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(2, '"say ""hello"""');
+    });
+
+    it('escapes values containing newlines', () => {
+      new CsvRenderer().render([{ text: 'line1\nline2' }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(2, '"line1\nline2"');
+    });
+
+    it('escapes complex values with multiple special characters', () => {
+      new CsvRenderer().render([{ text: 'hello, "world"\nfoo' }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(2, '"hello, ""world""\nfoo"');
+    });
+
+    it('does not escape simple values', () => {
+      new CsvRenderer().render([{ text: 'simple' }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(2, 'simple');
+    });
+  });
+
+  describe('missing and null fields', () => {
+    it('handles null values as empty strings', () => {
+      new CsvRenderer().render([{ id: '1', name: null }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(2, '1,');
+    });
+
+    it('handles undefined values as empty strings', () => {
+      new CsvRenderer().render([{ id: '1', name: undefined }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(2, '1,');
+    });
+
+    it('handles missing keys gracefully', () => {
+      const data = [
+        { id: '1', name: 'Alice', extra: 'value' },
+        { id: '2', name: 'Bob' }, // missing 'extra' key
+      ];
+      new CsvRenderer().render(data, ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(1, 'id,name,extra');
+      expect(spy).toHaveBeenNthCalledWith(2, '1,Alice,value');
+      expect(spy).toHaveBeenNthCalledWith(3, '2,Bob,');
+    });
+  });
+
+  describe('singleton instance', () => {
+    it('exports a usable singleton', () => {
+      csvRenderer.render([{ x: 1 }], ctx);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/src/renderers/human/kanban.test.ts
+++ b/packages/cli/src/renderers/human/kanban.test.ts
@@ -1,0 +1,265 @@
+import type { FormattedTask } from '@studiometa/productive-api';
+
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+
+import type { RenderContext } from '../types.js';
+
+import { setColorEnabled } from '../../utils/colors.js';
+import { KanbanRenderer, kanbanRenderer, stripAnsi, truncateText, padText } from './kanban.js';
+
+const ctx: RenderContext = { noColor: false, terminalWidth: 100 };
+
+// Sample task factory
+function createTask(overrides: Partial<FormattedTask> = {}): FormattedTask {
+  return {
+    id: '1',
+    title: 'Sample Task',
+    number: 42,
+    closed: false,
+    due_date: null,
+    description: null,
+    initial_estimate: null,
+    worked_time: null,
+    remaining_time: null,
+    project_id: null,
+    project_name: null,
+    assignee_id: null,
+    assignee_name: null,
+    status_id: null,
+    status_name: null,
+    ...overrides,
+  };
+}
+
+describe('KanbanRenderer', () => {
+  const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  beforeEach(() => {
+    // Disable colors for easier testing
+    setColorEnabled(false);
+  });
+
+  afterEach(() => {
+    spy.mockClear();
+    setColorEnabled(true);
+  });
+
+  describe('render with tasks grouped by status', () => {
+    it('renders columns for each status', () => {
+      const renderer = new KanbanRenderer();
+      const tasks = [
+        createTask({ id: '1', title: 'Task 1', status_name: 'To Do', status_id: 's1' }),
+        createTask({ id: '2', title: 'Task 2', status_name: 'In Progress', status_id: 's2' }),
+        createTask({ id: '3', title: 'Task 3', status_name: 'To Do', status_id: 's1' }),
+      ];
+
+      renderer.render({ data: tasks }, ctx);
+
+      // Should have been called multiple times for header, separator, tasks
+      expect(spy).toHaveBeenCalled();
+
+      // Check that both columns appear in the output
+      const allOutput = spy.mock.calls.map((c) => c[0]).join('\n');
+      expect(allOutput).toContain('In Progress');
+      expect(allOutput).toContain('To Do');
+    });
+
+    it('shows task count in column headers', () => {
+      const renderer = new KanbanRenderer();
+      const tasks = [
+        createTask({ id: '1', title: 'Task 1', status_name: 'Done', status_id: 's1' }),
+        createTask({ id: '2', title: 'Task 2', status_name: 'Done', status_id: 's1' }),
+      ];
+
+      renderer.render({ data: tasks }, ctx);
+
+      const allOutput = spy.mock.calls.map((c) => c[0]).join('\n');
+      expect(allOutput).toContain('(2)');
+    });
+  });
+
+  describe('render empty data', () => {
+    it('displays message when no columns', () => {
+      new KanbanRenderer().render({ data: [] }, ctx);
+
+      expect(spy).toHaveBeenCalledWith('No columns to display');
+    });
+  });
+
+  describe('render tasks without status', () => {
+    it('groups tasks without status into "No Status" column', () => {
+      const renderer = new KanbanRenderer();
+      const tasks = [
+        createTask({ id: '1', title: 'Task 1', status_name: undefined, status_id: undefined }),
+        createTask({ id: '2', title: 'Task 2', status_name: undefined, status_id: undefined }),
+      ];
+
+      renderer.render({ data: tasks }, ctx);
+
+      const allOutput = spy.mock.calls.map((c) => c[0]).join('\n');
+      expect(allOutput).toContain('No Status');
+    });
+  });
+
+  describe('render with assignees', () => {
+    it('shows assignee on a separate line', () => {
+      const renderer = new KanbanRenderer();
+      const tasks = [
+        createTask({
+          id: '1',
+          title: 'Task 1',
+          status_name: 'To Do',
+          assignee_name: 'Alice',
+        }),
+      ];
+
+      renderer.render({ data: tasks }, ctx);
+
+      const allOutput = spy.mock.calls.map((c) => c[0]).join('\n');
+      expect(allOutput).toContain('Alice');
+    });
+  });
+
+  describe('render with pagination', () => {
+    it('shows total count when meta is provided', () => {
+      const renderer = new KanbanRenderer();
+      const tasks = [createTask({ id: '1', title: 'Task 1', status_name: 'To Do' })];
+
+      renderer.render({ data: tasks, meta: { page: 1, total_pages: 2, total_count: 15 } }, ctx);
+
+      const allOutput = spy.mock.calls.map((c) => c[0]).join('\n');
+      expect(allOutput).toContain('Total: 15 tasks');
+    });
+  });
+
+  describe('render tasks with missing fields', () => {
+    it('handles task without title', () => {
+      const renderer = new KanbanRenderer();
+      const tasks = [
+        createTask({
+          id: '1',
+          title: undefined as unknown as string,
+          status_name: 'To Do',
+        }),
+      ];
+
+      renderer.render({ data: tasks }, ctx);
+
+      const allOutput = spy.mock.calls.map((c) => c[0]).join('\n');
+      expect(allOutput).toContain('Untitled');
+    });
+
+    it('handles task without number', () => {
+      const renderer = new KanbanRenderer();
+      const tasks = [
+        createTask({
+          id: '1',
+          title: 'Task',
+          number: undefined,
+          status_name: 'To Do',
+        }),
+      ];
+
+      renderer.render({ data: tasks }, ctx);
+
+      // Should not throw
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('column width calculation', () => {
+    it('adjusts to terminal width', () => {
+      const renderer = new KanbanRenderer();
+      const tasks = [
+        createTask({ id: '1', title: 'Task 1', status_name: 'Column A' }),
+        createTask({ id: '2', title: 'Task 2', status_name: 'Column B' }),
+        createTask({ id: '3', title: 'Task 3', status_name: 'Column C' }),
+      ];
+
+      const narrowCtx: RenderContext = { noColor: false, terminalWidth: 60 };
+      renderer.render({ data: tasks }, narrowCtx);
+
+      // Should render without error
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('handles very narrow terminal', () => {
+      const renderer = new KanbanRenderer();
+      const tasks = [createTask({ id: '1', title: 'Task 1', status_name: 'To Do' })];
+
+      const veryNarrowCtx: RenderContext = { noColor: false, terminalWidth: 30 };
+      renderer.render({ data: tasks }, veryNarrowCtx);
+
+      // Should still render
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
+  describe('singleton instance', () => {
+    it('exports a usable singleton', () => {
+      const tasks = [createTask({ id: '1', title: 'Task', status_name: 'Done' })];
+      kanbanRenderer.render({ data: tasks }, ctx);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('helper functions', () => {
+  describe('stripAnsi', () => {
+    it('removes ANSI color codes', () => {
+      expect(stripAnsi('\x1b[31mred\x1b[0m')).toBe('red');
+    });
+
+    it('removes bold codes', () => {
+      expect(stripAnsi('\x1b[1mbold\x1b[0m')).toBe('bold');
+    });
+
+    it('returns plain text unchanged', () => {
+      expect(stripAnsi('plain text')).toBe('plain text');
+    });
+
+    it('handles OSC hyperlink sequences', () => {
+      const linked = '\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\';
+      expect(stripAnsi(linked)).toBe('link');
+    });
+  });
+
+  describe('truncateText', () => {
+    it('returns short text unchanged', () => {
+      expect(truncateText('short', 10)).toBe('short');
+    });
+
+    it('truncates long text with ellipsis', () => {
+      const result = truncateText('this is a very long text', 10);
+      expect(stripAnsi(result).length).toBeLessThanOrEqual(10);
+      expect(result).toContain('…');
+    });
+
+    it('handles exact length', () => {
+      expect(truncateText('exact', 5)).toBe('exact');
+    });
+  });
+
+  describe('padText', () => {
+    it('pads short text to width', () => {
+      expect(padText('hi', 5)).toBe('hi   ');
+    });
+
+    it('returns text unchanged if already at width', () => {
+      expect(padText('hello', 5)).toBe('hello');
+    });
+
+    it('returns text unchanged if longer than width', () => {
+      expect(padText('hello world', 5)).toBe('hello world');
+    });
+
+    it('handles text with ANSI codes', () => {
+      setColorEnabled(true);
+      const colored = '\x1b[31mred\x1b[0m';
+      const padded = padText(colored, 10);
+      // Visible length should be 3 (red), so should add 7 spaces
+      expect(padded).toBe(colored + '       ');
+      setColorEnabled(false);
+    });
+  });
+});

--- a/packages/cli/src/renderers/json.test.ts
+++ b/packages/cli/src/renderers/json.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import type { RenderContext } from './types.js';
+
+import { JsonRenderer, jsonRenderer } from './json.js';
+
+const ctx: RenderContext = { noColor: false, terminalWidth: 80 };
+
+describe('JsonRenderer', () => {
+  const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  afterEach(() => spy.mockClear());
+
+  describe('render array data', () => {
+    it('outputs pretty-printed JSON array', () => {
+      const renderer = new JsonRenderer();
+      const data = [
+        { id: '1', name: 'Alice' },
+        { id: '2', name: 'Bob' },
+      ];
+      renderer.render(data, ctx);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      const output = spy.mock.calls[0][0];
+      expect(JSON.parse(output)).toEqual(data);
+      expect(output).toContain('\n'); // Pretty-printed
+    });
+
+    it('renders empty array', () => {
+      new JsonRenderer().render([], ctx);
+
+      expect(spy).toHaveBeenCalledWith('[]');
+    });
+  });
+
+  describe('render list with pagination', () => {
+    it('includes data and meta in output', () => {
+      const renderer = new JsonRenderer();
+      const data = {
+        data: [
+          { id: '1', title: 'Task A' },
+          { id: '2', title: 'Task B' },
+        ],
+        meta: { page: 1, total_pages: 3, total_count: 25 },
+      };
+      renderer.render(data, ctx);
+
+      const output = spy.mock.calls[0][0];
+      const parsed = JSON.parse(output);
+
+      expect(parsed.data).toHaveLength(2);
+      expect(parsed.meta.page).toBe(1);
+      expect(parsed.meta.total_pages).toBe(3);
+      expect(parsed.meta.total_count).toBe(25);
+    });
+  });
+
+  describe('render single object', () => {
+    it('outputs pretty-printed JSON object', () => {
+      const data = { id: '42', name: 'Single Item', nested: { key: 'value' } };
+      new JsonRenderer().render(data, ctx);
+
+      const output = spy.mock.calls[0][0];
+      expect(JSON.parse(output)).toEqual(data);
+    });
+  });
+
+  describe('render primitives', () => {
+    it('outputs string', () => {
+      new JsonRenderer().render('hello', ctx);
+      expect(spy).toHaveBeenCalledWith('"hello"');
+    });
+
+    it('outputs number', () => {
+      new JsonRenderer().render(123, ctx);
+      expect(spy).toHaveBeenCalledWith('123');
+    });
+
+    it('outputs boolean', () => {
+      new JsonRenderer().render(true, ctx);
+      expect(spy).toHaveBeenCalledWith('true');
+    });
+
+    it('outputs null', () => {
+      new JsonRenderer().render(null, ctx);
+      expect(spy).toHaveBeenCalledWith('null');
+    });
+  });
+
+  describe('null and undefined handling', () => {
+    it('preserves null values in objects', () => {
+      const data = { id: '1', name: null };
+      new JsonRenderer().render(data, ctx);
+
+      const output = spy.mock.calls[0][0];
+      expect(JSON.parse(output)).toEqual({ id: '1', name: null });
+    });
+
+    it('omits undefined values in objects (JSON behavior)', () => {
+      const data = { id: '1', name: undefined };
+      new JsonRenderer().render(data, ctx);
+
+      const output = spy.mock.calls[0][0];
+      expect(JSON.parse(output)).toEqual({ id: '1' });
+    });
+  });
+
+  describe('special values', () => {
+    it('handles nested objects', () => {
+      const data = {
+        user: { name: 'Alice', settings: { theme: 'dark' } },
+        tags: ['a', 'b'],
+      };
+      new JsonRenderer().render(data, ctx);
+
+      const output = spy.mock.calls[0][0];
+      expect(JSON.parse(output)).toEqual(data);
+    });
+
+    it('handles special characters in strings', () => {
+      const data = { text: 'hello\nworld\t"quoted"' };
+      new JsonRenderer().render(data, ctx);
+
+      const output = spy.mock.calls[0][0];
+      expect(JSON.parse(output)).toEqual(data);
+    });
+
+    it('handles unicode characters', () => {
+      const data = { emoji: '🚀', accent: 'café' };
+      new JsonRenderer().render(data, ctx);
+
+      const output = spy.mock.calls[0][0];
+      expect(JSON.parse(output)).toEqual(data);
+    });
+  });
+
+  describe('formatting', () => {
+    it('uses 2-space indentation', () => {
+      const data = { a: { b: 1 } };
+      new JsonRenderer().render(data, ctx);
+
+      const output = spy.mock.calls[0][0];
+      expect(output).toContain('  "a"');
+      expect(output).toContain('    "b"');
+    });
+  });
+
+  describe('singleton instance', () => {
+    it('exports a usable singleton', () => {
+      jsonRenderer.render({ x: 1 }, ctx);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/src/renderers/table.test.ts
+++ b/packages/cli/src/renderers/table.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import type { RenderContext } from './types.js';
+
+import { TableRenderer, tableRenderer } from './table.js';
+
+const ctx: RenderContext = { noColor: false, terminalWidth: 80 };
+
+describe('TableRenderer', () => {
+  const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  afterEach(() => spy.mockClear());
+
+  describe('render array data', () => {
+    it('renders headers, separator, and rows', () => {
+      const renderer = new TableRenderer();
+      renderer.render(
+        [
+          { id: '1', name: 'Alice' },
+          { id: '2', name: 'Bob' },
+        ],
+        ctx,
+      );
+
+      expect(spy).toHaveBeenCalledTimes(4);
+      // Header row
+      expect(spy).toHaveBeenNthCalledWith(1, 'id | name ');
+      // Separator
+      expect(spy).toHaveBeenNthCalledWith(2, '---+------');
+      // Data rows
+      expect(spy).toHaveBeenNthCalledWith(3, '1  | Alice');
+      expect(spy).toHaveBeenNthCalledWith(4, '2  | Bob  ');
+    });
+
+    it('renders empty array as nothing', () => {
+      new TableRenderer().render([], ctx);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('column alignment', () => {
+    it('pads columns to match longest value', () => {
+      new TableRenderer().render(
+        [
+          { id: '1', name: 'Al' },
+          { id: '123', name: 'Alexander' },
+        ],
+        ctx,
+      );
+
+      // Check that header and data are aligned
+      const headerCall = spy.mock.calls[0][0];
+      const row1Call = spy.mock.calls[2][0];
+      const row2Call = spy.mock.calls[3][0];
+
+      // All rows should have the same format structure
+      expect(headerCall).toBe('id  | name     ');
+      expect(row1Call).toBe('1   | Al       ');
+      expect(row2Call).toBe('123 | Alexander');
+    });
+
+    it('handles header longer than data', () => {
+      new TableRenderer().render([{ longheader: 'x' }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(1, 'longheader');
+      expect(spy).toHaveBeenNthCalledWith(2, '----------');
+      expect(spy).toHaveBeenNthCalledWith(3, 'x         ');
+    });
+  });
+
+  describe('render list with pagination wrapper', () => {
+    it('extracts data from { data: [...] } structure', () => {
+      const renderer = new TableRenderer();
+      renderer.render(
+        {
+          data: [
+            { id: '1', title: 'Task A' },
+            { id: '2', title: 'Task B' },
+          ],
+          meta: { page: 1, total_pages: 1, total_count: 2 },
+        },
+        ctx,
+      );
+
+      expect(spy).toHaveBeenCalledTimes(4);
+      expect(spy).toHaveBeenNthCalledWith(1, 'id | title ');
+    });
+  });
+
+  describe('render single object', () => {
+    it('wraps single object as one-row table', () => {
+      new TableRenderer().render({ id: '42', name: 'Single' }, ctx);
+
+      expect(spy).toHaveBeenCalledTimes(3);
+      expect(spy).toHaveBeenNthCalledWith(1, 'id | name  ');
+      expect(spy).toHaveBeenNthCalledWith(2, '---+-------');
+      expect(spy).toHaveBeenNthCalledWith(3, '42 | Single');
+    });
+  });
+
+  describe('render primitive', () => {
+    it('outputs string as-is', () => {
+      new TableRenderer().render('hello', ctx);
+      expect(spy).toHaveBeenCalledWith('hello');
+    });
+
+    it('outputs number as string', () => {
+      new TableRenderer().render(456, ctx);
+      expect(spy).toHaveBeenCalledWith('456');
+    });
+  });
+
+  describe('missing and null fields', () => {
+    it('handles null values as empty strings', () => {
+      new TableRenderer().render([{ id: '1', name: null }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(3, '1  |     ');
+    });
+
+    it('handles undefined values as empty strings', () => {
+      new TableRenderer().render([{ id: '1', name: undefined }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(3, '1  |     ');
+    });
+
+    it('handles missing keys with empty values', () => {
+      const data = [
+        { id: '1', name: 'Alice', extra: 'val' },
+        { id: '2', name: 'Bob' },
+      ];
+      new TableRenderer().render(data, ctx);
+
+      // Header (1), separator (2), row 1 (3), row 2 (4)
+      // Table renderer pads all columns to max width
+      expect(spy).toHaveBeenNthCalledWith(3, '1  | Alice | val  ');
+      expect(spy).toHaveBeenNthCalledWith(4, '2  | Bob   |      ');
+    });
+  });
+
+  describe('special characters', () => {
+    it('handles values with special characters', () => {
+      new TableRenderer().render([{ text: 'hello, world' }], ctx);
+
+      expect(spy).toHaveBeenNthCalledWith(3, 'hello, world');
+    });
+
+    it('handles values with pipe character', () => {
+      new TableRenderer().render([{ text: 'a | b' }], ctx);
+
+      // The pipe in the value doesn't need escaping, it's part of the content
+      expect(spy).toHaveBeenNthCalledWith(3, 'a | b');
+    });
+  });
+
+  describe('singleton instance', () => {
+    it('exports a usable singleton', () => {
+      tableRenderer.render([{ x: 1 }], ctx);
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #53

Adds dedicated test files for 4 CLI renderers that had no tests: csv, table, json, kanban. Tests cover rendering with data, empty data, missing fields, and format-specific edge cases.