### PR TITLE
MCP: add batch action for parallel multi-resource operations

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -29,6 +29,7 @@ export const RESOURCES = [
   'pages',
   'discussions',
   'reports',
+  'batch',
 ] as const;
 
 export type Resource = (typeof RESOURCES)[number];
@@ -51,6 +52,7 @@ export const ACTIONS = [
   'stop',
   'help',
   'schema',
+  'run',
 ] as const;
 
 export type Action = (typeof ACTIONS)[number];

--- a/packages/mcp/src/handlers/batch.test.ts
+++ b/packages/mcp/src/handlers/batch.test.ts
@@ -1,0 +1,473 @@
+/**
+ * Tests for the batch handler
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { ToolResult } from './types.js';
+
+import { handleBatch, MAX_BATCH_SIZE, type BatchOperation, type BatchResponse } from './batch.js';
+
+// Test credentials
+const credentials: ProductiveCredentials = {
+  apiToken: 'test-token',
+  organizationId: 'test-org',
+  userId: 'test-user',
+};
+
+// Helper to create a successful ToolResult
+function successResult(data: unknown): ToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data) }],
+  };
+}
+
+// Helper to create an error ToolResult
+function errorResultHelper(message: string): ToolResult {
+  return {
+    content: [{ type: 'text', text: message }],
+    isError: true,
+  };
+}
+
+// Helper to parse batch response from ToolResult
+function parseResponse(result: ToolResult): BatchResponse {
+  const content = result.content[0];
+  if (content?.type === 'text') {
+    return JSON.parse(content.text);
+  }
+  throw new Error('Unexpected result format');
+}
+
+describe('handleBatch', () => {
+  describe('validation', () => {
+    it('should error when operations is not an array', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch('not-an-array', credentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('operations must be an array');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should error when operations is null', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch(null, credentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('operations must be an array');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should error when operations is undefined', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch(undefined, credentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('operations must be an array');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should error when operations array is empty', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch([], credentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain(
+        'operations array cannot be empty',
+      );
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should error when operations exceeds max size', async () => {
+      const mockExecute = vi.fn();
+      const operations = Array.from({ length: 11 }, (_, i) => ({
+        resource: 'projects',
+        action: 'list',
+        index: i,
+      }));
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain(
+        `exceeds maximum size of ${MAX_BATCH_SIZE}`,
+      );
+      expect((result.content[0] as { text: string }).text).toContain('11 operations');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should error when operation is not an object', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch(['not-an-object'], credentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('must be an object');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should error when operation is null', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch([null], credentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain('must be an object');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should error when operation is missing resource', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch([{ action: 'list' }], credentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain(
+        'missing or invalid "resource" field',
+      );
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should error when operation has empty resource', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch(
+        [{ resource: '  ', action: 'list' }],
+        credentials,
+        mockExecute,
+      );
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain(
+        'missing or invalid "resource" field',
+      );
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should error when operation is missing action', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch([{ resource: 'projects' }], credentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain(
+        'missing or invalid "action" field',
+      );
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should error when operation has empty action', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch(
+        [{ resource: 'projects', action: '' }],
+        credentials,
+        mockExecute,
+      );
+
+      expect(result.isError).toBe(true);
+      expect((result.content[0] as { text: string }).text).toContain(
+        'missing or invalid "action" field',
+      );
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('should report multiple validation errors', async () => {
+      const mockExecute = vi.fn();
+
+      const result = await handleBatch(
+        [
+          { action: 'list' }, // missing resource
+          { resource: 'projects' }, // missing action
+        ],
+        credentials,
+        mockExecute,
+      );
+
+      expect(result.isError).toBe(true);
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('index 0');
+      expect(text).toContain('index 1');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('execution', () => {
+    it('should execute a single operation successfully', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(successResult({ id: '123', name: 'Test' }));
+
+      const operations: BatchOperation[] = [{ resource: 'projects', action: 'get', id: '123' }];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      expect(result.isError).toBeUndefined();
+      const response = parseResponse(result);
+      expect(response._batch).toEqual({ total: 1, succeeded: 1, failed: 0 });
+      expect(response.results).toHaveLength(1);
+      expect(response.results[0]).toEqual({
+        resource: 'projects',
+        action: 'get',
+        index: 0,
+        data: { id: '123', name: 'Test' },
+      });
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        'productive',
+        { resource: 'projects', action: 'get', id: '123' },
+        credentials,
+      );
+    });
+
+    it('should execute multiple operations in parallel', async () => {
+      const executionOrder: number[] = [];
+      const mockExecute = vi.fn().mockImplementation(async (_, args) => {
+        const index = (args as { index?: number }).index ?? 0;
+        executionOrder.push(index);
+        // Simulate varying response times to prove parallel execution
+        await new Promise((resolve) => setTimeout(resolve, 10 - index));
+        return successResult({ index });
+      });
+
+      const operations: BatchOperation[] = [
+        { resource: 'projects', action: 'list', index: 0 },
+        { resource: 'tasks', action: 'list', index: 1 },
+        { resource: 'people', action: 'list', index: 2 },
+      ];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      expect(result.isError).toBeUndefined();
+      const response = parseResponse(result);
+      expect(response._batch).toEqual({ total: 3, succeeded: 3, failed: 0 });
+      expect(response.results).toHaveLength(3);
+
+      // All operations should have been called
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+    });
+
+    it('should handle mixed success and error results', async () => {
+      const mockExecute = vi.fn().mockImplementation(async (_, args) => {
+        const { resource } = args as { resource: string };
+        if (resource === 'projects') {
+          return successResult({ id: '123' });
+        }
+        return errorResultHelper('Not found');
+      });
+
+      const operations: BatchOperation[] = [
+        { resource: 'projects', action: 'get', id: '123' },
+        { resource: 'tasks', action: 'get', id: '999' },
+        { resource: 'people', action: 'list' },
+      ];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      expect(result.isError).toBeUndefined();
+      const response = parseResponse(result);
+      expect(response._batch).toEqual({ total: 3, succeeded: 1, failed: 2 });
+
+      expect(response.results[0].data).toEqual({ id: '123' });
+      expect(response.results[0].error).toBeUndefined();
+
+      expect(response.results[1].error).toBe('Not found');
+      expect(response.results[1].data).toBeUndefined();
+
+      expect(response.results[2].error).toBe('Not found');
+      expect(response.results[2].data).toBeUndefined();
+    });
+
+    it('should continue executing other operations when one fails', async () => {
+      const callOrder: string[] = [];
+      const mockExecute = vi.fn().mockImplementation(async (_, args) => {
+        const { resource, action } = args as { resource: string; action: string };
+        callOrder.push(`${resource}:${action}`);
+        if (resource === 'tasks') {
+          throw new Error('API Error');
+        }
+        return successResult({ resource, action });
+      });
+
+      const operations: BatchOperation[] = [
+        { resource: 'projects', action: 'list' },
+        { resource: 'tasks', action: 'list' }, // This will throw
+        { resource: 'people', action: 'list' },
+      ];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      expect(result.isError).toBeUndefined();
+      const response = parseResponse(result);
+
+      // All operations should have been attempted
+      expect(mockExecute).toHaveBeenCalledTimes(3);
+
+      // Summary should reflect the failure
+      expect(response._batch).toEqual({ total: 3, succeeded: 2, failed: 1 });
+
+      // First and third should succeed
+      expect(response.results[0].data).toEqual({ resource: 'projects', action: 'list' });
+      expect(response.results[2].data).toEqual({ resource: 'people', action: 'list' });
+
+      // Second should have captured error
+      expect(response.results[1].error).toBe('API Error');
+    });
+
+    it('should preserve operation index in results', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(successResult({ ok: true }));
+
+      const operations: BatchOperation[] = [
+        { resource: 'projects', action: 'list' },
+        { resource: 'tasks', action: 'list' },
+        { resource: 'people', action: 'list' },
+      ];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      const response = parseResponse(result);
+
+      expect(response.results[0].index).toBe(0);
+      expect(response.results[1].index).toBe(1);
+      expect(response.results[2].index).toBe(2);
+    });
+
+    it('should pass additional params to each operation', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(successResult({ ok: true }));
+
+      const operations: BatchOperation[] = [
+        {
+          resource: 'time',
+          action: 'create',
+          service_id: '111',
+          date: '2024-01-15',
+          time: 60,
+          note: 'Test work',
+        },
+      ];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      expect(result.isError).toBeUndefined();
+      expect(mockExecute).toHaveBeenCalledWith(
+        'productive',
+        {
+          resource: 'time',
+          action: 'create',
+          service_id: '111',
+          date: '2024-01-15',
+          time: 60,
+          note: 'Test work',
+        },
+        credentials,
+      );
+    });
+
+    it('should handle non-JSON text responses as data', async () => {
+      const mockExecute = vi.fn().mockResolvedValue({
+        content: [{ type: 'text', text: 'Plain text response' }],
+      });
+
+      const operations: BatchOperation[] = [{ resource: 'projects', action: 'list' }];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      const response = parseResponse(result);
+      expect(response.results[0].data).toBe('Plain text response');
+    });
+
+    it('should handle empty content gracefully', async () => {
+      const mockExecute = vi.fn().mockResolvedValue({
+        content: [{ type: 'image', url: 'test.png' }],
+      });
+
+      const operations: BatchOperation[] = [{ resource: 'projects', action: 'list' }];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      const response = parseResponse(result);
+      expect(response.results[0].data).toBeNull();
+    });
+
+    it('should execute exactly MAX_BATCH_SIZE operations', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(successResult({ ok: true }));
+
+      const operations = Array.from({ length: MAX_BATCH_SIZE }, (_, i) => ({
+        resource: 'projects',
+        action: 'list',
+        page: i + 1,
+      }));
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      expect(result.isError).toBeUndefined();
+      const response = parseResponse(result);
+      expect(response._batch.total).toBe(MAX_BATCH_SIZE);
+      expect(response._batch.succeeded).toBe(MAX_BATCH_SIZE);
+      expect(mockExecute).toHaveBeenCalledTimes(MAX_BATCH_SIZE);
+    });
+  });
+
+  describe('result structure', () => {
+    it('should return proper _batch summary structure', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(successResult({ ok: true }));
+
+      const operations: BatchOperation[] = [
+        { resource: 'projects', action: 'list' },
+        { resource: 'tasks', action: 'list' },
+      ];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      const response = parseResponse(result);
+      expect(response._batch).toHaveProperty('total');
+      expect(response._batch).toHaveProperty('succeeded');
+      expect(response._batch).toHaveProperty('failed');
+      expect(typeof response._batch.total).toBe('number');
+      expect(typeof response._batch.succeeded).toBe('number');
+      expect(typeof response._batch.failed).toBe('number');
+    });
+
+    it('should return proper result item structure for success', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(successResult({ id: '123' }));
+
+      const operations: BatchOperation[] = [{ resource: 'projects', action: 'get', id: '123' }];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      const response = parseResponse(result);
+      const item = response.results[0];
+      expect(item).toHaveProperty('resource', 'projects');
+      expect(item).toHaveProperty('action', 'get');
+      expect(item).toHaveProperty('index', 0);
+      expect(item).toHaveProperty('data');
+      expect(item).not.toHaveProperty('error');
+    });
+
+    it('should return proper result item structure for error', async () => {
+      const mockExecute = vi.fn().mockResolvedValue(errorResultHelper('Not found'));
+
+      const operations: BatchOperation[] = [{ resource: 'projects', action: 'get', id: '999' }];
+
+      const result = await handleBatch(operations, credentials, mockExecute);
+
+      const response = parseResponse(result);
+      const item = response.results[0];
+      expect(item).toHaveProperty('resource', 'projects');
+      expect(item).toHaveProperty('action', 'get');
+      expect(item).toHaveProperty('index', 0);
+      expect(item).toHaveProperty('error');
+      expect(item).not.toHaveProperty('data');
+    });
+  });
+
+  describe('MAX_BATCH_SIZE constant', () => {
+    it('should be 10', () => {
+      expect(MAX_BATCH_SIZE).toBe(10);
+    });
+  });
+});

--- a/packages/mcp/src/handlers/batch.ts
+++ b/packages/mcp/src/handlers/batch.ts
@@ -1,0 +1,208 @@
+/**
+ * Batch handler - execute multiple operations in a single call
+ *
+ * Enables AI agents to reduce round-trips by batching multiple
+ * Productive.io operations into one MCP tool call.
+ */
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { ToolResult } from './types.js';
+
+import { UserInputError } from '../errors.js';
+import { inputErrorResult, jsonResult } from './utils.js';
+
+/** Maximum number of operations allowed in a single batch */
+export const MAX_BATCH_SIZE = 10;
+
+/**
+ * A single operation within a batch request
+ */
+export interface BatchOperation {
+  resource: string;
+  action: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Result of a single batch operation
+ */
+export interface BatchOperationResult {
+  resource: string;
+  action: string;
+  index: number;
+  data?: unknown;
+  error?: string;
+}
+
+/**
+ * Summary of batch execution
+ */
+export interface BatchSummary {
+  total: number;
+  succeeded: number;
+  failed: number;
+}
+
+/**
+ * Full batch response
+ */
+export interface BatchResponse {
+  _batch: BatchSummary;
+  results: BatchOperationResult[];
+}
+
+/**
+ * Function signature for executing a single tool operation
+ * Injected for testability - in production this is executeToolWithCredentials
+ */
+export type ExecuteFunction = (
+  name: string,
+  args: Record<string, unknown>,
+  credentials: ProductiveCredentials,
+) => Promise<ToolResult>;
+
+/**
+ * Validate batch operations array
+ */
+function validateOperations(operations: unknown): BatchOperation[] {
+  // Check if operations is an array
+  if (!Array.isArray(operations)) {
+    throw new UserInputError('operations must be an array', [
+      'Provide an array of operation objects',
+      'Each operation needs: { resource: "...", action: "...", ...params }',
+    ]);
+  }
+
+  // Check if array is empty
+  if (operations.length === 0) {
+    throw new UserInputError('operations array cannot be empty', [
+      'Provide at least one operation',
+      'Example: operations: [{ resource: "projects", action: "list" }]',
+    ]);
+  }
+
+  // Check max size
+  if (operations.length > MAX_BATCH_SIZE) {
+    throw new UserInputError(`operations array exceeds maximum size of ${MAX_BATCH_SIZE}`, [
+      `Split your batch into chunks of ${MAX_BATCH_SIZE} or fewer operations`,
+      `You provided ${operations.length} operations`,
+    ]);
+  }
+
+  // Validate each operation
+  const validatedOps: BatchOperation[] = [];
+  const errors: string[] = [];
+
+  for (let i = 0; i < operations.length; i++) {
+    const op = operations[i];
+
+    if (typeof op !== 'object' || op === null) {
+      errors.push(`Operation at index ${i}: must be an object`);
+      continue;
+    }
+
+    const { resource, action } = op as Record<string, unknown>;
+
+    if (typeof resource !== 'string' || resource.trim() === '') {
+      errors.push(`Operation at index ${i}: missing or invalid "resource" field`);
+    }
+
+    if (typeof action !== 'string' || action.trim() === '') {
+      errors.push(`Operation at index ${i}: missing or invalid "action" field`);
+    }
+
+    if (errors.length === 0) {
+      validatedOps.push(op as BatchOperation);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new UserInputError('Invalid operations in batch', errors);
+  }
+
+  return validatedOps;
+}
+
+/**
+ * Execute a single operation and capture result
+ */
+async function executeOperation(
+  operation: BatchOperation,
+  index: number,
+  credentials: ProductiveCredentials,
+  execute: ExecuteFunction,
+): Promise<BatchOperationResult> {
+  const { resource, action, ...params } = operation;
+
+  try {
+    const result = await execute('productive', { resource, action, ...params }, credentials);
+
+    // Parse the result content to extract data
+    const content = result.content[0];
+    if (content?.type === 'text') {
+      try {
+        const data = JSON.parse(content.text);
+        if (result.isError) {
+          return { resource, action, index, error: content.text };
+        }
+        return { resource, action, index, data };
+      } catch {
+        // If JSON parsing fails, treat text as error message if isError, otherwise as data
+        if (result.isError) {
+          return { resource, action, index, error: content.text };
+        }
+        return { resource, action, index, data: content.text };
+      }
+    }
+
+    return { resource, action, index, data: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { resource, action, index, error: message };
+  }
+}
+
+/**
+ * Handle batch operation - execute multiple operations in parallel
+ *
+ * @param operations - Array of operations to execute
+ * @param credentials - API credentials
+ * @param execute - Function to execute individual operations (injected for testability)
+ * @returns Batch response with summary and individual results
+ */
+export async function handleBatch(
+  operations: unknown,
+  credentials: ProductiveCredentials,
+  execute: ExecuteFunction,
+): Promise<ToolResult> {
+  // Validate operations
+  let validatedOps: BatchOperation[];
+  try {
+    validatedOps = validateOperations(operations);
+  } catch (err) {
+    if (err instanceof UserInputError) {
+      return inputErrorResult(err);
+    }
+    throw err;
+  }
+
+  // Execute all operations in parallel
+  const results = await Promise.all(
+    validatedOps.map((op, index) => executeOperation(op, index, credentials, execute)),
+  );
+
+  // Calculate summary
+  const succeeded = results.filter((r) => r.data !== undefined && r.error === undefined).length;
+  const failed = results.filter((r) => r.error !== undefined).length;
+
+  const response: BatchResponse = {
+    _batch: {
+      total: results.length,
+      succeeded,
+      failed,
+    },
+    results,
+  };
+
+  return jsonResult(response);
+}

--- a/packages/mcp/src/handlers/help.ts
+++ b/packages/mcp/src/handlers/help.ts
@@ -16,6 +16,57 @@ interface ResourceHelp {
 }
 
 const RESOURCE_HELP: Record<string, ResourceHelp> = {
+  batch: {
+    description:
+      'Execute multiple operations in a single call. Operations run in parallel via Promise.all, reducing round-trips for AI agents.',
+    actions: {
+      run: 'Execute a batch of operations (max 10)',
+    },
+    fields: {
+      operations:
+        'Array of operation objects. Each must have "resource" and "action", plus any additional params for that resource.',
+    },
+    examples: [
+      {
+        description: 'Batch multiple queries',
+        params: {
+          resource: 'batch',
+          action: 'run',
+          operations: [
+            { resource: 'projects', action: 'get', id: '123' },
+            { resource: 'time', action: 'list', filter: { project_id: '123' } },
+            { resource: 'services', action: 'list', filter: { project_id: '123' } },
+          ],
+        },
+      },
+      {
+        description: 'Batch create time entries',
+        params: {
+          resource: 'batch',
+          action: 'run',
+          operations: [
+            {
+              resource: 'time',
+              action: 'create',
+              service_id: '111',
+              date: '2024-01-15',
+              time: 60,
+              note: 'Morning work',
+            },
+            {
+              resource: 'time',
+              action: 'create',
+              service_id: '111',
+              date: '2024-01-15',
+              time: 120,
+              note: 'Afternoon work',
+            },
+          ],
+        },
+      },
+    ],
+  },
+
   projects: {
     description: 'Manage projects in Productive.io',
     actions: {

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -291,6 +291,22 @@ export const ProductiveToolInputSchema = z.object({
   from: ParamDate.optional().describe('Report start date (YYYY-MM-DD)'),
   to: ParamDate.optional().describe('Report end date (YYYY-MM-DD)'),
   status: z.string().trim().optional().describe('Status filter for reports'),
+
+  // Batch fields
+  operations: z
+    .array(
+      z
+        .object({
+          resource: z.string(),
+          action: z.string(),
+        })
+        .passthrough(),
+    )
+    .max(10)
+    .optional()
+    .describe(
+      'Array of operations for batch execution (max 10). Each operation needs resource, action, and any additional params.',
+    ),
 });
 
 export type ProductiveToolInput = z.infer<typeof ProductiveToolInputSchema>;

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -115,14 +115,14 @@ describe('tools', () => {
   describe('token optimization', () => {
     it('should have reasonable tool schema size', () => {
       const totalSize = JSON.stringify(TOOLS).length;
-      // Single tool with all resources and MCP annotations should be under 3200 bytes
-      expect(totalSize).toBeLessThan(3200);
+      // Single tool with all resources, batch operations, and MCP annotations should be under 3500 bytes
+      expect(totalSize).toBeLessThan(3500);
     });
 
-    it('should estimate under 800 tokens', () => {
+    it('should estimate under 900 tokens', () => {
       const totalSize = JSON.stringify(TOOLS).length;
       const estimatedTokens = Math.ceil(totalSize / 4);
-      expect(estimatedTokens).toBeLessThan(800);
+      expect(estimatedTokens).toBeLessThan(900);
     });
   });
 });

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -16,7 +16,8 @@ function generateDescription(): string {
     'Use include to fetch related data. ' +
     'Use compact=false for full details (default for get, true for list). ' +
     'Use action=help with a resource for detailed documentation. ' +
-    'Use action=schema with a resource for compact machine-readable field/filter spec.'
+    'Use action=schema with a resource for compact machine-readable field/filter spec. ' +
+    'Batch: use resource=batch, action=run with operations array to execute multiple operations in parallel (max 10).'
   );
 }
 
@@ -117,6 +118,21 @@ export const TOOLS: Tool[] = [
         from: { type: 'string' },
         to: { type: 'string' },
         status: { type: 'string' },
+        // Batch fields
+        operations: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              resource: { type: 'string' },
+              action: { type: 'string' },
+            },
+            required: ['resource', 'action'],
+          },
+          maxItems: 10,
+          description:
+            'Array of operations for batch execution (max 10). Each operation needs resource, action, and any additional params.',
+        },
       },
       required: ['resource', 'action'],
     },


### PR DESCRIPTION
## Summary

Closes #88

Adds `resource=batch action=run` to execute multiple Productive.io operations in a single MCP tool call, running them in parallel via Promise.all.

## Usage

```json
{
  "resource": "batch",
  "action": "run",
  "operations": [
    { "resource": "projects", "action": "get", "id": "123" },
    { "resource": "time", "action": "list", "filter": { "project_id": "123" } },
    { "resource": "services", "action": "list", "filter": { "project_id": "123" } }
  ]
}
```

Returns:
```json
{
  "_batch": { "total": 3, "succeeded": 3, "failed": 0 },
  "results": [
    { "resource": "projects", "action": "get", "index": 0, "data": { } },
    { "resource": "time", "action": "list", "index": 1, "data": [ ] },
    { "resource": "services", "action": "list", "index": 2, "data": [ ] }
  ]
}
```

## Changes

- **core**: Added `batch` to RESOURCES, `run` to ACTIONS constants
- **mcp**: New `packages/mcp/src/handlers/batch.ts` handler
- **mcp**: Batch routing in `handlers/index.ts` before API client init
- **mcp**: `operations` field added to tool inputSchema and Zod validation
- **mcp**: Updated tool description to advertise batch capability
- **mcp**: Full test coverage in `batch.test.ts` and integration tests in `handlers.test.ts`