### PR TITLE
MCP: add cross-resource search across projects, companies, people, tasks

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -30,6 +30,7 @@ export const RESOURCES = [
   'discussions',
   'reports',
   'batch',
+  'search',
 ] as const;
 
 export type Resource = (typeof RESOURCES)[number];

--- a/packages/mcp/src/handlers/search.test.ts
+++ b/packages/mcp/src/handlers/search.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Tests for cross-resource search handler
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { ToolResult } from './types.js';
+
+import { handleSearch, SEARCHABLE_RESOURCES, type ExecuteFunction } from './search.js';
+
+/**
+ * Helper to create a mock successful response
+ */
+function createMockResponse(items: unknown[]): ToolResult {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({ items, total_count: items.length }),
+      },
+    ],
+  };
+}
+
+/**
+ * Helper to parse result JSON
+ */
+function parseResult(result: ToolResult): Record<string, unknown> {
+  const textContent = result.content.find((c) => c.type === 'text');
+  if (!textContent || textContent.type !== 'text') {
+    throw new Error('No text content in result');
+  }
+  return JSON.parse(textContent.text);
+}
+
+describe('handleSearch', () => {
+  const mockCredentials: ProductiveCredentials = {
+    organizationId: 'test-org',
+    apiToken: 'test-token',
+    userId: 'test-user',
+  };
+
+  let mockExecute: ReturnType<
+    typeof vi.fn<Parameters<ExecuteFunction>, ReturnType<ExecuteFunction>>
+  >;
+
+  beforeEach(() => {
+    mockExecute = vi.fn();
+  });
+
+  describe('valid search', () => {
+    it('returns grouped results with correct structure', async () => {
+      mockExecute
+        .mockResolvedValueOnce(createMockResponse([{ id: '1', name: 'Project A' }]))
+        .mockResolvedValueOnce(createMockResponse([{ id: '2', name: 'Company B' }]))
+        .mockResolvedValueOnce(createMockResponse([]))
+        .mockResolvedValueOnce(createMockResponse([{ id: '3', name: 'Task C' }]));
+
+      const result = await handleSearch('Studio Meta', undefined, mockCredentials, mockExecute);
+
+      expect(result.isError).toBeUndefined();
+      const parsed = parseResult(result);
+
+      expect(parsed.query).toBe('Studio Meta');
+      expect(parsed.resources_searched).toEqual(['projects', 'companies', 'people', 'tasks']);
+      expect(parsed.results).toHaveProperty('projects');
+      expect(parsed.results).toHaveProperty('companies');
+      expect(parsed.results).toHaveProperty('people');
+      expect(parsed.results).toHaveProperty('tasks');
+      expect(parsed.total_results).toBe(3);
+    });
+
+    it('uses default resources when not specified', async () => {
+      mockExecute.mockResolvedValue(createMockResponse([]));
+
+      await handleSearch('test', undefined, mockCredentials, mockExecute);
+
+      expect(mockExecute).toHaveBeenCalledTimes(4);
+      const calledResources = mockExecute.mock.calls.map((call) => call[1].resource);
+      expect(calledResources).toEqual(['projects', 'companies', 'people', 'tasks']);
+    });
+
+    it('supports custom resources subset', async () => {
+      mockExecute
+        .mockResolvedValueOnce(createMockResponse([{ id: '1' }]))
+        .mockResolvedValueOnce(createMockResponse([{ id: '2' }]));
+
+      const result = await handleSearch(
+        'test',
+        ['projects', 'deals'],
+        mockCredentials,
+        mockExecute,
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(mockExecute).toHaveBeenCalledTimes(2);
+
+      const parsed = parseResult(result);
+      expect(parsed.resources_searched).toEqual(['projects', 'deals']);
+      expect(parsed.results).toHaveProperty('projects');
+      expect(parsed.results).toHaveProperty('deals');
+    });
+
+    it('calls execute with correct args per resource', async () => {
+      mockExecute.mockResolvedValue(createMockResponse([]));
+
+      await handleSearch('Studio Meta', ['projects', 'companies'], mockCredentials, mockExecute);
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        'productive',
+        {
+          resource: 'projects',
+          action: 'list',
+          query: 'Studio Meta',
+          compact: true,
+          per_page: 10,
+        },
+        mockCredentials,
+      );
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        'productive',
+        {
+          resource: 'companies',
+          action: 'list',
+          query: 'Studio Meta',
+          compact: true,
+          per_page: 10,
+        },
+        mockCredentials,
+      );
+    });
+
+    it('correctly sums total_results from array result lengths', async () => {
+      mockExecute
+        .mockResolvedValueOnce(createMockResponse([{ id: '1' }, { id: '2' }, { id: '3' }]))
+        .mockResolvedValueOnce(createMockResponse([{ id: '4' }, { id: '5' }]))
+        .mockResolvedValueOnce(createMockResponse([]))
+        .mockResolvedValueOnce(createMockResponse([{ id: '6' }]));
+
+      const result = await handleSearch('test', undefined, mockCredentials, mockExecute);
+      const parsed = parseResult(result);
+
+      expect(parsed.total_results).toBe(6);
+    });
+
+    it('trims whitespace from query', async () => {
+      mockExecute.mockResolvedValue(createMockResponse([]));
+
+      await handleSearch('  Studio Meta  ', ['projects'], mockCredentials, mockExecute);
+
+      expect(mockExecute).toHaveBeenCalledWith(
+        'productive',
+        expect.objectContaining({ query: 'Studio Meta' }),
+        mockCredentials,
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns error for empty query', async () => {
+      const result = await handleSearch('', undefined, mockCredentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      const textContent = result.content.find((c) => c.type === 'text');
+      expect(textContent?.type === 'text' && textContent.text).toContain('query');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns error for missing query', async () => {
+      const result = await handleSearch(undefined, undefined, mockCredentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      const textContent = result.content.find((c) => c.type === 'text');
+      expect(textContent?.type === 'text' && textContent.text).toContain('query');
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns error for whitespace-only query', async () => {
+      const result = await handleSearch('   ', undefined, mockCredentials, mockExecute);
+
+      expect(result.isError).toBe(true);
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns error for invalid resource name', async () => {
+      const result = await handleSearch(
+        'test',
+        ['projects', 'invalid_resource', 'companies'],
+        mockCredentials,
+        mockExecute,
+      );
+
+      expect(result.isError).toBe(true);
+      const textContent = result.content.find((c) => c.type === 'text');
+      expect(textContent?.type === 'text' && textContent.text).toContain('invalid_resource');
+      expect(textContent?.type === 'text' && textContent.text).toContain(
+        SEARCHABLE_RESOURCES.join(', '),
+      );
+      expect(mockExecute).not.toHaveBeenCalled();
+    });
+
+    it('returns error listing all invalid resources', async () => {
+      const result = await handleSearch(
+        'test',
+        ['invalid1', 'invalid2'],
+        mockCredentials,
+        mockExecute,
+      );
+
+      expect(result.isError).toBe(true);
+      const textContent = result.content.find((c) => c.type === 'text');
+      expect(textContent?.type === 'text' && textContent.text).toContain('invalid1');
+      expect(textContent?.type === 'text' && textContent.text).toContain('invalid2');
+    });
+
+    it('captures per-resource error without aborting others', async () => {
+      mockExecute
+        .mockResolvedValueOnce(createMockResponse([{ id: '1', name: 'Project A' }]))
+        .mockRejectedValueOnce(new Error('API rate limited'))
+        .mockResolvedValueOnce(createMockResponse([{ id: '2', name: 'Person B' }]))
+        .mockResolvedValueOnce(createMockResponse([{ id: '3', name: 'Task C' }]));
+
+      const result = await handleSearch('test', undefined, mockCredentials, mockExecute);
+
+      expect(result.isError).toBeUndefined();
+      const parsed = parseResult(result);
+
+      // Projects succeeded
+      expect(Array.isArray(parsed.results.projects)).toBe(true);
+      expect((parsed.results.projects as unknown[]).length).toBe(1);
+
+      // Companies failed with captured error
+      expect(parsed.results.companies).toHaveProperty('error');
+      expect((parsed.results.companies as { error: string }).error).toContain('API rate limited');
+
+      // People and tasks succeeded
+      expect(Array.isArray(parsed.results.people)).toBe(true);
+      expect(Array.isArray(parsed.results.tasks)).toBe(true);
+
+      // Total only counts successful results
+      expect(parsed.total_results).toBe(3);
+    });
+
+    it('captures error when response has no content', async () => {
+      mockExecute.mockResolvedValueOnce({ content: [] });
+
+      const result = await handleSearch('test', ['projects'], mockCredentials, mockExecute);
+
+      expect(result.isError).toBeUndefined();
+      const parsed = parseResult(result);
+      expect(parsed.results.projects).toHaveProperty('error');
+    });
+
+    it('captures error when response JSON is invalid', async () => {
+      mockExecute.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'not valid json' }],
+      });
+
+      const result = await handleSearch('test', ['projects'], mockCredentials, mockExecute);
+
+      expect(result.isError).toBeUndefined();
+      const parsed = parseResult(result);
+      expect(parsed.results.projects).toHaveProperty('error');
+      expect((parsed.results.projects as { error: string }).error).toContain('parse');
+    });
+  });
+
+  describe('SEARCHABLE_RESOURCES constant', () => {
+    it('contains the expected resources', () => {
+      expect(SEARCHABLE_RESOURCES).toContain('projects');
+      expect(SEARCHABLE_RESOURCES).toContain('companies');
+      expect(SEARCHABLE_RESOURCES).toContain('people');
+      expect(SEARCHABLE_RESOURCES).toContain('tasks');
+      expect(SEARCHABLE_RESOURCES).toContain('deals');
+      expect(SEARCHABLE_RESOURCES.length).toBe(5);
+    });
+  });
+});

