### PR TITLE
Extract createCommandRouter utility for CLI commands

### DIFF
--- a/packages/cli/src/commands/tasks/command.ts
+++ b/packages/cli/src/commands/tasks/command.ts
@@ -2,42 +2,20 @@
  * Tasks command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { tasksList, tasksGet, tasksAdd, tasksUpdate } from './handlers.js';
 
 /**
  * Handle tasks command
  */
-export async function handleTasksCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await tasksList(ctx);
-      break;
-    case 'get':
-      await tasksGet(args, ctx);
-      break;
-    case 'add':
-    case 'create':
-      await tasksAdd(ctx);
-      break;
-    case 'update':
-      await tasksUpdate(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown tasks subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleTasksCommand = createCommandRouter({
+  resource: 'tasks',
+  handlers: {
+    list: tasksList,
+    ls: tasksList,
+    get: [tasksGet, 'args'],
+    add: tasksAdd,
+    create: tasksAdd,
+    update: [tasksUpdate, 'args'],
+  },
+});

--- a/packages/cli/src/utils/command-router.test.ts
+++ b/packages/cli/src/utils/command-router.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { createCommandRouter, type ListHandler, type ArgsHandler } from './command-router.js';
+
+// Mock the context module to avoid API token requirement
+vi.mock('../context.js', () => ({
+  createContext: vi.fn((options) => ({
+    api: {},
+    formatter: { output: vi.fn(), error: vi.fn() },
+    config: { apiToken: 'test-token', organizationId: '12345' },
+    cache: {},
+    options,
+    createSpinner: vi.fn(() => ({ start: vi.fn(), succeed: vi.fn(), fail: vi.fn() })),
+    getPagination: () => ({ page: 1, perPage: 100 }),
+    getSort: () => '',
+    resolveFilters: vi.fn(),
+    tryResolveValue: vi.fn(),
+  })),
+}));
+
+// Mock process.exit to prevent test from actually exiting
+const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+// Mock console.error to capture error output
+const mockConsoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+describe('createCommandRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes to correct handler for list-style commands', async () => {
+    const listHandler = vi.fn<ListHandler>().mockResolvedValue(undefined);
+
+    const router = createCommandRouter({
+      resource: 'tasks',
+      handlers: {
+        list: listHandler,
+      },
+    });
+
+    await router('list', [], { format: 'json' });
+
+    expect(listHandler).toHaveBeenCalledTimes(1);
+    expect(listHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({ format: 'json' }),
+      }),
+    );
+  });
+
+  it('handles aliases correctly', async () => {
+    const listHandler = vi.fn<ListHandler>().mockResolvedValue(undefined);
+
+    const router = createCommandRouter({
+      resource: 'tasks',
+      handlers: {
+        list: listHandler,
+        ls: listHandler, // alias
+      },
+    });
+
+    await router('ls', [], { format: 'json' });
+
+    expect(listHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes args to args-style handlers', async () => {
+    const getHandler = vi.fn<ArgsHandler>().mockResolvedValue(undefined);
+
+    const router = createCommandRouter({
+      resource: 'tasks',
+      handlers: {
+        get: [getHandler, 'args'],
+      },
+    });
+
+    await router('get', ['123', '456'], { format: 'json' });
+
+    expect(getHandler).toHaveBeenCalledTimes(1);
+    expect(getHandler).toHaveBeenCalledWith(
+      ['123', '456'],
+      expect.objectContaining({
+        options: expect.objectContaining({ format: 'json' }),
+      }),
+    );
+  });
+
+  it('exits with error for unknown subcommand', async () => {
+    const router = createCommandRouter({
+      resource: 'tasks',
+      handlers: {
+        list: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+
+    await router('unknown', [], { format: 'human' });
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown tasks subcommand: unknown'),
+    );
+  });
+
+  it('uses resource name in error message', async () => {
+    const router = createCommandRouter({
+      resource: 'projects',
+      handlers: {},
+    });
+
+    await router('invalid', [], { format: 'human' });
+
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown projects subcommand: invalid'),
+    );
+  });
+
+  it('passes format option to context', async () => {
+    const listHandler = vi.fn<ListHandler>().mockResolvedValue(undefined);
+
+    const router = createCommandRouter({
+      resource: 'tasks',
+      handlers: {
+        list: listHandler,
+      },
+    });
+
+    await router('list', [], { format: 'table', 'no-color': true });
+
+    expect(listHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          format: 'table',
+          'no-color': true,
+        }),
+      }),
+    );
+  });
+
+  it('supports short format option (f)', async () => {
+    const listHandler = vi.fn<ListHandler>().mockResolvedValue(undefined);
+
+    const router = createCommandRouter({
+      resource: 'tasks',
+      handlers: {
+        list: listHandler,
+      },
+    });
+
+    await router('list', [], { f: 'csv' });
+
+    expect(listHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({ f: 'csv' }),
+      }),
+    );
+  });
+
+  it('handles multiple handlers in config', async () => {
+    const listHandler = vi.fn<ListHandler>().mockResolvedValue(undefined);
+    const getHandler = vi.fn<ArgsHandler>().mockResolvedValue(undefined);
+    const addHandler = vi.fn<ListHandler>().mockResolvedValue(undefined);
+    const updateHandler = vi.fn<ArgsHandler>().mockResolvedValue(undefined);
+
+    const router = createCommandRouter({
+      resource: 'tasks',
+      handlers: {
+        list: listHandler,
+        ls: listHandler,
+        get: [getHandler, 'args'],
+        add: addHandler,
+        create: addHandler,
+        update: [updateHandler, 'args'],
+      },
+    });
+
+    // Test each handler type
+    await router('list', [], { format: 'json' });
+    expect(listHandler).toHaveBeenCalledTimes(1);
+
+    await router('get', ['123'], { format: 'json' });
+    expect(getHandler).toHaveBeenCalledTimes(1);
+    expect(getHandler).toHaveBeenCalledWith(['123'], expect.anything());
+
+    await router('add', [], { format: 'json' });
+    expect(addHandler).toHaveBeenCalledTimes(1);
+
+    await router('update', ['456'], { format: 'json' });
+    expect(updateHandler).toHaveBeenCalledTimes(1);
+    expect(updateHandler).toHaveBeenCalledWith(['456'], expect.anything());
+  });
+});

