### PR TITLE
Migrate remaining CLI commands to createCommandRouter

### DIFF
--- a/packages/cli/src/commands/attachments/command.ts
+++ b/packages/cli/src/commands/attachments/command.ts
@@ -2,39 +2,19 @@
  * Attachments command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { attachmentsList, attachmentsGet, attachmentsDelete } from './handlers.js';
 
 /**
  * Handle attachments command
  */
-export async function handleAttachmentsCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await attachmentsList(ctx);
-      break;
-    case 'get':
-      await attachmentsGet(args, ctx);
-      break;
-    case 'delete':
-    case 'rm':
-      await attachmentsDelete(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown attachments subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleAttachmentsCommand = createCommandRouter({
+  resource: 'attachments',
+  handlers: {
+    list: attachmentsList,
+    ls: attachmentsList,
+    get: [attachmentsGet, 'args'],
+    delete: [attachmentsDelete, 'args'],
+    rm: [attachmentsDelete, 'args'],
+  },
+});

--- a/packages/cli/src/commands/bookings/command.ts
+++ b/packages/cli/src/commands/bookings/command.ts
@@ -2,42 +2,20 @@
  * Bookings command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { bookingsList, bookingsGet, bookingsAdd, bookingsUpdate } from './handlers.js';
 
 /**
  * Handle bookings command
  */
-export async function handleBookingsCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await bookingsList(ctx);
-      break;
-    case 'get':
-      await bookingsGet(args, ctx);
-      break;
-    case 'add':
-    case 'create':
-      await bookingsAdd(ctx);
-      break;
-    case 'update':
-      await bookingsUpdate(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown bookings subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleBookingsCommand = createCommandRouter({
+  resource: 'bookings',
+  handlers: {
+    list: bookingsList,
+    ls: bookingsList,
+    get: [bookingsGet, 'args'],
+    add: bookingsAdd,
+    create: bookingsAdd,
+    update: [bookingsUpdate, 'args'],
+  },
+});

--- a/packages/cli/src/commands/comments/command.ts
+++ b/packages/cli/src/commands/comments/command.ts
@@ -2,42 +2,20 @@
  * Comments command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { commentsList, commentsGet, commentsAdd, commentsUpdate } from './handlers.js';
 
 /**
  * Handle comments command
  */
-export async function handleCommentsCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await commentsList(ctx);
-      break;
-    case 'get':
-      await commentsGet(args, ctx);
-      break;
-    case 'add':
-    case 'create':
-      await commentsAdd(ctx);
-      break;
-    case 'update':
-      await commentsUpdate(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown comments subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleCommentsCommand = createCommandRouter({
+  resource: 'comments',
+  handlers: {
+    list: commentsList,
+    ls: commentsList,
+    get: [commentsGet, 'args'],
+    add: commentsAdd,
+    create: commentsAdd,
+    update: [commentsUpdate, 'args'],
+  },
+});

--- a/packages/cli/src/commands/companies/command.ts
+++ b/packages/cli/src/commands/companies/command.ts
@@ -2,42 +2,20 @@
  * Companies command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { companiesList, companiesGet, companiesAdd, companiesUpdate } from './handlers.js';
 
 /**
  * Handle companies command
  */
-export async function handleCompaniesCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await companiesList(ctx);
-      break;
-    case 'get':
-      await companiesGet(args, ctx);
-      break;
-    case 'add':
-    case 'create':
-      await companiesAdd(ctx);
-      break;
-    case 'update':
-      await companiesUpdate(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown companies subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleCompaniesCommand = createCommandRouter({
+  resource: 'companies',
+  handlers: {
+    list: companiesList,
+    ls: companiesList,
+    get: [companiesGet, 'args'],
+    add: companiesAdd,
+    create: companiesAdd,
+    update: [companiesUpdate, 'args'],
+  },
+});

--- a/packages/cli/src/commands/deals/command.ts
+++ b/packages/cli/src/commands/deals/command.ts
@@ -2,42 +2,20 @@
  * Deals command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { dealsList, dealsGet, dealsAdd, dealsUpdate } from './handlers.js';
 
 /**
  * Handle deals command
  */
-export async function handleDealsCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await dealsList(ctx);
-      break;
-    case 'get':
-      await dealsGet(args, ctx);
-      break;
-    case 'add':
-    case 'create':
-      await dealsAdd(ctx);
-      break;
-    case 'update':
-      await dealsUpdate(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown deals subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleDealsCommand = createCommandRouter({
+  resource: 'deals',
+  handlers: {
+    list: dealsList,
+    ls: dealsList,
+    get: [dealsGet, 'args'],
+    add: dealsAdd,
+    create: dealsAdd,
+    update: [dealsUpdate, 'args'],
+  },
+});

--- a/packages/cli/src/commands/discussions/command.ts
+++ b/packages/cli/src/commands/discussions/command.ts
@@ -2,10 +2,7 @@
  * Discussions command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import {
   discussionsList,
   discussionsGet,
@@ -19,43 +16,18 @@ import {
 /**
  * Handle discussions command
  */
-export async function handleDiscussionsCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await discussionsList(ctx);
-      break;
-    case 'get':
-      await discussionsGet(args, ctx);
-      break;
-    case 'add':
-    case 'create':
-      await discussionsAdd(ctx);
-      break;
-    case 'update':
-      await discussionsUpdate(args, ctx);
-      break;
-    case 'delete':
-    case 'rm':
-      await discussionsDelete(args, ctx);
-      break;
-    case 'resolve':
-      await discussionsResolve(args, ctx);
-      break;
-    case 'reopen':
-      await discussionsReopen(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown discussions subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleDiscussionsCommand = createCommandRouter({
+  resource: 'discussions',
+  handlers: {
+    list: discussionsList,
+    ls: discussionsList,
+    get: [discussionsGet, 'args'],
+    add: discussionsAdd,
+    create: discussionsAdd,
+    update: [discussionsUpdate, 'args'],
+    delete: [discussionsDelete, 'args'],
+    rm: [discussionsDelete, 'args'],
+    resolve: [discussionsResolve, 'args'],
+    reopen: [discussionsReopen, 'args'],
+  },
+});

--- a/packages/cli/src/commands/pages/command.ts
+++ b/packages/cli/src/commands/pages/command.ts
@@ -2,46 +2,22 @@
  * Pages command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { pagesList, pagesGet, pagesAdd, pagesUpdate, pagesDelete } from './handlers.js';
 
 /**
  * Handle pages command
  */
-export async function handlePagesCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await pagesList(ctx);
-      break;
-    case 'get':
-      await pagesGet(args, ctx);
-      break;
-    case 'add':
-    case 'create':
-      await pagesAdd(ctx);
-      break;
-    case 'update':
-      await pagesUpdate(args, ctx);
-      break;
-    case 'delete':
-    case 'rm':
-      await pagesDelete(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown pages subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handlePagesCommand = createCommandRouter({
+  resource: 'pages',
+  handlers: {
+    list: pagesList,
+    ls: pagesList,
+    get: [pagesGet, 'args'],
+    add: pagesAdd,
+    create: pagesAdd,
+    update: [pagesUpdate, 'args'],
+    delete: [pagesDelete, 'args'],
+    rm: [pagesDelete, 'args'],
+  },
+});

--- a/packages/cli/src/commands/people/command.ts
+++ b/packages/cli/src/commands/people/command.ts
@@ -2,35 +2,17 @@
  * People command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { peopleList, peopleGet } from './handlers.js';
 
 /**
  * Handle people command
  */
-export async function handlePeopleCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await peopleList(ctx);
-      break;
-    case 'get':
-      await peopleGet(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown people subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handlePeopleCommand = createCommandRouter({
+  resource: 'people',
+  handlers: {
+    list: peopleList,
+    ls: peopleList,
+    get: [peopleGet, 'args'],
+  },
+});

--- a/packages/cli/src/commands/projects/command.ts
+++ b/packages/cli/src/commands/projects/command.ts
@@ -4,35 +4,17 @@
  * Handles command routing and dispatches to appropriate handlers.
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { projectsList, projectsGet } from './handlers.js';
 
 /**
  * Handle projects command
  */
-export async function handleProjectsCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await projectsList(ctx);
-      break;
-    case 'get':
-      await projectsGet(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown projects subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleProjectsCommand = createCommandRouter({
+  resource: 'projects',
+  handlers: {
+    list: projectsList,
+    ls: projectsList,
+    get: [projectsGet, 'args'],
+  },
+});

--- a/packages/cli/src/commands/reports/command.ts
+++ b/packages/cli/src/commands/reports/command.ts
@@ -2,10 +2,7 @@
  * Reports command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import {
   reportsTime,
   reportsProject,
@@ -23,65 +20,29 @@ import {
 /**
  * Handle reports command
  */
-export async function handleReportsCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'time':
-      await reportsTime(ctx);
-      break;
-    case 'project':
-    case 'projects':
-      await reportsProject(ctx);
-      break;
-    case 'budget':
-    case 'budgets':
-      await reportsBudget(ctx);
-      break;
-    case 'person':
-    case 'people':
-      await reportsPerson(ctx);
-      break;
-    case 'invoice':
-    case 'invoices':
-      await reportsInvoice(ctx);
-      break;
-    case 'payment':
-    case 'payments':
-      await reportsPayment(ctx);
-      break;
-    case 'service':
-    case 'services':
-      await reportsService(ctx);
-      break;
-    case 'task':
-    case 'tasks':
-      await reportsTask(ctx);
-      break;
-    case 'company':
-    case 'companies':
-      await reportsCompany(ctx);
-      break;
-    case 'deal':
-    case 'deals':
-      await reportsDeal(ctx);
-      break;
-    case 'timesheet':
-    case 'timesheets':
-      await reportsTimesheet(ctx);
-      break;
-    default:
-      formatter.error(`Unknown reports subcommand: ${subcommand}`);
-      console.log(
-        'Available report types: time, project, budget, person, invoice, payment, service, task, company, deal, timesheet',
-      );
-      process.exit(1);
-  }
-}
+export const handleReportsCommand = createCommandRouter({
+  resource: 'reports',
+  handlers: {
+    time: reportsTime,
+    project: reportsProject,
+    projects: reportsProject,
+    budget: reportsBudget,
+    budgets: reportsBudget,
+    person: reportsPerson,
+    people: reportsPerson,
+    invoice: reportsInvoice,
+    invoices: reportsInvoice,
+    payment: reportsPayment,
+    payments: reportsPayment,
+    service: reportsService,
+    services: reportsService,
+    task: reportsTask,
+    tasks: reportsTask,
+    company: reportsCompany,
+    companies: reportsCompany,
+    deal: reportsDeal,
+    deals: reportsDeal,
+    timesheet: reportsTimesheet,
+    timesheets: reportsTimesheet,
+  },
+});

--- a/packages/cli/src/commands/services/command.ts
+++ b/packages/cli/src/commands/services/command.ts
@@ -2,32 +2,16 @@
  * Services command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { servicesList } from './handlers.js';
 
 /**
  * Handle services command
  */
-export async function handleServicesCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await servicesList(ctx);
-      break;
-    default:
-      formatter.error(`Unknown services subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleServicesCommand = createCommandRouter({
+  resource: 'services',
+  handlers: {
+    list: servicesList,
+    ls: servicesList,
+  },
+});

--- a/packages/cli/src/commands/time/command.ts
+++ b/packages/cli/src/commands/time/command.ts
@@ -4,45 +4,21 @@
  * Handles command routing and dispatches to appropriate handlers.
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { timeList, timeGet, timeAdd, timeUpdate, timeDelete } from './handlers.js';
 
 /**
  * Handle time command
  */
-export async function handleTimeCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await timeList(ctx);
-      break;
-    case 'get':
-      await timeGet(args, ctx);
-      break;
-    case 'add':
-      await timeAdd(ctx);
-      break;
-    case 'update':
-      await timeUpdate(args, ctx);
-      break;
-    case 'delete':
-    case 'rm':
-      await timeDelete(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown time subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleTimeCommand = createCommandRouter({
+  resource: 'time',
+  handlers: {
+    list: timeList,
+    ls: timeList,
+    get: [timeGet, 'args'],
+    add: timeAdd,
+    update: [timeUpdate, 'args'],
+    delete: [timeDelete, 'args'],
+    rm: [timeDelete, 'args'],
+  },
+});

--- a/packages/cli/src/commands/timers/command.ts
+++ b/packages/cli/src/commands/timers/command.ts
@@ -2,41 +2,19 @@
  * Timers command entry point
  */
 
-import type { OutputFormat } from '../../types.js';
-
-import { createContext, type CommandOptions } from '../../context.js';
-import { OutputFormatter } from '../../output.js';
+import { createCommandRouter } from '../../utils/command-router.js';
 import { timersList, timersGet, timersStart, timersStop } from './handlers.js';
 
 /**
  * Handle timers command
  */
-export async function handleTimersCommand(
-  subcommand: string,
-  args: string[],
-  options: Record<string, string | boolean>,
-): Promise<void> {
-  const format = (options.format || options.f || 'human') as OutputFormat;
-  const formatter = new OutputFormatter(format, options['no-color'] === true);
-
-  const ctx = createContext(options as CommandOptions);
-
-  switch (subcommand) {
-    case 'list':
-    case 'ls':
-      await timersList(ctx);
-      break;
-    case 'get':
-      await timersGet(args, ctx);
-      break;
-    case 'start':
-      await timersStart(ctx);
-      break;
-    case 'stop':
-      await timersStop(args, ctx);
-      break;
-    default:
-      formatter.error(`Unknown timers subcommand: ${subcommand}`);
-      process.exit(1);
-  }
-}
+export const handleTimersCommand = createCommandRouter({
+  resource: 'timers',
+  handlers: {
+    list: timersList,
+    ls: timersList,
+    get: [timersGet, 'args'],
+    start: timersStart,
+    stop: [timersStop, 'args'],
+  },
+});


### PR DESCRIPTION
## Summary

Migrates 13 CLI command files from the manual switch/case pattern to the `createCommandRouter` factory introduced in PR #66.

Closes #67

## Changes

All command files now use the declarative `createCommandRouter({ resource, handlers })` pattern:

| File | Subcommands |
|------|------------|
| `attachments/command.ts` | list, ls, get, delete, rm |
| `bookings/command.ts` | list, ls, get, add, create, update |
| `comments/command.ts` | list, ls, get, add, create, update |
| `companies/command.ts` | list, ls, get, add, create, update |
| `deals/command.ts` | list, ls, get, add, create, update |
| `discussions/command.ts` | list, ls, get, add, create, update, delete, rm, resolve, reopen |
| `pages/command.ts` | list, ls, get, add, create, update, delete, rm |
| `people/command.ts` | list, ls, get |
| `projects/command.ts` | list, ls, get |
| `reports/command.ts` | time, project/s, budget/s, person/people, invoice/s, payment/s, service/s, task/s, company/ies, deal/s, timesheet/s |
| `services/command.ts` | list, ls |
| `time/command.ts` | list, ls, get, add, update, delete, rm |
| `timers/command.ts` | list, ls, get, start, stop |

### Not migrated

**`resolve/command.ts`** — left unchanged. It has a non-standard command signature (`subcommand: string | undefined`) with custom query-combining logic that doesn't fit the factory pattern.

## Impact

- **Net reduction**: ~300 lines of boilerplate removed
- **No behavioral changes** — all existing command.test.ts files pass unchanged
- **Consistent pattern** — all 14 standard command files (+ tasks from #66) now use the same factory