--- a/packages/mcp/src/handlers/search.ts
+++ b/packages/mcp/src/handlers/search.ts
@@ -1,0 +1,138 @@
+/**
+ * Cross-resource search handler for MCP.
+ *
+ * Fans out a text query across multiple resource types simultaneously,
+ * returning grouped results in a single tool call.
+ */
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { ToolResult } from './types.js';
+
+import { errorResult, jsonResult } from './utils.js';
+
+/**
+ * Resources that support the query filter for text search
+ */
+export const SEARCHABLE_RESOURCES = ['projects', 'companies', 'people', 'tasks', 'deals'] as const;
+export type SearchableResource = (typeof SEARCHABLE_RESOURCES)[number];
+
+/**
+ * Default resources to search when not specified
+ */
+const DEFAULT_SEARCH_RESOURCES: SearchableResource[] = ['projects', 'companies', 'people', 'tasks'];
+
+/**
+ * Type for the execute function injected for delegation
+ */
+export type ExecuteFunction = (
+  name: string,
+  args: Record<string, unknown>,
+  credentials: ProductiveCredentials,
+) => Promise<ToolResult>;
+
+/**
+ * Search result for a single resource
+ */
+interface ResourceSearchResult {
+  items?: unknown[];
+  error?: string;
+}
+
+/**
+ * Handle cross-resource search.
+ *
+ * @param query - Search query text (required)
+ * @param resources - Resource types to search (optional, defaults to DEFAULT_SEARCH_RESOURCES)
+ * @param credentials - Productive API credentials
+ * @param execute - Function to execute tool calls (injected for delegation and testing)
+ * @returns Grouped search results across all requested resources
+ */
+export async function handleSearch(
+  query: string | undefined,
+  resources: string[] | undefined,
+  credentials: ProductiveCredentials,
+  execute: ExecuteFunction,
+): Promise<ToolResult> {
+  // Validate query is non-empty
+  if (!query || query.trim() === '') {
+    return errorResult('Missing required parameter: query. Provide a non-empty search string.');
+  }
+
+  const trimmedQuery = query.trim();
+
+  // Resolve resources to default if not provided
+  const resourcesToSearch =
+    resources && resources.length > 0 ? resources : DEFAULT_SEARCH_RESOURCES;
+
+  // Validate all resources are searchable
+  const invalidResources = resourcesToSearch.filter(
+    (r) => !SEARCHABLE_RESOURCES.includes(r as SearchableResource),
+  );
+
+  if (invalidResources.length > 0) {
+    return errorResult(
+      `Invalid searchable resources: ${invalidResources.join(', ')}. ` +
+        `Valid searchable resources: ${SEARCHABLE_RESOURCES.join(', ')}.`,
+    );
+  }
+
+  // Run all searches in parallel
+  const searchPromises = resourcesToSearch.map(
+    async (resource): Promise<[string, ResourceSearchResult]> => {
+      try {
+        const result = await execute(
+          'productive',
+          {
+            resource,
+            action: 'list',
+            query: trimmedQuery,
+            compact: true,
+            per_page: 10,
+          },
+          credentials,
+        );
+
+        // Parse JSON from result content
+        const textContent = result.content.find((c) => c.type === 'text');
+        if (!textContent || textContent.type !== 'text') {
+          return [resource, { error: 'No content in response' }];
+        }
+
+        try {
+          const parsed = JSON.parse(textContent.text);
+          // Extract items array from the response (formatListResponse uses 'items' key)
+          const items = parsed.items ?? parsed.data ?? [];
+          return [resource, { items: Array.isArray(items) ? items : [] }];
+        } catch {
+          return [resource, { error: 'Failed to parse response JSON' }];
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return [resource, { error: message }];
+      }
+    },
+  );
+
+  const searchResults = await Promise.all(searchPromises);
+
+  // Build results object and count total
+  const results: Record<string, unknown[] | { error: string }> = {};
+  let totalResults = 0;
+
+  for (const [resource, result] of searchResults) {
+    if (result.error) {
+      results[resource] = { error: result.error };
+    } else {
+      const items = result.items ?? [];
+      results[resource] = items;
+      totalResults += items.length;
+    }
+  }
+
+  return jsonResult({
+    query: trimmedQuery,
+    resources_searched: resourcesToSearch,
+    results,
+    total_results: totalResults,
+  });
+}

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -163,6 +163,16 @@ export const ParamQuery = z
   );
 
 /**
+ * Resources parameter for cross-resource search
+ */
+export const ParamResources = z
+  .array(z.string())
+  .optional()
+  .describe(
+    'Resource types to search (for resource=search action=run). Defaults to [projects, companies, people, tasks]. Valid: projects, companies, people, tasks, deals.',
+  );
+
+/**
  * No hints parameter - disable contextual hints in responses
  */
 export const ParamNoHints = z