--- a/packages/cli/src/utils/command-router.ts
+++ b/packages/cli/src/utils/command-router.ts
@@ -1,0 +1,91 @@
+/**
+ * Generic command router factory for CLI commands.
+ *
+ * Eliminates boilerplate switch/case pattern in command routing.
+ *
+ * @example
+ * ```typescript
+ * import { createCommandRouter } from '../../utils/command-router.js';
+ * import { tasksList, tasksGet, tasksAdd, tasksUpdate } from './handlers.js';
+ *
+ * export const handleTasksCommand = createCommandRouter({
+ *   resource: 'tasks',
+ *   handlers: {
+ *     list: tasksList,
+ *     ls: tasksList,           // alias
+ *     get: [tasksGet, 'args'], // handler that receives args
+ *     add: tasksAdd,
+ *     create: tasksAdd,        // alias
+ *     update: [tasksUpdate, 'args'],
+ *   },
+ * });
+ * ```
+ */
+
+import type { CommandContext, CommandOptions } from '../context.js';
+import type { OutputFormat } from '../types.js';
+
+import { createContext } from '../context.js';
+import { OutputFormatter } from '../output.js';
+
+/**
+ * Handler that only receives context (e.g., list commands)
+ */
+export type ListHandler = (ctx: CommandContext) => Promise<void>;
+
+/**
+ * Handler that receives args and context (e.g., get/update commands)
+ */
+export type ArgsHandler = (args: string[], ctx: CommandContext) => Promise<void>;
+
+/**
+ * Handler definition - either a ListHandler or an ArgsHandler marked with 'args'
+ */
+export type Handler = ListHandler | [ArgsHandler, 'args'];
+
+/**
+ * Configuration for the command router
+ */
+export interface CommandRouterConfig {
+  /** Resource name for error messages (e.g., 'tasks', 'projects') */
+  resource: string;
+  /** Map of subcommand names to handlers */
+  handlers: Record<string, Handler>;
+}
+
+/**
+ * Creates a command router function that dispatches to the appropriate handler.
+ *
+ * This factory eliminates the repetitive switch/case pattern found in all
+ * command.ts files, centralizing the routing logic.
+ *
+ * @param config - Router configuration with resource name and handlers
+ * @returns Async function that routes subcommands to handlers
+ */
+export function createCommandRouter(config: CommandRouterConfig) {
+  return async function (
+    subcommand: string,
+    args: string[],
+    options: Record<string, string | boolean>,
+  ): Promise<void> {
+    const format = (options.format || options.f || 'human') as OutputFormat;
+    const formatter = new OutputFormatter(format, options['no-color'] === true);
+
+    const ctx = createContext(options as CommandOptions);
+
+    const handler = config.handlers[subcommand];
+    if (!handler) {
+      formatter.error(`Unknown ${config.resource} subcommand: ${subcommand}`);
+      process.exit(1);
+      return; // Unreachable in production, but needed for tests where process.exit is mocked
+    }
+
+    if (Array.isArray(handler)) {
+      // ArgsHandler - receives args and context
+      await handler[0](args, ctx);
+    } else {
+      // ListHandler - receives only context
+      await handler(ctx);
+    }
+  };
+}


### PR DESCRIPTION
Closes #49

Extracts a generic `createCommandRouter()` factory that eliminates the boilerplate switch/case pattern in CLI command routing. Refactors `tasks/command.ts` as proof of concept. Other commands can be migrated incrementally.