### PR TITLE
MCP: add action=schema for compact machine-readable resource specs

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -50,6 +50,7 @@ export const ACTIONS = [
   'start',
   'stop',
   'help',
+  'schema',
 ] as const;
 
 export type Action = (typeof ACTIONS)[number];

--- a/packages/mcp/src/handlers/index.ts
+++ b/packages/mcp/src/handlers/index.ts
@@ -27,6 +27,7 @@ import { handlePeople } from './people.js';
 import { handleProjects } from './projects.js';
 import { handleReports } from './reports.js';
 import { type ResolvableResourceType } from './resolve.js';
+import { handleSchema, handleSchemaOverview } from './schema.js';
 import { handleServices } from './services.js';
 import { handleTasks } from './tasks.js';
 import { handleTime } from './time.js';
@@ -162,6 +163,11 @@ export async function executeToolWithCredentials(
     // Handle help action first (doesn't need API)
     if (action === 'help') {
       return resource ? handleHelp(resource) : handleHelpOverview();
+    }
+
+    // Handle schema action (doesn't need API)
+    if (action === 'schema') {
+      return resource ? handleSchema(resource) : handleSchemaOverview();
     }
 
     // Route to appropriate resource handler

--- a/packages/mcp/src/handlers/schema.test.ts
+++ b/packages/mcp/src/handlers/schema.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+
+import { handleSchema, handleSchemaOverview } from './schema.js';
+
+describe('handleSchema', () => {
+  it('returns correct structure for time resource', () => {
+    const result = handleSchema('time');
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe('text');
+
+    const data = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+    expect(data.resource).toBe('time');
+    expect(data.actions).toEqual(['list', 'get', 'create', 'update', 'delete']);
+    expect(data.filters).toBeDefined();
+    expect(data.filters.person_id).toContain('me');
+    expect(data.filters.after).toContain('YYYY-MM-DD');
+    expect(data.filters.status).toContain('approved');
+    expect(data.create).toBeDefined();
+    expect(data.create.person_id).toEqual({ required: true, type: 'string' });
+    expect(data.create.service_id).toEqual({ required: true, type: 'string' });
+    expect(data.create.date).toEqual({ required: true, type: 'date YYYY-MM-DD' });
+    expect(data.create.time).toEqual({ required: true, type: 'minutes integer' });
+    expect(data.create.note).toEqual({ required: false, type: 'string' });
+    expect(data.includes).toEqual(['person', 'service', 'task']);
+  });
+
+  it('returns structure without create for projects (read-only resource)', () => {
+    const result = handleSchema('projects');
+
+    expect(result.isError).toBeUndefined();
+
+    const data = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+    expect(data.resource).toBe('projects');
+    expect(data.actions).toEqual(['list', 'get', 'resolve']);
+    expect(data.filters).toBeDefined();
+    expect(data.filters.query).toBeDefined();
+    expect(data.filters.project_type).toBeDefined();
+    expect(data.create).toBeUndefined();
+    expect(data.includes).toBeUndefined();
+  });
+
+  it('returns structure with create for tasks', () => {
+    const result = handleSchema('tasks');
+
+    expect(result.isError).toBeUndefined();
+
+    const data = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+    expect(data.resource).toBe('tasks');
+    expect(data.actions).toContain('create');
+    expect(data.create).toBeDefined();
+    expect(data.create.title.required).toBe(true);
+    expect(data.create.project_id.required).toBe(true);
+    expect(data.create.task_list_id.required).toBe(true);
+    expect(data.create.description.required).toBe(false);
+    expect(data.includes).toContain('project');
+    expect(data.includes).toContain('assignee');
+    expect(data.includes).toContain('comments');
+  });
+
+  it('returns error for unknown resource', () => {
+    const result = handleSchema('unknown');
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].type).toBe('text');
+
+    const text = (result.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toContain('Unknown resource');
+    expect(text).toContain('unknown');
+    expect(text).toContain('Valid resources');
+  });
+
+  it('returns correct structure for deals with includes', () => {
+    const result = handleSchema('deals');
+
+    const data = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+    expect(data.resource).toBe('deals');
+    expect(data.actions).toContain('create');
+    expect(data.create.name.required).toBe(true);
+    expect(data.create.company_id.required).toBe(true);
+    expect(data.includes).toContain('company');
+    expect(data.includes).toContain('deal_status');
+  });
+
+  it('returns correct structure for reports', () => {
+    const result = handleSchema('reports');
+
+    const data = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+    expect(data.resource).toBe('reports');
+    expect(data.actions).toEqual(['get']);
+    expect(data.create).toBeDefined();
+    expect(data.create.report_type.required).toBe(true);
+  });
+});
+
+describe('handleSchemaOverview', () => {
+  it('returns list with all resource names', () => {
+    const result = handleSchemaOverview();
+
+    expect(result.isError).toBeUndefined();
+
+    const data = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+    expect(data._tip).toContain('action="schema"');
+    expect(data.resources).toBeDefined();
+    expect(Array.isArray(data.resources)).toBe(true);
+
+    // Check all expected resources are present
+    const resourceNames = data.resources.map((r: { resource: string }) => r.resource);
+    expect(resourceNames).toContain('projects');
+    expect(resourceNames).toContain('time');
+    expect(resourceNames).toContain('tasks');
+    expect(resourceNames).toContain('services');
+    expect(resourceNames).toContain('people');
+    expect(resourceNames).toContain('companies');
+    expect(resourceNames).toContain('comments');
+    expect(resourceNames).toContain('attachments');
+    expect(resourceNames).toContain('timers');
+    expect(resourceNames).toContain('deals');
+    expect(resourceNames).toContain('bookings');
+    expect(resourceNames).toContain('pages');
+    expect(resourceNames).toContain('discussions');
+    expect(resourceNames).toContain('reports');
+  });
+
+  it('each resource has actions array', () => {
+    const result = handleSchemaOverview();
+    const data = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+    for (const resource of data.resources) {
+      expect(resource.resource).toBeDefined();
+      expect(Array.isArray(resource.actions)).toBe(true);
+      expect(resource.actions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('time resource has expected actions in overview', () => {
+    const result = handleSchemaOverview();
+    const data = JSON.parse((result.content[0] as { type: 'text'; text: string }).text);
+
+    const timeResource = data.resources.find((r: { resource: string }) => r.resource === 'time');
+    expect(timeResource).toBeDefined();
+    expect(timeResource.actions).toEqual(['list', 'get', 'create', 'update', 'delete']);
+  });
+});

--- a/packages/mcp/src/handlers/schema.ts
+++ b/packages/mcp/src/handlers/schema.ts
@@ -1,0 +1,262 @@
+/**
+ * Schema handler - provides compact, machine-readable resource specifications
+ *
+ * More concise than action=help, optimized for LLM consumption when only
+ * field metadata is needed (filters, create fields, includes).
+ */
+
+import type { ToolResult } from './types.js';
+
+import { errorResult, jsonResult } from './utils.js';
+
+/**
+ * Field specification for create/update operations
+ */
+export interface ResourceFieldSpec {
+  required: boolean;
+  type: string;
+}
+
+/**
+ * Compact schema data for a resource
+ */
+export interface ResourceSchemaData {
+  actions: string[];
+  filters: Record<string, string>;
+  create?: Record<string, ResourceFieldSpec>;
+  update?: string[];
+  includes?: string[];
+}
+
+/**
+ * Schema definitions for all resources.
+ *
+ * This provides a compact, machine-readable specification of each resource's
+ * capabilities. For detailed documentation with examples, use action=help.
+ */
+const RESOURCE_SCHEMAS: Record<string, ResourceSchemaData> = {
+  projects: {
+    actions: ['list', 'get', 'resolve'],
+    filters: {
+      query: 'string — text search on project name',
+      project_type: '1=internal|2=client',
+      company_id: 'string',
+      responsible_id: 'string',
+      person_id: 'string',
+      status: '1=active|2=archived',
+    },
+  },
+
+  time: {
+    actions: ['list', 'get', 'create', 'update', 'delete'],
+    filters: {
+      person_id: "string — use 'me' for current user",
+      after: 'date YYYY-MM-DD',
+      before: 'date YYYY-MM-DD',
+      project_id: 'string',
+      service_id: 'string',
+      task_id: 'string',
+      status: '1=approved|2=unapproved|3=rejected',
+    },
+    create: {
+      person_id: { required: true, type: 'string' },
+      service_id: { required: true, type: 'string' },
+      date: { required: true, type: 'date YYYY-MM-DD' },
+      time: { required: true, type: 'minutes integer' },
+      note: { required: false, type: 'string' },
+      task_id: { required: false, type: 'string' },
+    },
+    includes: ['person', 'service', 'task'],
+  },
+
+  tasks: {
+    actions: ['list', 'get', 'create', 'update', 'resolve'],
+    filters: {
+      query: 'string — text search on task title',
+      project_id: 'string',
+      assignee_id: 'string',
+      status: '1=open|2=closed (or "open", "closed", "all")',
+      task_list_id: 'string',
+      workflow_status_id: 'string — kanban column',
+    },
+    create: {
+      title: { required: true, type: 'string' },
+      project_id: { required: true, type: 'string' },
+      task_list_id: { required: true, type: 'string' },
+      description: { required: false, type: 'string' },
+      assignee_id: { required: false, type: 'string' },
+    },
+    includes: ['project', 'assignee', 'comments', 'subtasks', 'workflow_status'],
+  },
+
+  services: {
+    actions: ['list', 'get'],
+    filters: {
+      project_id: 'string',
+      deal_id: 'string',
+      task_id: 'string',
+      budget_status: '1=open|2=delivered',
+    },
+  },
+
+  people: {
+    actions: ['list', 'get', 'me', 'resolve'],
+    filters: {
+      query: 'string — text search on name or email',
+      status: '1=active|2=deactivated',
+      company_id: 'string',
+    },
+  },
+
+  companies: {
+    actions: ['list', 'get', 'create', 'update', 'resolve'],
+    filters: {
+      query: 'string — text search on company name',
+      archived: 'boolean',
+    },
+    create: {
+      name: { required: true, type: 'string' },
+    },
+  },
+
+  comments: {
+    actions: ['list', 'get', 'create', 'update'],
+    filters: {
+      task_id: 'string',
+      deal_id: 'string',
+      page_id: 'string',
+      discussion_id: 'string',
+    },
+    create: {
+      body: { required: true, type: 'string' },
+      task_id: { required: false, type: 'string — one of task_id, deal_id required' },
+      deal_id: { required: false, type: 'string — one of task_id, deal_id required' },
+    },
+    includes: ['creator'],
+  },
+
+  attachments: {
+    actions: ['list', 'get', 'delete'],
+    filters: {
+      task_id: 'string',
+      comment_id: 'string',
+      deal_id: 'string',
+      page_id: 'string',
+    },
+  },
+
+  timers: {
+    actions: ['list', 'get', 'start', 'stop'],
+    filters: {
+      person_id: 'string',
+      time_entry_id: 'string',
+    },
+  },
+
+  deals: {
+    actions: ['list', 'get', 'create', 'update', 'resolve'],
+    filters: {
+      query: 'string — text search on deal name',
+      company_id: 'string',
+      type: '1=deal|2=budget',
+      stage_status_id: '1=open|2=won|3=lost',
+    },
+    create: {
+      name: { required: true, type: 'string' },
+      company_id: { required: true, type: 'string' },
+    },
+    includes: ['company', 'deal_status'],
+  },
+
+  bookings: {
+    actions: ['list', 'get', 'create', 'update'],
+    filters: {
+      person_id: 'string',
+      after: 'date YYYY-MM-DD',
+      before: 'date YYYY-MM-DD',
+      service_id: 'string',
+    },
+    create: {
+      person_id: { required: true, type: 'string' },
+      started_on: { required: true, type: 'date YYYY-MM-DD' },
+      ended_on: { required: true, type: 'date YYYY-MM-DD' },
+      service_id: { required: false, type: 'string — one of service_id, event_id required' },
+      event_id: { required: false, type: 'string — one of service_id, event_id required' },
+    },
+  },
+
+  pages: {
+    actions: ['list', 'get', 'create', 'update', 'delete'],
+    filters: {
+      project_id: 'string',
+    },
+    create: {
+      title: { required: true, type: 'string' },
+      project_id: { required: true, type: 'string' },
+      body: { required: false, type: 'string' },
+      parent_page_id: { required: false, type: 'string' },
+    },
+  },
+
+  discussions: {
+    actions: ['list', 'get', 'create', 'update', 'delete', 'resolve', 'reopen'],
+    filters: {
+      page_id: 'string',
+      status: '1=active|2=resolved',
+    },
+    create: {
+      body: { required: true, type: 'string' },
+      page_id: { required: true, type: 'string' },
+    },
+  },
+
+  reports: {
+    actions: ['get'],
+    filters: {
+      person_id: 'string',
+      project_id: 'string',
+      company_id: 'string',
+      after: 'date YYYY-MM-DD',
+      before: 'date YYYY-MM-DD',
+    },
+    create: {
+      report_type: { required: true, type: 'time_reports|project_reports|budget_reports|...' },
+      from: { required: false, type: 'date YYYY-MM-DD' },
+      to: { required: false, type: 'date YYYY-MM-DD' },
+      group: { required: false, type: 'string — grouping dimension' },
+    },
+  },
+};
+
+/**
+ * Handle schema action - returns compact specification for a specific resource
+ */
+export function handleSchema(resource: string): ToolResult {
+  const schema = RESOURCE_SCHEMAS[resource];
+
+  if (!schema) {
+    return errorResult(
+      `Unknown resource: ${resource}. Valid resources: ${Object.keys(RESOURCE_SCHEMAS).join(', ')}`,
+    );
+  }
+
+  return jsonResult({
+    resource,
+    ...schema,
+  });
+}
+
+/**
+ * Get schema overview for all resources
+ */
+export function handleSchemaOverview(): ToolResult {
+  const overview = Object.entries(RESOURCE_SCHEMAS).map(([resource, schema]) => ({
+    resource,
+    actions: schema.actions,
+  }));
+
+  return jsonResult({
+    _tip: 'Use action="schema" with a specific resource for full filter/create/includes spec',
+    resources: overview,
+  });
+}

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -15,7 +15,8 @@ function generateDescription(): string {
     'Filters: project_id, person_id, service_id, company_id, after/before (dates). ' +
     'Use include to fetch related data. ' +
     'Use compact=false for full details (default for get, true for list). ' +
-    'Use action=help with a resource for detailed documentation.'
+    'Use action=help with a resource for detailed documentation. ' +
+    'Use action=schema with a resource for compact machine-readable field/filter spec.'
   );
 }
 


### PR DESCRIPTION
## Summary

Closes #89

Adds `action=schema` to return a compact, structured specification of a resource's available actions, filters, create fields, and includes. More concise than `action=help` — optimized for LLM consumption when only field metadata is needed.

## Usage

```json
{ "resource": "time", "action": "schema" }
```

Returns the resource's actions, filters, create requirements, and includes in a compact structured format.

## Changes

- **core**: Added `schema` to ACTIONS constant
- **mcp**: New `packages/mcp/src/handlers/schema.ts` with `handleSchema` and `handleSchemaOverview`
- **mcp**: Routing for `action=schema` in `handlers/index.ts` (no API call needed, pure)
- **mcp**: Updated tool description to advertise `action=schema`
- **mcp**: Full test coverage in `schema.test.ts`