### PR TITLE
Extract createResourceHandler factory for MCP handlers

### DIFF
--- a/packages/mcp/src/handlers/factory.test.ts
+++ b/packages/mcp/src/handlers/factory.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Tests for the resource handler factory.
+ */
+
+import type { JsonApiResource } from '@studiometa/productive-api';
+import type { ExecutorContext } from '@studiometa/productive-core';
+
+import { describe, it, expect, vi } from 'vitest';
+
+import type { HandlerContext } from './types.js';
+
+import { createResourceHandler } from './factory.js';
+
+// Mock data
+const mockProject: JsonApiResource = {
+  id: '123',
+  type: 'projects',
+  attributes: {
+    name: 'Test Project',
+    number: 42,
+  },
+  relationships: {},
+};
+
+const mockProjects: JsonApiResource[] = [
+  mockProject,
+  {
+    id: '456',
+    type: 'projects',
+    attributes: { name: 'Another Project', number: 43 },
+    relationships: {},
+  },
+];
+
+// Mock formatter
+const mockFormatter = (item: JsonApiResource) => ({
+  id: item.id,
+  name: item.attributes?.name,
+});
+
+// Mock hints generator
+const mockHints = (_data: JsonApiResource, id: string) => ({
+  related_resources: [
+    { resource: 'tasks', description: 'Get tasks', example: { filter: { project_id: id } } },
+  ],
+});
+
+// Mock executor context factory
+const createMockExecutorContext = (): ExecutorContext => ({
+  api: {} as ExecutorContext['api'],
+  resolver: {} as ExecutorContext['resolver'],
+});
+
+// Mock handler context factory
+const createMockHandlerContext = (overrides?: Partial<HandlerContext>): HandlerContext => ({
+  formatOptions: {},
+  perPage: 20,
+  executor: createMockExecutorContext,
+  ...overrides,
+});
+
+describe('createResourceHandler', () => {
+  describe('list action', () => {
+    it('should call list executor and format results', async () => {
+      const listExecutor = vi.fn().mockResolvedValue({
+        data: mockProjects,
+        meta: { total_count: 2, current_page: 1, total_pages: 1 },
+      });
+
+      const handler = createResourceHandler({
+        resource: 'projects',
+        actions: ['list', 'get'],
+        formatter: mockFormatter,
+        executors: { list: listExecutor },
+      });
+
+      const result = await handler('list', {}, createMockHandlerContext());
+
+      expect(listExecutor).toHaveBeenCalled();
+      expect(result.isError).toBeUndefined();
+      const content = JSON.parse((result.content[0] as { text: string }).text);
+      expect(content.data).toHaveLength(2);
+      expect(content.data[0].id).toBe('123');
+      // meta is only present when total_pages > 1
+    });
+
+    it('should include meta when there are multiple pages', async () => {
+      const listExecutor = vi.fn().mockResolvedValue({
+        data: mockProjects,
+        meta: { total_count: 50, current_page: 1, total_pages: 3 },
+      });
+
+      const handler = createResourceHandler({
+        resource: 'projects',
+        actions: ['list'],
+        formatter: mockFormatter,
+        executors: { list: listExecutor },
+      });
+
+      const result = await handler('list', {}, createMockHandlerContext());
+
+      const content = JSON.parse((result.content[0] as { text: string }).text);
+      expect(content.meta).toBeDefined();
+      expect(content.meta.total_pages).toBe(3);
+    });
+
+    it('should include _resolved when present', async () => {
+      const listExecutor = vi.fn().mockResolvedValue({
+        data: mockProjects,
+        resolved: { project: 'Test Project → 123' },
+      });
+
+      const handler = createResourceHandler({
+        resource: 'projects',
+        actions: ['list'],
+        formatter: mockFormatter,
+        executors: { list: listExecutor },
+      });
+
+      const result = await handler('list', {}, createMockHandlerContext());
+
+      const content = JSON.parse((result.content[0] as { text: string }).text);
+      expect(content._resolved).toEqual({ project: 'Test Project → 123' });
+    });
+
+    it('should merge user includes with defaults', async () => {
+      const listExecutor = vi.fn().mockResolvedValue({ data: [] });
+
+      const handler = createResourceHandler({
+        resource: 'projects',
+        actions: ['list'],
+        formatter: mockFormatter,
+        defaultInclude: { list: ['company'] },
+        executors: { list: listExecutor },
+      });
+
+      await handler('list', {}, createMockHandlerContext({ include: ['custom'] }));
+
+      expect(listExecutor).toHaveBeenCalledWith(
+        expect.objectContaining({ include: ['company', 'custom'] }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('get action', () => {
+    it('should return error when id is missing', async () => {
+      const handler = createResourceHandler({
+        resource: 'projects',
+        actions: ['list', 'get'],
+        formatter: mockFormatter,
+        executors: {
+          list: vi.fn(),
+          get: vi.fn(),
+        },
+      });
+
+      const result = await handler('get', {}, createMockHandlerContext());
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('id is required');
+    });
+
+    it('should call get executor and format result', async () => {
+      const getExecutor = vi.fn().mockResolvedValue({ data: mockProject });
+
+      const handler = createResourceHandler({
+        resource: 'projects',
+        actions: ['list', 'get'],
+        formatter: mockFormatter,
+        executors: {
+          list: vi.fn(),
+          get: getExecutor,
+        },
+      });
+
+      const result = await handler(
+        'get',
+        { id: '123' },
+        createMockHandlerContext({ includeHints: false }),
+      );
+
+      expect(getExecutor).toHaveBeenCalledWith(
+        { id: '123', include: undefined },
+        expect.anything(),
+      );
+      expect(result.isError).toBeUndefined();
+      const content = JSON.parse((result.content[0] as { text: string }).text);
+      expect(content.id).toBe('123');
+      expect(content.name).toBe('Test Project');
+    });
+
+    it('should include hints when configured and enabled', async () => {
+      const getExecutor = vi.fn().mockResolvedValue({ data: mockProject });
+
+      const handler = createResourceHandler({
+        resource: 'projects',
+        actions: ['list', 'get'],
+        formatter: mockFormatter,
+        hints: mockHints,
+        executors: {
+          list: vi.fn(),
+          get: getExecutor,
+        },
+      });
+
+      const result = await handler(
+        'get',
+        { id: '123' },
+        createMockHandlerContext({ includeHints: true }),
+      );
+
+      const content = JSON.parse((result.content[0] as { text: string }).text);
+      expect(content._hints).toBeDefined();
+      expect(content._hints.related_resources).toHaveLength(1);
+    });
+
+    it('should not include hints when disabled', async () => {
+      const getExecutor = vi.fn().mockResolvedValue({ data: mockProject });
+
+      const handler = createResourceHandler({
+        resource: 'projects',
+        actions: ['list', 'get'],
+        formatter: mockFormatter,
+        hints: mockHints,
+        executors: {
+          list: vi.fn(),
+          get: getExecutor,
+        },
+      });
+
+      const result = await handler(
+        'get',
+        { id: '123' },
+        createMockHandlerContext({ includeHints: false }),
+      );
+
+      const content = JSON.parse((result.content[0] as { text: string }).text);
+      expect(content._hints).toBeUndefined();
+    });
+  });
+
+  describe('create action', () => {
+    it('should return error when required fields are missing', async () => {
+      const handler = createResourceHandler({
+        resource: 'tasks',
+        actions: ['list', 'create'],
+        formatter: mockFormatter,
+        create: {
+          required: ['title', 'project_id'] as (keyof { title?: string; project_id?: string })[],
+          mapOptions: (args) => ({ title: (args as { title?: string }).title }),
+        },
+        executors: {
+          list: vi.fn(),
+          create: vi.fn(),
+        },
+      });
+
+      const result = await handler('create', {}, createMockHandlerContext());
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('title');
+      expect((result.content[0] as { text: string }).text).toContain('project_id');
+    });
+
+    it('should call create executor with mapped options', async () => {
+      interface TaskArgs {
+        id?: string;
+        title?: string;
+        project_id?: string;
+      }
+      const createExecutor = vi.fn().mockResolvedValue({ data: mockProject });
+
+      const handler = createResourceHandler<TaskArgs>({
+        resource: 'tasks',
+        actions: ['list', 'create'],
+        formatter: mockFormatter,
+        create: {
+          required: ['title', 'project_id'],
+          mapOptions: (args) => ({ title: args.title, projectId: args.project_id }),
+        },
+        executors: {
+          list: vi.fn(),
+          create: createExecutor,
+        },
+      });
+
+      const result = await handler(
+        'create',
+        { title: 'New Task', project_id: '456' },
+        createMockHandlerContext(),
+      );
+
+      expect(createExecutor).toHaveBeenCalledWith(
+        { title: 'New Task', projectId: '456' },
+        expect.anything(),
+      );
+      expect(result.isError).toBeUndefined();
+      const content = JSON.parse((result.content[0] as { text: string }).text);
+      expect(content.success).toBe(true);
+    });
+  });
+
+  describe('update action', () => {
+    it('should return error when id is missing', async () => {
+      const handler = createResourceHandler({
+        resource: 'tasks',
+        actions: ['list', 'update'],
+        formatter: mockFormatter,
+        update: {
+          mapOptions: () => ({}),
+        },
+        executors: {
+          list: vi.fn(),
+          update: vi.fn(),
+        },
+      });
+
+      const result = await handler('update', {}, createMockHandlerContext());
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('id is required');
+    });
+
+    it('should call update executor with id and mapped options', async () => {
+      interface TaskArgs {
+        id?: string;
+        title?: string;
+      }
+      const updateExecutor = vi.fn().mockResolvedValue({ data: mockProject });
+
+      const handler = createResourceHandler<TaskArgs>({
+        resource: 'tasks',
+        actions: ['list', 'update'],
+        formatter: mockFormatter,
+        update: {
+          mapOptions: (args) => ({ title: args.title }),
+        },
+        executors: {
+          list: vi.fn(),
+          update: updateExecutor,
+        },
+      });
+
+      const result = await handler(
+        'update',
+        { id: '123', title: 'Updated' },
+        createMockHandlerContext(),
+      );
+
+      expect(updateExecutor).toHaveBeenCalledWith(
+        { id: '123', title: 'Updated' },
+        expect.anything(),
+      );
+      expect(result.isError).toBeUndefined();
+      const content = JSON.parse((result.content[0] as { text: string }).text);
+      expect(content.success).toBe(true);
+    });
+  });
+
+  describe('delete action', () => {
+    it('should return error when id is missing', async () => {
+      const handler = createResourceHandler({
+        resource: 'attachments',
+        actions: ['list', 'delete'],
+        formatter: mockFormatter,
+        executors: {
+          list: vi.fn(),
+          delete: vi.fn(),
+        },
+      });
+
+      const result = await handler('delete', {}, createMockHandlerContext());
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('id is required');
+    });
+
+    it('should call delete executor and return success', async () => {
+      const deleteExecutor = vi.fn().mockResolvedValue(undefined);
+
+      const handler = createResourceHandler({
+        resource: 'attachments',
+        actions: ['list', 'delete'],
+        formatter: mockFormatter,
+        executors: {
+          list: vi.fn(),
+          delete: deleteExecutor,
+        },
+      });
+
+      const result = await handler('delete', { id: '123' }, createMockHandlerContext());
+
+      expect(deleteExecutor).toHaveBeenCalledWith({ id: '123' }, expect.anything());
+      expect(result.isError).toBeUndefined();
+      const content = JSON.parse((result.content[0] as { text: string }).text);
+      expect(content.success).toBe(true);
+      expect(content.deleted).toBe('123');
+    });
+  });
+
+  describe('resolve action', () => {
+    it('should return error when resolve is not supported', async () => {
+      const handler = createResourceHandler({
+        resource: 'attachments',
+        actions: ['list', 'get'],
+        formatter: mockFormatter,
+        supportsResolve: false,
+        executors: { list: vi.fn(), get: vi.fn() },
+      });
+
+      const result = await handler('resolve', { query: 'test' }, createMockHandlerContext());
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('Invalid action');
+    });
+  });
+
+  describe('invalid action', () => {
+    it('should return error for unknown actions', async () => {
+      const handler = createResourceHandler({
+        resource: 'projects',
+        actions: ['list', 'get'],
+        formatter: mockFormatter,
+        executors: { list: vi.fn(), get: vi.fn() },
+      });
+
+      const result = await handler('unknown', {}, createMockHandlerContext());
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('Invalid action');
+      expect((result.content[0] as { text: string }).text).toContain('list, get');
+    });
+
+    it('should return error when action executor is not configured', async () => {
+      const handler = createResourceHandler({
+        resource: 'projects',
+        actions: ['list', 'get', 'create'], // create in actions but no executor
+        formatter: mockFormatter,
+        executors: { list: vi.fn(), get: vi.fn() },
+      });
+
+      const result = await handler('create', {}, createMockHandlerContext());
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('Invalid action');
+    });
+  });
+});

--- a/packages/mcp/src/handlers/factory.ts
+++ b/packages/mcp/src/handlers/factory.ts
@@ -1,0 +1,276 @@
+/**
+ * Factory for creating resource handlers.
+ *
+ * Encapsulates the repetitive list/get/create/update/delete/resolve pattern
+ * shared by all MCP resource handlers.
+ */
+
+import type { JsonApiResource } from '@studiometa/productive-api';
+import type { ExecutorContext, ResolvedInfo } from '@studiometa/productive-core';
+
+import type { McpFormatOptions } from '../formatters.js';
+import type { ContextualHints } from '../hints.js';
+import type { CommonArgs, HandlerContext, ToolResult } from './types.js';
+
+import { ErrorMessages } from '../errors.js';
+import { formatListResponse } from '../formatters.js';
+import { handleResolve, type ResolvableResourceType } from './resolve.js';
+import { inputErrorResult, jsonResult } from './utils.js';
+
+/**
+ * Result type from executors (list operations)
+ */
+interface ListExecutorResult {
+  data: JsonApiResource[];
+  meta?: { total_count?: number; total_pages?: number; current_page?: number };
+  included?: JsonApiResource[];
+  resolved?: Record<string, ResolvedInfo>;
+}
+
+/**
+ * Result type from executors (single resource operations)
+ */
+interface SingleExecutorResult {
+  data: JsonApiResource;
+  included?: JsonApiResource[];
+}
+
+/**
+ * Configuration for the create action
+ */
+interface CreateConfig<TArgs> {
+  /** Fields that must be present for create */
+  required: (keyof TArgs)[];
+  /** Custom validation (return error message or undefined if valid) */
+  validate?: (args: TArgs) => string | undefined;
+  /** Map args to executor options */
+  mapOptions: (args: TArgs) => Record<string, unknown>;
+}
+
+/**
+ * Configuration for the update action
+ */
+interface UpdateConfig<TArgs> {
+  /** Map args to executor options (id is handled automatically) */
+  mapOptions: (args: TArgs) => Record<string, unknown>;
+}
+
+/**
+ * Configuration for a resource handler
+ */
+export interface ResourceHandlerConfig<TArgs extends CommonArgs = CommonArgs> {
+  /** Resource name (e.g., 'projects', 'tasks') */
+  resource: string;
+
+  /** Valid actions for this resource */
+  actions: string[];
+
+  /** Formatter function for this resource */
+  formatter: (item: JsonApiResource, options?: McpFormatOptions) => Record<string, unknown>;
+
+  /** Optional hints generator for get action */
+  hints?: (data: JsonApiResource, id: string) => ContextualHints;
+
+  /** Default include for list/get operations */
+  defaultInclude?: {
+    list?: string[];
+    get?: string[];
+  };
+
+  /** Whether this resource supports the resolve action */
+  supportsResolve?: boolean;
+
+  /** Create action configuration (if supported) */
+  create?: CreateConfig<TArgs>;
+
+  /** Update action configuration (if supported) */
+  update?: UpdateConfig<TArgs>;
+
+  /** Executors for each action */
+  executors: {
+    list: (
+      options: {
+        page?: number;
+        perPage?: number;
+        additionalFilters?: Record<string, string>;
+        include?: string[];
+      },
+      ctx: ExecutorContext,
+    ) => Promise<ListExecutorResult>;
+    get?: (
+      options: { id: string; include?: string[] },
+      ctx: ExecutorContext,
+    ) => Promise<SingleExecutorResult>;
+    create?: (
+      options: Record<string, unknown>,
+      ctx: ExecutorContext,
+    ) => Promise<SingleExecutorResult>;
+    update?: (
+      options: Record<string, unknown>,
+      ctx: ExecutorContext,
+    ) => Promise<SingleExecutorResult>;
+    delete?: (options: { id: string }, ctx: ExecutorContext) => Promise<void>;
+  };
+}
+
+/**
+ * Merge user includes with defaults, ensuring no duplicates
+ */
+function mergeIncludes(userInclude?: string[], defaults?: string[]): string[] | undefined {
+  if (!userInclude?.length && !defaults?.length) return undefined;
+  if (!userInclude?.length) return defaults;
+  if (!defaults?.length) return userInclude;
+  return [...new Set([...defaults, ...userInclude])];
+}
+
+/**
+ * Create a resource handler function from configuration.
+ *
+ * @example
+ * ```typescript
+ * export const handleProjects = createResourceHandler({
+ *   resource: 'projects',
+ *   actions: ['list', 'get', 'resolve'],
+ *   formatter: formatProject,
+ *   hints: (data, id) => getProjectHints(id),
+ *   supportsResolve: true,
+ *   executors: {
+ *     list: listProjects,
+ *     get: getProject,
+ *   },
+ * });
+ * ```
+ */
+export function createResourceHandler<TArgs extends CommonArgs = CommonArgs>(
+  config: ResourceHandlerConfig<TArgs>,
+): (
+  action: string,
+  args: TArgs & { query?: string; type?: ResolvableResourceType },
+  ctx: HandlerContext,
+) => Promise<ToolResult> {
+  const {
+    resource,
+    actions,
+    formatter,
+    hints,
+    defaultInclude,
+    supportsResolve,
+    create: createConfig,
+    update: updateConfig,
+    executors,
+  } = config;
+
+  return async (
+    action: string,
+    args: TArgs & { query?: string; type?: ResolvableResourceType },
+    ctx: HandlerContext,
+  ): Promise<ToolResult> => {
+    const { formatOptions, filter, page, perPage, include: userInclude } = ctx;
+    const { id, query, type } = args;
+
+    // Handle resolve action
+    if (action === 'resolve') {
+      if (!supportsResolve) {
+        return inputErrorResult(ErrorMessages.invalidAction(action, resource, actions));
+      }
+      return handleResolve({ query, type }, ctx);
+    }
+
+    const execCtx = ctx.executor();
+
+    // Handle get action
+    if (action === 'get') {
+      if (!executors.get) {
+        return inputErrorResult(ErrorMessages.invalidAction(action, resource, actions));
+      }
+      if (!id) return inputErrorResult(ErrorMessages.missingId('get'));
+
+      const include = mergeIncludes(userInclude, defaultInclude?.get);
+      const result = await executors.get({ id, include }, execCtx);
+      const formatted = formatter(result.data, { ...formatOptions, included: result.included });
+
+      if (ctx.includeHints !== false && hints) {
+        return jsonResult({
+          ...formatted,
+          _hints: hints(result.data, id),
+        });
+      }
+
+      return jsonResult(formatted);
+    }
+
+    // Handle create action
+    if (action === 'create') {
+      if (!executors.create || !createConfig) {
+        return inputErrorResult(ErrorMessages.invalidAction(action, resource, actions));
+      }
+
+      // Check required fields
+      const missingFields = createConfig.required.filter((field) => !args[field]);
+      if (missingFields.length > 0) {
+        return inputErrorResult(
+          ErrorMessages.missingRequiredFields(resource, missingFields as string[]),
+        );
+      }
+
+      // Run custom validation if provided
+      if (createConfig.validate) {
+        const errorMessage = createConfig.validate(args);
+        if (errorMessage) {
+          return inputErrorResult(ErrorMessages.missingRequiredFields(resource, [errorMessage]));
+        }
+      }
+
+      const options = createConfig.mapOptions(args);
+      const result = await executors.create(options, execCtx);
+      return jsonResult({ success: true, ...formatter(result.data, formatOptions) });
+    }
+
+    // Handle update action
+    if (action === 'update') {
+      if (!executors.update || !updateConfig) {
+        return inputErrorResult(ErrorMessages.invalidAction(action, resource, actions));
+      }
+      if (!id) return inputErrorResult(ErrorMessages.missingId('update'));
+
+      const options = { id, ...updateConfig.mapOptions(args) };
+      const result = await executors.update(options, execCtx);
+      return jsonResult({ success: true, ...formatter(result.data, formatOptions) });
+    }
+
+    // Handle delete action
+    if (action === 'delete') {
+      if (!executors.delete) {
+        return inputErrorResult(ErrorMessages.invalidAction(action, resource, actions));
+      }
+      if (!id) return inputErrorResult(ErrorMessages.missingId('delete'));
+
+      await executors.delete({ id }, execCtx);
+      return jsonResult({ success: true, deleted: id });
+    }
+
+    // Handle list action
+    if (action === 'list') {
+      const include = mergeIncludes(userInclude, defaultInclude?.list);
+      const result = await executors.list(
+        { page, perPage, additionalFilters: filter, include },
+        execCtx,
+      );
+
+      const response = formatListResponse(result.data, formatter, result.meta, {
+        ...formatOptions,
+        included: result.included,
+      });
+
+      // Include resolution metadata if any resolutions occurred
+      if (result.resolved && Object.keys(result.resolved).length > 0) {
+        return jsonResult({ ...response, _resolved: result.resolved });
+      }
+
+      return jsonResult(response);
+    }
+
+    // Invalid action
+    return inputErrorResult(ErrorMessages.invalidAction(action, resource, actions));
+  };
+}

--- a/packages/mcp/src/handlers/projects.ts
+++ b/packages/mcp/src/handlers/projects.ts
@@ -1,60 +1,30 @@
 /**
  * Projects MCP handler.
+ *
+ * Uses the createResourceHandler factory for the common list/get/resolve pattern.
  */
 
 import { listProjects, getProject } from '@studiometa/productive-core';
 
-import type { CommonArgs, HandlerContext, ToolResult } from './types.js';
+import type { CommonArgs } from './types.js';
 
-import { ErrorMessages } from '../errors.js';
-import { formatListResponse, formatProject } from '../formatters.js';
+import { formatProject } from '../formatters.js';
 import { getProjectHints } from '../hints.js';
-import { handleResolve, type ResolvableResourceType } from './resolve.js';
-import { inputErrorResult, jsonResult } from './utils.js';
+import { createResourceHandler } from './factory.js';
 
-const VALID_ACTIONS = ['list', 'get', 'resolve'];
-
-export async function handleProjects(
-  action: string,
-  args: CommonArgs & { query?: string; type?: ResolvableResourceType },
-  ctx: HandlerContext,
-): Promise<ToolResult> {
-  const { formatOptions, filter, page, perPage } = ctx;
-  const { id, query, type } = args;
-
-  if (action === 'resolve') {
-    return handleResolve({ query, type }, ctx);
-  }
-
-  const execCtx = ctx.executor();
-
-  if (action === 'get') {
-    if (!id) return inputErrorResult(ErrorMessages.missingId('get'));
-
-    const result = await getProject({ id }, execCtx);
-    const formatted = formatProject(result.data, formatOptions);
-
-    if (ctx.includeHints !== false) {
-      return jsonResult({
-        ...formatted,
-        _hints: getProjectHints(id),
-      });
-    }
-
-    return jsonResult(formatted);
-  }
-
-  if (action === 'list') {
-    const result = await listProjects({ page, perPage, additionalFilters: filter }, execCtx);
-
-    const response = formatListResponse(result.data, formatProject, result.meta, formatOptions);
-
-    if (result.resolved && Object.keys(result.resolved).length > 0) {
-      return jsonResult({ ...response, _resolved: result.resolved });
-    }
-
-    return jsonResult(response);
-  }
-
-  return inputErrorResult(ErrorMessages.invalidAction(action, 'projects', VALID_ACTIONS));
-}
+/**
+ * Handle projects resource.
+ *
+ * Supports: list, get, resolve
+ */
+export const handleProjects = createResourceHandler<CommonArgs>({
+  resource: 'projects',
+  actions: ['list', 'get', 'resolve'],
+  formatter: formatProject,
+  hints: (_data, id) => getProjectHints(id),
+  supportsResolve: true,
+  executors: {
+    list: listProjects,
+    get: getProject,
+  },
+});


### PR DESCRIPTION
Closes #50

Extracts a generic `createResourceHandler()` factory that encapsulates the repetitive list/get/create/update/delete/resolve pattern shared by all 14 MCP resource handlers. Refactors `projects.ts` as proof of concept. Other handlers can be migrated incrementally.