### PR TITLE
MCP: validate include values and warn on invalid ones

### DIFF
--- a/packages/mcp/src/handlers.test.ts
+++ b/packages/mcp/src/handlers.test.ts
@@ -1894,14 +1894,14 @@ describe('include parameter', () => {
 
       await executeToolWithCredentials(
         'productive',
-        { resource: 'deals', action: 'get', id: '123', include: ['services'] },
+        { resource: 'deals', action: 'get', id: '123', include: ['project'] },
         credentials,
       );
 
       expect(mockApi.getDeal).toHaveBeenCalledWith(
         '123',
         expect.objectContaining({
-          include: expect.arrayContaining(['company', 'deal_status', 'responsible', 'services']),
+          include: expect.arrayContaining(['company', 'deal_status', 'responsible', 'project']),
         }),
       );
     });
@@ -1956,14 +1956,14 @@ describe('include parameter', () => {
 
       await executeToolWithCredentials(
         'productive',
-        { resource: 'bookings', action: 'get', id: '123', include: ['approver'] },
+        { resource: 'bookings', action: 'get', id: '123', include: ['event'] },
         credentials,
       );
 
       expect(mockApi.getBooking).toHaveBeenCalledWith(
         '123',
         expect.objectContaining({
-          include: expect.arrayContaining(['person', 'service', 'approver']),
+          include: expect.arrayContaining(['person', 'service', 'event']),
         }),
       );
     });
@@ -3626,6 +3626,146 @@ describe('smart ID resolution', () => {
       // Should get batch validation error, not API error
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('cannot be empty');
+    });
+  });
+
+  describe('include validation', () => {
+    it('should return error for invalid include on tasks', async () => {
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'tasks', action: 'list', include: ['notes'] },
+        credentials,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid include value');
+      expect(result.content[0].text).toContain('notes');
+    });
+
+    it('should return error for invalid include on deals', async () => {
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'deals', action: 'list', include: ['services'] },
+        credentials,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid include value');
+      expect(result.content[0].text).toContain('services');
+      // Should provide a helpful suggestion
+      expect(result.content[0].text).toContain('resource=services');
+    });
+
+    it('should list valid includes in the error hints', async () => {
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'tasks', action: 'list', include: ['foobar'] },
+        credentials,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('project');
+      expect(result.content[0].text).toContain('assignee');
+    });
+
+    it('should pass through valid includes without error for tasks', async () => {
+      mockApi.getTasks.mockResolvedValue({
+        data: [{ id: '1', type: 'tasks', attributes: { title: 'Task 1' } }],
+        meta: { current_page: 1, total_pages: 1 },
+        included: [],
+      });
+
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'tasks', action: 'list', include: ['project', 'assignee'] },
+        credentials,
+      );
+
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should skip validation for resources with no include map (projects)', async () => {
+      mockApi.getProjects.mockResolvedValue({
+        data: [{ id: '1', type: 'projects', attributes: { name: 'Project 1' } }],
+        meta: { current_page: 1, total_pages: 1 },
+      });
+
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'projects', action: 'list', include: ['anything'] },
+        credentials,
+      );
+
+      // Projects has no include map — should not error
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should return error for multiple invalid includes', async () => {
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'tasks', action: 'list', include: ['notes', 'services', 'time_entries'] },
+        credentials,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('notes');
+      expect(result.content[0].text).toContain('services');
+      expect(result.content[0].text).toContain('time_entries');
+    });
+
+    it('should mention valid includes when some are valid and some are not', async () => {
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'tasks', action: 'list', include: ['project', 'notes'] },
+        credentials,
+      );
+
+      expect(result.isError).toBe(true);
+      // Should mention the valid includes that were found
+      expect(result.content[0].text).toContain('project');
+    });
+
+    it('should not validate empty include array', async () => {
+      mockApi.getTasks.mockResolvedValue({
+        data: [{ id: '1', type: 'tasks', attributes: { title: 'Task 1' } }],
+        meta: { current_page: 1, total_pages: 1 },
+        included: [],
+      });
+
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'tasks', action: 'list', include: [] },
+        credentials,
+      );
+
+      // Empty include array should not trigger validation error
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should validate includes for comments resource', async () => {
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'comments', action: 'list', include: ['author'] },
+        credentials,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('author');
+      // Known suggestion: use "creator" instead
+      expect(result.content[0].text).toContain('creator');
+    });
+
+    it('should validate includes for bookings resource', async () => {
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'bookings', action: 'list', include: ['project'] },
+        credentials,
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('project');
+      // Valid includes: person, service, event
+      expect(result.content[0].text).toContain('person');
     });
   });
 });