@@ -235,6 +245,7 @@ export const ProductiveToolInputSchema = z.object({
   compact: ParamCompact,
   include: ParamInclude.optional(),
   query: ParamQuery.optional(),
+  resources: ParamResources,
   no_hints: ParamNoHints,
 
   // ID references

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -119,7 +119,7 @@ describe('tools', () => {
       expect(totalSize).toBeLessThan(4500);
     });
 
-    it('should estimate under 900 tokens', () => {
+    it('should estimate under 1200 tokens', () => {
       const totalSize = JSON.stringify(TOOLS).length;
       const estimatedTokens = Math.ceil(totalSize / 4);
       expect(estimatedTokens).toBeLessThan(1200);

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -15,7 +15,7 @@ function generateDescription(): string {
     'Filters: filter:{key:value}. Common: project_id, person_id, after/before (YYYY-MM-DD).',
     'Includes: include:[...] for related data (e.g. ["project","assignee"]).',
     'Output: compact=false for full detail (default for get; list defaults true).',
-    'Search: query for text search on list actions.',
+    'Search: query for text search on list actions. Cross-resource: resource=search action=run with query searches projects, companies, people, tasks simultaneously.',
     'Reports: resource=reports action=get with report_type, from, to.',
     'Batch: resource=batch action=run with operations=[{resource,action,...}] executes up to 10 ops in parallel.',
   ].join('\n');
@@ -73,6 +73,12 @@ export const TOOLS: Tool[] = [
           description: 'Related data to include (e.g. ["project","assignee"])',
         },
         query: { type: 'string', description: 'Text search for list actions' },
+        resources: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Resource types to search (for resource=search). Defaults to [projects, companies, people, tasks]. Valid values: projects, companies, people, tasks, deals.',
+        },
         // Common fields
         person_id: { type: 'string' },
         service_id: { type: 'string' },


### PR DESCRIPTION
## Summary

Closes #90

Adds `resource=search action=run` to fan out a text query across multiple resource types simultaneously, returning grouped results in a single tool call.

## Usage

```json
{
  "resource": "search",
  "action": "run",
  "query": "Studio Meta",
  "resources": ["projects", "companies", "people"]
}
```

Returns grouped results with total count across all searched resources.

## Changes

- **core**: Added `search` to RESOURCES, `run` to ACTIONS
- **mcp**: New `packages/mcp/src/handlers/search.ts` handler
- **mcp**: `resource=search` routing in `handlers/index.ts` before API init
- **mcp**: `resources` field added to tool inputSchema and Zod validation
- **mcp**: Updated tool description to advertise cross-resource search
- **mcp**: Full test coverage in `search.test.ts`