### PR TITLE
MCP: guide agents to use action=help before interacting with resources

### DIFF
--- a/packages/mcp/skills/SKILL.md
+++ b/packages/mcp/skills/SKILL.md
@@ -7,6 +7,10 @@ description: MCP server for Productive.io - use with Claude Desktop or MCP-compa
 
 MCP (Model Context Protocol) server for Productive.io. Provides a single unified tool for all operations.
 
+## Quick Start
+
+Before your first interaction with any resource, call `action=help` with that resource to discover valid filters, required fields, includes, and examples.
+
 ## The `productive` Tool
 
 Single unified tool with this signature:

--- a/packages/mcp/src/handlers/help.ts
+++ b/packages/mcp/src/handlers/help.ts
@@ -631,6 +631,7 @@ export function handleHelp(resource: string): ToolResult {
     return jsonResult({
       error: `Unknown resource: ${resource}`,
       available_resources: Object.keys(RESOURCE_HELP),
+      _tip: "Call { action: 'help' } without a resource to see all available resources.",
     });
   }
 
@@ -653,5 +654,6 @@ export function handleHelpOverview(): ToolResult {
   return jsonResult({
     message: 'Use action="help" with a specific resource for detailed documentation',
     resources: overview,
+    _tip: "Always call { action: 'help', resource: '<name>' } before your first interaction with any resource to learn valid filters, required fields, and examples.",
   });
 }


### PR DESCRIPTION
## Summary

Closes #87

Adds proactive guidance for LLMs to use `action=help` before their first interaction with any resource, reducing parameter guessing errors.

## Changes

- **mcp**: `handleHelpOverview()` now includes a `_tip` field with the guidance
- **mcp**: `handleHelp(resource)` unknown-resource error includes tip for help overview
- **mcp**: SKILL.md updated with Quick Start section