--- a/packages/mcp/src/handlers/valid-includes.test.ts
+++ b/packages/mcp/src/handlers/valid-includes.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+
+import { VALID_INCLUDES, validateIncludes } from './valid-includes.js';
+
+describe('VALID_INCLUDES', () => {
+  it('contains known resources', () => {
+    expect(VALID_INCLUDES).toHaveProperty('tasks');
+    expect(VALID_INCLUDES).toHaveProperty('comments');
+    expect(VALID_INCLUDES).toHaveProperty('deals');
+    expect(VALID_INCLUDES).toHaveProperty('bookings');
+    expect(VALID_INCLUDES).toHaveProperty('time');
+  });
+
+  it('tasks includes are correct', () => {
+    expect(VALID_INCLUDES.tasks).toContain('project');
+    expect(VALID_INCLUDES.tasks).toContain('assignee');
+    expect(VALID_INCLUDES.tasks).toContain('comments');
+    expect(VALID_INCLUDES.tasks).toContain('subtasks');
+    expect(VALID_INCLUDES.tasks).toContain('workflow_status');
+    expect(VALID_INCLUDES.tasks).toContain('attachments');
+    expect(VALID_INCLUDES.tasks).toContain('project.company');
+  });
+
+  it('deals includes are correct', () => {
+    expect(VALID_INCLUDES.deals).toContain('company');
+    expect(VALID_INCLUDES.deals).toContain('deal_status');
+    expect(VALID_INCLUDES.deals).toContain('responsible');
+    expect(VALID_INCLUDES.deals).toContain('project');
+  });
+
+  it('bookings includes are correct', () => {
+    expect(VALID_INCLUDES.bookings).toContain('person');
+    expect(VALID_INCLUDES.bookings).toContain('service');
+    expect(VALID_INCLUDES.bookings).toContain('event');
+  });
+
+  it('comments includes are correct', () => {
+    expect(VALID_INCLUDES.comments).toContain('creator');
+    expect(VALID_INCLUDES.comments).toContain('task');
+    expect(VALID_INCLUDES.comments).toContain('deal');
+  });
+
+  it('time includes are correct', () => {
+    expect(VALID_INCLUDES.time).toContain('person');
+    expect(VALID_INCLUDES.time).toContain('service');
+    expect(VALID_INCLUDES.time).toContain('task');
+  });
+});
+
+describe('validateIncludes', () => {
+  describe('returns null for unknown resources', () => {
+    it('returns null for projects (no include validation)', () => {
+      expect(validateIncludes('projects', ['company'])).toBeNull();
+    });
+
+    it('returns null for services', () => {
+      expect(validateIncludes('services', ['project'])).toBeNull();
+    });
+
+    it('returns null for people', () => {
+      expect(validateIncludes('people', ['company'])).toBeNull();
+    });
+
+    it('returns null for companies', () => {
+      expect(validateIncludes('companies', ['contacts'])).toBeNull();
+    });
+
+    it('returns null for completely unknown resource', () => {
+      expect(validateIncludes('foobar', ['anything'])).toBeNull();
+    });
+  });
+
+  describe('all valid includes', () => {
+    it('returns all values as valid for tasks with valid includes', () => {
+      const result = validateIncludes('tasks', ['project', 'assignee']);
+      expect(result).not.toBeNull();
+      expect(result!.valid).toEqual(['project', 'assignee']);
+      expect(result!.invalid).toEqual([]);
+      expect(result!.suggestions).toEqual({});
+    });
+
+    it('returns all values as valid for deals with valid includes', () => {
+      const result = validateIncludes('deals', ['company', 'deal_status']);
+      expect(result).not.toBeNull();
+      expect(result!.valid).toEqual(['company', 'deal_status']);
+      expect(result!.invalid).toEqual([]);
+    });
+
+    it('handles empty includes array', () => {
+      const result = validateIncludes('tasks', []);
+      expect(result).not.toBeNull();
+      expect(result!.valid).toEqual([]);
+      expect(result!.invalid).toEqual([]);
+      expect(result!.suggestions).toEqual({});
+    });
+  });
+
+  describe('invalid includes', () => {
+    it('detects invalid include values for tasks', () => {
+      const result = validateIncludes('tasks', ['project', 'notes', 'services']);
+      expect(result).not.toBeNull();
+      expect(result!.valid).toEqual(['project']);
+      expect(result!.invalid).toEqual(['notes', 'services']);
+    });
+
+    it('provides known suggestion for "notes"', () => {
+      const result = validateIncludes('tasks', ['notes']);
+      expect(result!.suggestions.notes).toContain('comments');
+    });
+
+    it('provides known suggestion for "services" on deals', () => {
+      const result = validateIncludes('deals', ['services']);
+      expect(result!.suggestions.services).toContain('resource=services');
+    });
+
+    it('provides known suggestion for "time_entries"', () => {
+      const result = validateIncludes('tasks', ['time_entries']);
+      expect(result!.suggestions.time_entries).toContain('resource=time');
+    });
+
+    it('provides known suggestion for "time"', () => {
+      const result = validateIncludes('tasks', ['time']);
+      expect(result!.suggestions.time).toContain('resource=time');
+    });
+
+    it('provides known suggestion for "user"', () => {
+      const result = validateIncludes('tasks', ['user']);
+      expect(result!.suggestions.user).toContain('assignee');
+    });
+
+    it('provides known suggestion for "author"', () => {
+      const result = validateIncludes('comments', ['author']);
+      expect(result!.suggestions.author).toContain('creator');
+    });
+
+    it('provides known suggestion for "owner"', () => {
+      const result = validateIncludes('deals', ['owner']);
+      expect(result!.suggestions.owner).toContain('responsible');
+    });
+
+    it('provides generic suggestion for unknown invalid include', () => {
+      const result = validateIncludes('tasks', ['foobar']);
+      expect(result!.suggestions.foobar).toContain('Valid includes for tasks');
+      expect(result!.suggestions.foobar).toContain('project');
+      expect(result!.suggestions.foobar).toContain('assignee');
+    });
+
+    it('separates valid and invalid correctly when mixed', () => {
+      const result = validateIncludes('tasks', ['project', 'foobar', 'assignee', 'nonexistent']);
+      expect(result!.valid).toEqual(['project', 'assignee']);
+      expect(result!.invalid).toEqual(['foobar', 'nonexistent']);
+      expect(Object.keys(result!.suggestions)).toEqual(['foobar', 'nonexistent']);
+    });
+  });
+
+  describe('all includes invalid', () => {
+    it('returns all as invalid when none are valid', () => {
+      const result = validateIncludes('comments', ['notes', 'services', 'tasks_list']);
+      expect(result!.valid).toEqual([]);
+      expect(result!.invalid).toEqual(['notes', 'services', 'tasks_list']);
+    });
+  });
+});

