### PR TITLE
MCP: add services.list hint showing deal_id filter

### DIFF
--- a/packages/mcp/skills/SKILL.md
+++ b/packages/mcp/skills/SKILL.md
@@ -252,6 +252,13 @@ Response:
 ### Services
 
 ```json
+// List services for a deal (budget line items) — prefer this over project_id when you have a deal
+{
+  "resource": "services",
+  "action": "list",
+  "filter": { "deal_id": "12345" }
+}
+
 // List services for a project
 {
   "resource": "services",

--- a/packages/mcp/src/handlers.test.ts
+++ b/packages/mcp/src/handlers.test.ts
@@ -449,6 +449,43 @@ describe('handlers', () => {
         );
       });
 
+      it('should include deal_id hint when listing without deal_id filter', async () => {
+        const mockResponse = {
+          data: [{ id: '1', type: 'services', attributes: { name: 'Development' } }],
+          meta: { current_page: 1, total_pages: 1 },
+        };
+        mockApi.getServices.mockResolvedValue(mockResponse);
+
+        const result = await executeToolWithCredentials(
+          'productive',
+          { resource: 'services', action: 'list' },
+          credentials,
+        );
+
+        expect(result.isError).toBeUndefined();
+        const content = JSON.parse(result.content[0].text as string);
+        expect(content._hints).toBeDefined();
+        expect(content._hints.common_actions[0].example.filter).toHaveProperty('deal_id');
+      });
+
+      it('should not include deal_id hint when already filtering by deal_id', async () => {
+        const mockResponse = {
+          data: [{ id: '1', type: 'services', attributes: { name: 'Development' } }],
+          meta: { current_page: 1, total_pages: 1 },
+        };
+        mockApi.getServices.mockResolvedValue(mockResponse);
+
+        const result = await executeToolWithCredentials(
+          'productive',
+          { resource: 'services', action: 'list', filter: { deal_id: '123' } },
+          credentials,
+        );
+
+        expect(result.isError).toBeUndefined();
+        const content = JSON.parse(result.content[0].text as string);
+        expect(content._hints).toBeUndefined();
+      });
+
       it('should return error for invalid action', async () => {
         const result = await executeToolWithCredentials(
           'productive',

--- a/packages/mcp/src/handlers/help.ts
+++ b/packages/mcp/src/handlers/help.ts
@@ -275,6 +275,10 @@ const RESOURCE_HELP: Record<string, ResourceHelp> = {
     },
     examples: [
       {
+        description: 'List services for a deal (budget line items)',
+        params: { resource: 'services', action: 'list', filter: { deal_id: '12345' } },
+      },
+      {
         description: 'List services for a project',
         params: { resource: 'services', action: 'list', filter: { project_id: '12345' } },
       },

--- a/packages/mcp/src/handlers/services.ts
+++ b/packages/mcp/src/handlers/services.ts
@@ -8,8 +8,10 @@ import { listServices } from '@studiometa/productive-core';
 
 import type { CommonArgs } from './types.js';
 
-import { formatService } from '../formatters.js';
+import { formatService, formatListResponse } from '../formatters.js';
+import { getServiceListHints } from '../hints.js';
 import { createResourceHandler } from './factory.js';
+import { jsonResult } from './utils.js';
 
 /**
  * Handle services resource.
@@ -22,5 +24,28 @@ export const handleServices = createResourceHandler<CommonArgs>({
   formatter: formatService,
   executors: {
     list: listServices,
+  },
+  customActions: {
+    list: async (args, ctx, execCtx) => {
+      const { formatOptions, filter, page, perPage } = ctx;
+      const additionalFilters = { ...filter };
+
+      const result = await listServices({ page, perPage, additionalFilters }, execCtx);
+
+      const response = formatListResponse(result.data, formatService, result.meta, {
+        ...formatOptions,
+        included: result.included,
+      });
+
+      // Append hint when not filtering by deal_id
+      // Note: ctx.includeHints is only true for get actions, but list-level
+      // hints are lightweight suggestions that should always be included
+      const hints = getServiceListHints(additionalFilters);
+      if (hints) {
+        return jsonResult({ ...response, _hints: hints });
+      }
+
+      return jsonResult(response);
+    },
   },
 });

--- a/packages/mcp/src/hints.test.ts
+++ b/packages/mcp/src/hints.test.ts
@@ -10,6 +10,7 @@ import {
   getDealHints,
   getPersonHints,
   getServiceHints,
+  getServiceListHints,
   getCompanyHints,
   getTimeEntryHints,
   getCommentHints,
@@ -138,6 +139,37 @@ describe('hints', () => {
       const timerAction = hints.common_actions?.find((a) => a.action === 'Start a timer');
       expect(timerAction).toBeDefined();
       expect(timerAction?.example.service_id).toBe('12345');
+    });
+  });
+
+  describe('getServiceListHints', () => {
+    it('returns a deal_id filter hint when no filter is provided', () => {
+      const hints = getServiceListHints();
+
+      expect(hints).not.toBeNull();
+      expect(hints?.common_actions).toBeDefined();
+      expect(hints?.common_actions).toHaveLength(1);
+
+      const dealHint = hints?.common_actions?.[0];
+      expect(dealHint?.action).toContain('deal');
+      expect(dealHint?.example).toEqual({
+        resource: 'services',
+        action: 'list',
+        filter: { deal_id: '<deal_id>' },
+      });
+    });
+
+    it('returns a deal_id filter hint when filter does not include deal_id', () => {
+      const hints = getServiceListHints({ project_id: '12345' });
+
+      expect(hints).not.toBeNull();
+      expect(hints?.common_actions).toHaveLength(1);
+    });
+
+    it('returns null when filter already includes deal_id', () => {
+      const hints = getServiceListHints({ deal_id: '12345' });
+
+      expect(hints).toBeNull();
     });
   });
 

--- a/packages/mcp/src/hints.ts
+++ b/packages/mcp/src/hints.ts
@@ -258,6 +258,36 @@ export function getPersonHints(personId: string): ContextualHints {
 }
 
 /**
+ * Generate hints for a services list response.
+ *
+ * When the query doesn't already filter by deal_id, suggests filtering
+ * by deal_id to scope services to a specific budget/deal.
+ *
+ * @param currentFilter - The filter object currently applied to the list query
+ */
+export function getServiceListHints(
+  currentFilter?: Record<string, string>,
+): ContextualHints | null {
+  // No hint needed if already filtering by deal_id
+  if (currentFilter?.deal_id) {
+    return null;
+  }
+
+  return {
+    common_actions: [
+      {
+        action: 'Filter services by deal to see budget line items for a specific deal',
+        example: {
+          resource: 'services',
+          action: 'list',
+          filter: { deal_id: '<deal_id>' },
+        },
+      },
+    ],
+  };
+}
+
+/**
  * Generate hints for a service
  */
 export function getServiceHints(serviceId: string): ContextualHints {


### PR DESCRIPTION
Adds a contextual hint when listing services without a deal_id filter, and makes it the lead example in help docs.

Closes #85