--- a/packages/mcp/src/handlers/valid-includes.ts
+++ b/packages/mcp/src/handlers/valid-includes.ts
@@ -1,0 +1,82 @@
+/**
+ * Valid include values per resource.
+ *
+ * Sourced from help.ts and schema.ts include lists.
+ * Resources not listed here have no include validation (pass-through).
+ */
+
+export const VALID_INCLUDES: Record<string, string[]> = {
+  tasks: [
+    'project',
+    'project.company',
+    'assignee',
+    'workflow_status',
+    'comments',
+    'attachments',
+    'subtasks',
+  ],
+  comments: ['creator', 'task', 'deal'],
+  deals: ['company', 'deal_status', 'responsible', 'project'],
+  bookings: ['person', 'service', 'event'],
+  time: ['person', 'service', 'task'],
+};
+
+export interface ValidateIncludesResult {
+  valid: string[];
+  invalid: string[];
+  suggestions: Record<string, string>;
+}
+
+/**
+ * Known misleading include values and their suggestions.
+ * These are values that agents commonly try that don't exist.
+ */
+const KNOWN_SUGGESTIONS: Record<string, string> = {
+  notes: 'Use resource=comments to fetch comments on a resource',
+  services: 'Use resource=services with filter.deal_id or filter.project_id to list services',
+  time_entries:
+    'Use resource=time with a filter (e.g. filter.task_id, filter.project_id) to list time entries',
+  time: 'Use resource=time with a filter (e.g. filter.task_id) to list time entries',
+  user: 'Use "assignee" or "person" instead',
+  author: 'Use "creator" instead',
+  owner: 'Use "responsible" or "assignee" instead',
+  company: 'Use "project.company" to include the project\'s company on tasks',
+  status: 'Use "workflow_status" to include the workflow/kanban status on tasks',
+};
+
+/**
+ * Validate include values for a given resource.
+ *
+ * Returns the valid and invalid values, plus suggestions for invalid values.
+ * If the resource is not in VALID_INCLUDES, skips validation (returns all as valid).
+ */
+export function validateIncludes(
+  resource: string,
+  includes: string[],
+): ValidateIncludesResult | null {
+  const validSet = VALID_INCLUDES[resource];
+
+  // Resource has no include validation — skip
+  if (!validSet) {
+    return null;
+  }
+
+  const valid: string[] = [];
+  const invalid: string[] = [];
+  const suggestions: Record<string, string> = {};
+
+  for (const inc of includes) {
+    if (validSet.includes(inc)) {
+      valid.push(inc);
+    } else {
+      invalid.push(inc);
+      if (KNOWN_SUGGESTIONS[inc]) {
+        suggestions[inc] = KNOWN_SUGGESTIONS[inc];
+      } else {
+        suggestions[inc] = `Valid includes for ${resource}: ${validSet.join(', ')}`;
+      }
+    }
+  }
+
+  return { valid, invalid, suggestions };
+}


### PR DESCRIPTION
Validates include values against known-valid values per resource and returns helpful suggestions.

Closes #82