### PR TITLE
Switch HTTP transport to StreamableHTTPServerTransport with SSE support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2486,7 +2486,6 @@
       "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3177,7 +3176,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3281,7 +3279,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3554,7 +3551,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
       "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4441,7 +4437,6 @@
       "integrity": "sha512-4RuJK2jP08XwqtUu+5yhCbxEauCm6tv2MFHKEMsjbosK2+vy5us82oI3VLuHwbNyZG7ekZA26U2LLHnGR4frIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "tsgolint": "bin/tsgolint.js"
       },
@@ -5107,7 +5102,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5179,8 +5173,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -5319,7 +5312,6 @@
       "integrity": "sha512-oFoeAOQednbyV7mR1hAmT4/yQ4xnNzvHUcU0lFwxo8riim0wsuh2EXF/xOtsT3q33ACeufP5BkWFVyJUC5B/DQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.0-beta.5",
         "@vitest/mocker": "4.1.0-beta.5",
@@ -5447,7 +5439,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5461,7 +5452,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5626,7 +5616,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/packages/mcp/src/http.test.ts
+++ b/packages/mcp/src/http.test.ts
@@ -1,4 +1,3 @@
-import { toNodeHandler } from 'h3';
 import { createServer, type Server as HttpServer } from 'node:http';
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 
@@ -23,12 +22,6 @@ vi.mock('./resources.js', () => ({
       description: 'Schema overview',
       mimeType: 'application/json',
     },
-    {
-      uri: 'productive://instructions',
-      name: 'Instructions',
-      description: 'Instructions',
-      mimeType: 'application/json',
-    },
   ]),
   listResourceTemplates: vi.fn().mockReturnValue([
     {
@@ -49,93 +42,43 @@ vi.mock('./resources.js', () => ({
 }));
 
 import { executeToolWithCredentials } from './handlers.js';
-import {
-  createHttpApp,
-  jsonRpcError,
-  jsonRpcSuccess,
-  handleInitialize,
-  handleToolsList,
-} from './http.js';
-import { listResources, listResourceTemplates, readResource } from './resources.js';
+import { createHttpApp, createHttpHandler, createMcpServer, extractCredentials } from './http.js';
 import { VERSION } from './version.js';
 
 describe('http module', () => {
-  describe('jsonRpcError', () => {
-    it('should create error response with id', () => {
-      const error = jsonRpcError(-32600, 'Invalid request', 123);
-
-      expect(error).toEqual({
-        jsonrpc: '2.0',
-        error: { code: -32600, message: 'Invalid request' },
-        id: 123,
+  describe('extractCredentials', () => {
+    it('returns credentials from authInfo extra', () => {
+      const creds = extractCredentials({
+        extra: { organizationId: 'org-1', apiToken: 'token-1', userId: 'user-1' },
+      });
+      expect(creds).toEqual({
+        organizationId: 'org-1',
+        apiToken: 'token-1',
+        userId: 'user-1',
       });
     });
 
-    it('should create error response without id', () => {
-      const error = jsonRpcError(-32700, 'Parse error');
+    it('returns undefined when authInfo is undefined', () => {
+      expect(extractCredentials(undefined)).toBeUndefined();
+    });
 
-      expect(error).toEqual({
-        jsonrpc: '2.0',
-        error: { code: -32700, message: 'Parse error' },
-        id: null,
-      });
+    it('returns undefined when extra is missing', () => {
+      expect(extractCredentials({})).toBeUndefined();
+    });
+
+    it('returns undefined when organizationId is missing', () => {
+      expect(extractCredentials({ extra: { apiToken: 'token' } })).toBeUndefined();
+    });
+
+    it('returns undefined when apiToken is missing', () => {
+      expect(extractCredentials({ extra: { organizationId: 'org' } })).toBeUndefined();
     });
   });
 
-  describe('jsonRpcSuccess', () => {
-    it('should create success response', () => {
-      const success = jsonRpcSuccess({ data: 'test' }, 456);
-
-      expect(success).toEqual({
-        jsonrpc: '2.0',
-        result: { data: 'test' },
-        id: 456,
-      });
-    });
-
-    it('should handle string id', () => {
-      const success = jsonRpcSuccess({ ok: true }, 'request-1');
-
-      expect(success.id).toBe('request-1');
-    });
-  });
-
-  describe('handleInitialize', () => {
-    it('should return server info and capabilities', () => {
-      const result = handleInitialize();
-
-      expect(result.protocolVersion).toBe('2024-11-05');
-      expect(result.serverInfo.name).toBe('productive-mcp');
-      expect(result.serverInfo.version).toBe(VERSION);
-      expect(result.capabilities.tools).toEqual({});
-      expect(result.capabilities.resources).toEqual({});
-    });
-
-    it('should include instructions for Claude Desktop', () => {
-      const result = handleInitialize();
-
-      expect(result.instructions).toBeDefined();
-      expect(typeof result.instructions).toBe('string');
-      expect(result.instructions).toContain('productive');
-      expect(result.instructions).toContain('Best Practices');
-    });
-  });
-
-  describe('handleToolsList', () => {
-    it('should return tools array', () => {
-      const result = handleToolsList();
-
-      expect(result.tools).toBeDefined();
-      expect(Array.isArray(result.tools)).toBe(true);
-      expect(result.tools.length).toBe(1); // Single consolidated tool
-
-      // Should NOT include stdio-only tools
-      const configure = result.tools.find((t) => t.name === 'productive_configure');
-      expect(configure).toBeUndefined();
-
-      // Should include single consolidated tool
-      const productive = result.tools.find((t) => t.name === 'productive');
-      expect(productive).toBeDefined();
+  describe('createMcpServer', () => {
+    it('creates a server with tools and resources capabilities', () => {
+      const server = createMcpServer();
+      expect(server).toBeDefined();
     });
   });
 });
@@ -147,9 +90,14 @@ describe('HTTP Server Integration', () => {
   // Valid auth token: base64("test-org:test-token:test-user")
   const validToken = Buffer.from('test-org:test-token:test-user').toString('base64');
 
+  const sseHeaders = {
+    'Content-Type': 'application/json',
+    Accept: 'text/event-stream, application/json',
+  };
+
   beforeAll(async () => {
-    const app = createHttpApp();
-    server = createServer(toNodeHandler(app));
+    const handler = createHttpHandler();
+    server = createServer(handler);
 
     await new Promise<void>((resolve) => {
       server.listen(0, '127.0.0.1', () => {
@@ -171,6 +119,81 @@ describe('HTTP Server Integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+
+  /**
+   * Parse SSE events from response text
+   */
+  function parseSseEvents(text: string): Array<{ event?: string; data: unknown }> {
+    const events: Array<{ event?: string; data: unknown }> = [];
+    const lines = text.split('\n');
+    let currentEvent: string | undefined;
+    let dataLines: string[] = [];
+
+    for (const line of lines) {
+      if (line.startsWith('event: ')) {
+        currentEvent = line.slice(7);
+      } else if (line.startsWith('data: ')) {
+        dataLines.push(line.slice(6));
+      } else if (line === '' && dataLines.length > 0) {
+        const dataStr = dataLines.join('\n');
+        try {
+          events.push({ event: currentEvent, data: JSON.parse(dataStr) });
+        } catch {
+          events.push({ event: currentEvent, data: dataStr });
+        }
+        currentEvent = undefined;
+        dataLines = [];
+      }
+    }
+
+    return events;
+  }
+
+  /**
+   * Extract the JSON-RPC result from SSE events
+   */
+  function getResult(events: Array<{ event?: string; data: unknown }>): unknown {
+    const message = events.find((e) => e.event === 'message');
+    const data = message?.data as { result?: unknown; error?: unknown } | undefined;
+    return data?.result ?? data;
+  }
+
+  /**
+   * Initialize a session and return the session ID.
+   */
+  async function initializeSession(): Promise<string> {
+    const response = await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: { ...sseHeaders, Authorization: `Bearer ${validToken}` },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+        id: 1,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const sessionId = response.headers.get('mcp-session-id');
+    expect(sessionId).toBeTruthy();
+
+    // Send initialized notification
+    await fetch(`${baseUrl}/mcp`, {
+      method: 'POST',
+      headers: {
+        ...sseHeaders,
+        Authorization: `Bearer ${validToken}`,
+        'mcp-session-id': sessionId!,
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+    });
+
+    return sessionId!;
+  }
 
   describe('health endpoints', () => {
     it('GET / should return service info', async () => {
@@ -204,8 +227,7 @@ describe('HTTP Server Integration', () => {
       const data = await response.json();
 
       expect(response.status).toBe(401);
-      expect(data.error.code).toBe(-32001);
-      expect(data.error.message).toContain('Authentication required');
+      expect(data.error).toContain('Authentication required');
     });
 
     it('should return 401 with invalid token format', async () => {
@@ -217,13 +239,11 @@ describe('HTTP Server Integration', () => {
         },
         body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
       });
-      await response.json();
 
       expect(response.status).toBe(401);
     });
 
     it('should return 401 with incomplete credentials', async () => {
-      // Token with only org (missing apiToken)
       const incompleteToken = Buffer.from('only-org-id').toString('base64');
 
       const response = await fetch(`${baseUrl}/mcp`, {
@@ -234,24 +254,59 @@ describe('HTTP Server Integration', () => {
         },
         body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
       });
-      await response.json();
 
       expect(response.status).toBe(401);
     });
 
-    it('should accept valid Bearer token', async () => {
+    it('should return WWW-Authenticate header on 401', async () => {
       const response = await fetch(`${baseUrl}/mcp`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${validToken}`,
-        },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
       });
-      const data = await response.json();
+
+      expect(response.status).toBe(401);
+      const wwwAuth = response.headers.get('www-authenticate');
+      expect(wwwAuth).toContain('Bearer');
+      expect(wwwAuth).toContain('oauth-protected-resource');
+    });
+  });
+
+  describe('POST /mcp - session lifecycle', () => {
+    it('should initialize a session and return session ID', async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: { ...sseHeaders, Authorization: `Bearer ${validToken}` },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'test', version: '1.0.0' },
+          },
+          id: 1,
+        }),
+      });
 
       expect(response.status).toBe(200);
-      expect(data.result).toBeDefined();
+      const sessionId = response.headers.get('mcp-session-id');
+      expect(sessionId).toBeTruthy();
+
+      const events = parseSseEvents(await response.text());
+      const result = getResult(events) as Record<string, unknown>;
+      expect(result).toBeDefined();
+      expect((result.serverInfo as { name: string }).name).toBe('productive-mcp');
+    });
+
+    it('should reject non-initialize requests without session ID', async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: { ...sseHeaders, Authorization: `Bearer ${validToken}` },
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 2 }),
+      });
+
+      expect(response.status).toBe(400);
     });
 
     it('should accept token without userId', async () => {
@@ -259,67 +314,57 @@ describe('HTTP Server Integration', () => {
 
       const response = await fetch(`${baseUrl}/mcp`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${tokenWithoutUser}`,
-        },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
+        headers: { ...sseHeaders, Authorization: `Bearer ${tokenWithoutUser}` },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            protocolVersion: '2024-11-05',
+            capabilities: {},
+            clientInfo: { name: 'test', version: '1.0.0' },
+          },
+          id: 1,
+        }),
       });
-      const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.result).toBeDefined();
     });
   });
 
-  describe('POST /mcp - JSON-RPC methods', () => {
-    it('should handle initialize method', async () => {
+  describe('POST /mcp - MCP protocol', () => {
+    it('should handle tools/list', async () => {
+      const sessionId = await initializeSession();
+
       const response = await fetch(`${baseUrl}/mcp`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          ...sseHeaders,
           Authorization: `Bearer ${validToken}`,
-        },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 1 }),
-      });
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.jsonrpc).toBe('2.0');
-      expect(data.id).toBe(1);
-      expect(data.result.protocolVersion).toBe('2024-11-05');
-      expect(data.result.serverInfo.name).toBe('productive-mcp');
-    });
-
-    it('should handle tools/list method', async () => {
-      const response = await fetch(`${baseUrl}/mcp`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${validToken}`,
+          'mcp-session-id': sessionId,
         },
         body: JSON.stringify({ jsonrpc: '2.0', method: 'tools/list', id: 2 }),
       });
-      const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.result.tools).toBeDefined();
-      expect(Array.isArray(data.result.tools)).toBe(true);
+      const events = parseSseEvents(await response.text());
+      const result = getResult(events) as { tools: Array<{ name: string }> };
 
-      // Verify single consolidated tool
-      const productiveTool = data.result.tools.find(
-        (t: { name: string }) => t.name === 'productive',
-      );
+      expect(result.tools).toBeDefined();
+      expect(Array.isArray(result.tools)).toBe(true);
+
+      const productiveTool = result.tools.find((t) => t.name === 'productive');
       expect(productiveTool).toBeDefined();
-      expect(productiveTool.inputSchema).toBeDefined();
     });
 
-    it('should handle tools/call method', async () => {
+    it('should handle tools/call', async () => {
+      const sessionId = await initializeSession();
+
       const response = await fetch(`${baseUrl}/mcp`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          ...sseHeaders,
           Authorization: `Bearer ${validToken}`,
+          'mcp-session-id': sessionId,
         },
         body: JSON.stringify({
           jsonrpc: '2.0',
@@ -331,12 +376,13 @@ describe('HTTP Server Integration', () => {
           id: 3,
         }),
       });
-      const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.result.content).toBeDefined();
+      const events = parseSseEvents(await response.text());
+      const result = getResult(events) as { content: unknown[] };
 
-      // Verify handler was called with correct credentials
+      expect(result.content).toBeDefined();
+
       expect(executeToolWithCredentials).toHaveBeenCalledWith(
         'productive',
         { resource: 'projects', action: 'list', page: 1 },
@@ -348,104 +394,173 @@ describe('HTTP Server Integration', () => {
       );
     });
 
-    it('should return error for unknown method', async () => {
+    it('should handle resources/list', async () => {
+      const sessionId = await initializeSession();
+
       const response = await fetch(`${baseUrl}/mcp`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          ...sseHeaders,
           Authorization: `Bearer ${validToken}`,
+          'mcp-session-id': sessionId,
         },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'unknown/method', id: 4 }),
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'resources/list', id: 10 }),
       });
-      const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.error).toBeDefined();
-      expect(data.error.code).toBe(-32601);
-      expect(data.error.message).toContain('Method not found');
+      const events = parseSseEvents(await response.text());
+      const result = getResult(events) as { resources: unknown[] };
+
+      expect(result.resources).toBeDefined();
+      expect(Array.isArray(result.resources)).toBe(true);
     });
 
-    it('should preserve request id in response', async () => {
+    it('should handle resources/templates/list', async () => {
+      const sessionId = await initializeSession();
+
       const response = await fetch(`${baseUrl}/mcp`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          ...sseHeaders,
           Authorization: `Bearer ${validToken}`,
+          'mcp-session-id': sessionId,
         },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize', id: 'custom-id-123' }),
+        body: JSON.stringify({ jsonrpc: '2.0', method: 'resources/templates/list', id: 11 }),
       });
-      const data = await response.json();
-
-      expect(data.id).toBe('custom-id-123');
-    });
-
-    it('should handle missing id gracefully', async () => {
-      const response = await fetch(`${baseUrl}/mcp`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${validToken}`,
-        },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'initialize' }),
-      });
-      const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.id).toBeNull();
-    });
-  });
+      const events = parseSseEvents(await response.text());
+      const result = getResult(events) as { resourceTemplates: unknown[] };
 
-  describe('POST /mcp - error handling', () => {
-    it('should handle tool execution errors', async () => {
+      expect(result.resourceTemplates).toBeDefined();
+      expect(Array.isArray(result.resourceTemplates)).toBe(true);
+    });
+
+    it('should handle resources/read', async () => {
+      const sessionId = await initializeSession();
+
       const response = await fetch(`${baseUrl}/mcp`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          ...sseHeaders,
           Authorization: `Bearer ${validToken}`,
+          'mcp-session-id': sessionId,
         },
         body: JSON.stringify({
           jsonrpc: '2.0',
-          method: 'tools/call',
-          params: {
-            name: 'failing_tool',
-            arguments: {},
-          },
-          id: 5,
+          method: 'resources/read',
+          params: { uri: 'productive://schema' },
+          id: 12,
         }),
       });
-      const data = await response.json();
 
       expect(response.status).toBe(200);
-      expect(data.error).toBeDefined();
-      expect(data.error.code).toBe(-32603);
-      expect(data.error.message).toContain('Tool execution failed');
+      const events = parseSseEvents(await response.text());
+      const result = getResult(events) as { contents: unknown[] };
+
+      expect(result.contents).toBeDefined();
     });
 
-    it('should handle empty body', async () => {
+    it('should return error for invalid JSON body', async () => {
       const response = await fetch(`${baseUrl}/mcp`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${validToken}`,
-        },
-        body: '',
-      });
-
-      // Should return an error (either 400 or parse error)
-      expect(response.status).toBeGreaterThanOrEqual(200);
-    });
-
-    it('should return parse error for non-JSON body', async () => {
-      const response = await fetch(`${baseUrl}/mcp`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+          ...sseHeaders,
           Authorization: `Bearer ${validToken}`,
         },
         body: 'not valid json {{{',
       });
 
-      expect([200, 400]).toContain(response.status);
+      expect(response.status).toBe(400);
+    });
+
+    it('should return error for empty body', async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: {
+          ...sseHeaders,
+          Authorization: `Bearer ${validToken}`,
+        },
+        body: '',
+      });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('GET /mcp - SSE stream', () => {
+    it('should return 401 without auth header', async () => {
+      const response = await fetch(`${baseUrl}/mcp`);
+      expect(response.status).toBe(401);
+    });
+
+    it('should return 400 without session ID', async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        headers: {
+          Authorization: `Bearer ${validToken}`,
+          Accept: 'text/event-stream',
+        },
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 with invalid session ID', async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        headers: {
+          Authorization: `Bearer ${validToken}`,
+          Accept: 'text/event-stream',
+          'mcp-session-id': 'nonexistent-session',
+        },
+      });
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('DELETE /mcp - session termination', () => {
+    it('should return 401 without auth header', async () => {
+      const response = await fetch(`${baseUrl}/mcp`, { method: 'DELETE' });
+      expect(response.status).toBe(401);
+    });
+
+    it('should return 400 without session ID', async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${validToken}` },
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it('should terminate an existing session', async () => {
+      const sessionId = await initializeSession();
+
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${validToken}`,
+          'mcp-session-id': sessionId,
+        },
+      });
+
+      // Session should be terminated
+      expect([200, 204]).toContain(response.status);
+    });
+  });
+
+  describe('Method not allowed', () => {
+    it('should return 405 for PUT /mcp', async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${validToken}` },
+      });
+      expect(response.status).toBe(405);
+    });
+
+    it('should return 405 for PATCH /mcp', async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: 'PATCH',
+        headers: { Authorization: `Bearer ${validToken}` },
+      });
+      expect(response.status).toBe(405);
     });
   });
 
@@ -457,22 +572,18 @@ describe('HTTP Server Integration', () => {
       expect(response.status).toBe(200);
       expect(data).toHaveProperty('resource');
       expect(data).toHaveProperty('authorization_servers');
-      expect(data).toHaveProperty('scopes_supported');
       expect(data.scopes_supported).toContain('productive');
-      expect(data).toHaveProperty('bearer_methods_supported');
       expect(data.bearer_methods_supported).toContain('header');
     });
 
     it('should include cache-control header', async () => {
       const response = await fetch(`${baseUrl}/.well-known/oauth-protected-resource`);
-
       expect(response.headers.get('cache-control')).toContain('max-age=3600');
     });
 
     it('should include the /mcp resource URL', async () => {
       const response = await fetch(`${baseUrl}/.well-known/oauth-protected-resource`);
       const data = await response.json();
-
       expect(data.resource).toContain('/mcp');
     });
 
@@ -481,220 +592,7 @@ describe('HTTP Server Integration', () => {
         headers: { 'x-forwarded-proto': 'https' },
       });
       const data = await response.json();
-
-      expect(response.status).toBe(200);
-      // Should use the forwarded protocol
       expect(data.authorization_servers[0]).toContain('https://');
-    });
-  });
-
-  describe('GET /mcp/sse', () => {
-    it('should return 401 without auth header', async () => {
-      const response = await fetch(`${baseUrl}/mcp/sse`);
-
-      expect(response.status).toBe(401);
-      const data = await response.json();
-      expect(data).toHaveProperty('error');
-      expect(data.error).toContain('Authentication required');
-    });
-
-    it('should return 401 with invalid token', async () => {
-      const response = await fetch(`${baseUrl}/mcp/sse`, {
-        headers: { Authorization: 'Bearer invalid-token' },
-      });
-
-      expect(response.status).toBe(401);
-    });
-
-    it('should return WWW-Authenticate header on 401 for SSE', async () => {
-      const response = await fetch(`${baseUrl}/mcp/sse`);
-
-      expect(response.status).toBe(401);
-      const wwwAuth = response.headers.get('www-authenticate');
-      expect(wwwAuth).toContain('Bearer');
-      expect(wwwAuth).toContain('oauth-protected-resource');
-    });
-
-    it('should use x-forwarded-proto in WWW-Authenticate URL for SSE', async () => {
-      const response = await fetch(`${baseUrl}/mcp/sse`, {
-        headers: { 'x-forwarded-proto': 'https' },
-      });
-
-      expect(response.status).toBe(401);
-      const wwwAuth = response.headers.get('www-authenticate');
-      expect(wwwAuth).toContain('https://');
-    });
-
-    it('should start SSE stream with valid auth and send session event', async () => {
-      const controller = new AbortController();
-      const { signal } = controller;
-
-      try {
-        const response = await fetch(`${baseUrl}/mcp/sse`, {
-          headers: { Authorization: `Bearer ${validToken}` },
-          signal,
-        });
-
-        expect(response.status).toBe(200);
-        expect(response.headers.get('content-type')).toContain('text/event-stream');
-        expect(response.headers.get('cache-control')).toContain('no-cache');
-
-        // Read first chunk to get session event
-        const reader = response.body!.getReader();
-        const decoder = new TextDecoder();
-        let buffer = '';
-
-        // Read until we get the session event
-        while (!buffer.includes('event: session')) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-        }
-
-        expect(buffer).toContain('event: session');
-        expect(buffer).toContain('sessionId');
-        reader.cancel();
-      } finally {
-        controller.abort();
-      }
-    });
-
-    it('should clean up interval when SSE connection closes', async () => {
-      // Test the close event handler path by aborting after connection
-      const controller = new AbortController();
-
-      const response = await fetch(`${baseUrl}/mcp/sse`, {
-        headers: { Authorization: `Bearer ${validToken}` },
-        signal: controller.signal,
-      });
-
-      expect(response.status).toBe(200);
-      const reader = response.body!.getReader();
-
-      // Read until session event then abort
-      const decoder = new TextDecoder();
-      let buffer = '';
-      while (!buffer.includes('event: session')) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-      }
-
-      // Abort the connection to trigger the close handler
-      reader.cancel();
-      controller.abort();
-
-      // Give the server time to process the close event
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // If we get here without errors, the close handler worked correctly
-      expect(buffer).toContain('sessionId');
-    });
-  });
-
-  describe('POST /mcp - resources methods', () => {
-    it('should handle resources/list method', async () => {
-      const response = await fetch(`${baseUrl}/mcp`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${validToken}`,
-        },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'resources/list', id: 10 }),
-      });
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.result.resources).toBeDefined();
-      expect(Array.isArray(data.result.resources)).toBe(true);
-      expect(listResources).toHaveBeenCalled();
-    });
-
-    it('should handle resources/templates/list method', async () => {
-      const response = await fetch(`${baseUrl}/mcp`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${validToken}`,
-        },
-        body: JSON.stringify({ jsonrpc: '2.0', method: 'resources/templates/list', id: 11 }),
-      });
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.result.resourceTemplates).toBeDefined();
-      expect(Array.isArray(data.result.resourceTemplates)).toBe(true);
-      expect(listResourceTemplates).toHaveBeenCalled();
-    });
-
-    it('should handle resources/read method', async () => {
-      const response = await fetch(`${baseUrl}/mcp`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${validToken}`,
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'resources/read',
-          params: { uri: 'productive://schema' },
-          id: 12,
-        }),
-      });
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.result.contents).toBeDefined();
-      expect(Array.isArray(data.result.contents)).toBe(true);
-      expect(readResource).toHaveBeenCalledWith('productive://schema', {
-        organizationId: 'test-org',
-        apiToken: 'test-token',
-        userId: 'test-user',
-      });
-    });
-
-    it('should return error for resources/read without uri', async () => {
-      const response = await fetch(`${baseUrl}/mcp`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${validToken}`,
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'resources/read',
-          params: {},
-          id: 13,
-        }),
-      });
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.error).toBeDefined();
-      expect(data.error.code).toBe(-32602);
-      expect(data.error.message).toContain('uri is required');
-    });
-
-    it('should return error when readResource throws', async () => {
-      const response = await fetch(`${baseUrl}/mcp`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${validToken}`,
-        },
-        body: JSON.stringify({
-          jsonrpc: '2.0',
-          method: 'resources/read',
-          params: { uri: 'productive://unknown' },
-          id: 14,
-        }),
-      });
-      const data = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(data.error).toBeDefined();
-      expect(data.error.code).toBe(-32603);
-      expect(data.error.message).toContain('Unknown resource URI');
     });
   });
 });

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -1,11 +1,32 @@
 /**
  * HTTP transport handlers for Productive MCP Server
  *
- * This module contains the app/router creation logic for the HTTP transport.
- * The actual server startup is in server.ts.
+ * Uses StreamableHTTPServerTransport from the MCP SDK for spec-compliant
+ * JSON-RPC over HTTP with SSE streaming support.
+ *
+ * Architecture:
+ * - POST/GET/DELETE /mcp → delegated to StreamableHTTPServerTransport
+ * - OAuth, health, metadata endpoints → handled by h3
+ *
+ * Uses stateful mode: one MCP Server + Transport per session.
+ * The session is initialized on the first `initialize` request and reused
+ * for subsequent requests via the `mcp-session-id` header.
  */
 
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ReadResourceRequestSchema,
+  isInitializeRequest,
+} from '@modelcontextprotocol/sdk/types.js';
 import { H3, defineHandler, type H3Event } from 'h3';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import type { ProductiveCredentials } from './auth.js';
 
 import { parseAuthHeader } from './auth.js';
 import { executeToolWithCredentials } from './handlers.js';
@@ -22,54 +43,158 @@ import { TOOLS } from './tools.js';
 import { VERSION } from './version.js';
 
 /**
- * JSON-RPC error response
+ * Extract credentials from AuthInfo extra data.
+ * Returns undefined if credentials are missing or invalid.
  */
-export function jsonRpcError(code: number, message: string, id: string | number | null = null) {
-  return {
-    jsonrpc: '2.0',
-    error: { code, message },
-    id,
-  };
+export function extractCredentials(
+  authInfo: { extra?: Record<string, unknown> } | undefined,
+): ProductiveCredentials | undefined {
+  const extra = authInfo?.extra;
+  if (!extra) return undefined;
+  const { organizationId, apiToken, userId } = extra as Record<string, string>;
+  if (!organizationId || !apiToken) return undefined;
+  return { organizationId, apiToken, userId };
 }
 
 /**
- * JSON-RPC success response
+ * Create and configure the MCP Server for HTTP transport.
+ * Unlike stdio, credentials come from the auth header per-request via authInfo.extra.
  */
-export function jsonRpcSuccess(result: unknown, id: string | number | null = null) {
-  return {
-    jsonrpc: '2.0',
-    result,
-    id,
-  };
-}
-
-/**
- * Handle the initialize JSON-RPC method
- */
-export function handleInitialize() {
-  return {
-    protocolVersion: '2024-11-05',
-    serverInfo: {
+export function createMcpServer(): Server {
+  const server = new Server(
+    {
       name: 'productive-mcp',
       version: VERSION,
     },
-    capabilities: {
-      tools: {},
-      resources: {},
+    {
+      capabilities: {
+        tools: {},
+        resources: {},
+      },
+      instructions: INSTRUCTIONS,
     },
-    instructions: INSTRUCTIONS,
+  );
+
+  // List available tools (HTTP-only, no stdio config tools)
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools: TOOLS };
+  });
+
+  // Handle tool calls — credentials come from authInfo.extra
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    const credentials = extractCredentials(extra.authInfo);
+    if (!credentials) {
+      return {
+        content: [{ type: 'text', text: 'Error: Authentication required' }],
+        isError: true,
+      };
+    }
+
+    const { name, arguments: args } = request.params;
+    try {
+      return await executeToolWithCredentials(
+        name,
+        (args as Record<string, unknown>) || {},
+        credentials,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: 'text', text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  });
+
+  // List resources
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    return { resources: listResources() };
+  });
+
+  // List resource templates
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+    return { resourceTemplates: listResourceTemplates() };
+  });
+
+  // Read a resource
+  server.setRequestHandler(ReadResourceRequestSchema, async (request, extra) => {
+    const credentials = extractCredentials(extra.authInfo);
+    if (!credentials) {
+      throw new Error('Authentication required');
+    }
+    return readResource(request.params.uri, credentials);
+  });
+
+  return server;
+}
+
+/**
+ * Get base URL from request headers (Node.js IncomingMessage)
+ */
+function getBaseUrlFromReq(req: IncomingMessage): string {
+  const host = req.headers['host'] || 'localhost:3000';
+  const protocol = (req.headers['x-forwarded-proto'] as string) || 'http';
+  return `${protocol}://${host}`;
+}
+
+/**
+ * Send a JSON response on a Node.js ServerResponse
+ */
+function sendJson(
+  res: ServerResponse,
+  status: number,
+  data: unknown,
+  headers?: Record<string, string>,
+): void {
+  const body = JSON.stringify(data);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    ...headers,
+  });
+  res.end(body);
+}
+
+/**
+ * Authenticate an incoming request.
+ * Returns credentials on success, or sends a 401 response and returns undefined.
+ */
+function authenticateRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): ProductiveCredentials | undefined {
+  const authHeader = req.headers['authorization'] || null;
+  const credentials = parseAuthHeader(authHeader);
+
+  if (!credentials) {
+    const baseUrl = getBaseUrlFromReq(req);
+    sendJson(res, 401, { error: 'Authentication required' }, {
+      'WWW-Authenticate': `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`,
+    });
+    return undefined;
+  }
+
+  return credentials;
+}
+
+/**
+ * Inject auth credentials into a Node.js request object for the MCP transport.
+ * The SDK passes req.auth through to handler extra.authInfo.
+ */
+function injectAuth(req: IncomingMessage, credentials: ProductiveCredentials): void {
+  (req as IncomingMessage & { auth?: unknown }).auth = {
+    token: req.headers['authorization']?.replace('Bearer ', '') || '',
+    clientId: credentials.organizationId,
+    scopes: ['productive'],
+    extra: {
+      organizationId: credentials.organizationId,
+      apiToken: credentials.apiToken,
+      userId: credentials.userId,
+    },
   };
 }
 
 /**
- * Handle the tools/list JSON-RPC method
- */
-export function handleToolsList() {
-  return { tools: TOOLS };
-}
-
-/**
- * Get base URL from event headers
+ * Get base URL from h3 event headers
  */
 function getBaseUrl(event: H3Event): string {
   const host = event.req.headers.get('host') || 'localhost:3000';
@@ -78,7 +203,8 @@ function getBaseUrl(event: H3Event): string {
 }
 
 /**
- * Create the H3 application with all routes
+ * Create the H3 application with non-MCP routes (OAuth, health, metadata).
+ * MCP routes (POST/GET/DELETE /mcp) are handled separately at the Node.js HTTP level.
  */
 export function createHttpApp(): H3 {
   const app = new H3();
@@ -91,7 +217,6 @@ export function createHttpApp(): H3 {
   app.post('/token', tokenHandler);
 
   // OAuth Protected Resource Metadata (RFC 9728 / MCP spec 2025-03-26)
-  // This endpoint tells clients where to find the authorization server
   app.get(
     '/.well-known/oauth-protected-resource',
     defineHandler((event) => {
@@ -124,146 +249,196 @@ export function createHttpApp(): H3 {
     }),
   );
 
-  // MCP endpoint - handles JSON-RPC over HTTP
-  app.post(
-    '/mcp',
-    defineHandler(async (event) => {
-      // Parse authorization header
-      const authHeader = event.req.headers.get('authorization');
-      const credentials = parseAuthHeader(authHeader);
+  return app;
+}
 
-      if (!credentials) {
-        // RFC 6750: Return WWW-Authenticate header to trigger OAuth flow
-        const baseUrl = getBaseUrl(event);
+/** Map of session ID → transport for active sessions */
+type SessionMap = Map<string, StreamableHTTPServerTransport>;
 
-        event.res.headers.set('Content-Type', 'application/json');
-        event.res.headers.set(
-          'WWW-Authenticate',
-          `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`,
-        );
-        event.res.status = 401;
-        return jsonRpcError(
-          -32001,
-          'Authentication required. Provide Bearer token with base64(organizationId:apiToken:userId)',
-        );
+/**
+ * Handle a POST /mcp request.
+ * Creates a new session on `initialize`, reuses existing sessions otherwise.
+ */
+async function handleMcpPost(
+  req: IncomingMessage,
+  res: ServerResponse,
+  credentials: ProductiveCredentials,
+  sessions: SessionMap,
+): Promise<void> {
+  // Parse the body to check if it's an initialize request
+  const body = await readBody(req);
+  if (!body) {
+    sendJson(res, 400, {
+      jsonrpc: '2.0',
+      error: { code: -32700, message: 'Parse error: Invalid JSON' },
+      id: null,
+    });
+    return;
+  }
+
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+  // Check for existing session
+  if (sessionId && sessions.has(sessionId)) {
+    const transport = sessions.get(sessionId)!;
+    injectAuth(req, credentials);
+    await transport.handleRequest(req, res, body);
+    return;
+  }
+
+  // New session: must be an initialize request
+  if (!isInitializeRequest(body)) {
+    sendJson(res, 400, {
+      jsonrpc: '2.0',
+      error: {
+        code: -32000,
+        message: 'Bad Request: No valid session ID provided, and this is not an initialization request',
+      },
+      id: null,
+    });
+    return;
+  }
+
+  // Create new transport and server for this session
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => crypto.randomUUID(),
+    onsessioninitialized: (sid: string) => {
+      sessions.set(sid, transport);
+    },
+  });
+
+  transport.onclose = () => {
+    const sid = transport.sessionId;
+    if (sid) sessions.delete(sid);
+  };
+
+  const server = createMcpServer();
+  await server.connect(transport);
+
+  injectAuth(req, credentials);
+  await transport.handleRequest(req, res, body);
+}
+
+/**
+ * Handle a GET /mcp request (SSE stream for server-initiated notifications).
+ */
+async function handleMcpGet(
+  req: IncomingMessage,
+  res: ServerResponse,
+  credentials: ProductiveCredentials,
+  sessions: SessionMap,
+): Promise<void> {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+  if (!sessionId || !sessions.has(sessionId)) {
+    sendJson(res, 400, { error: 'Invalid or missing session ID' });
+    return;
+  }
+
+  const transport = sessions.get(sessionId)!;
+  injectAuth(req, credentials);
+  await transport.handleRequest(req, res);
+}
+
+/**
+ * Handle a DELETE /mcp request (session termination).
+ */
+async function handleMcpDelete(
+  req: IncomingMessage,
+  res: ServerResponse,
+  credentials: ProductiveCredentials,
+  sessions: SessionMap,
+): Promise<void> {
+  const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+  if (!sessionId || !sessions.has(sessionId)) {
+    sendJson(res, 400, { error: 'Invalid or missing session ID' });
+    return;
+  }
+
+  const transport = sessions.get(sessionId)!;
+  injectAuth(req, credentials);
+  await transport.handleRequest(req, res);
+}
+
+/**
+ * Read and parse the request body as JSON.
+ */
+function readBody(req: IncomingMessage): Promise<unknown | null> {
+  return new Promise((resolve) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (chunk: Buffer) => chunks.push(chunk));
+    req.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf-8');
+      if (!raw) {
+        resolve(null);
+        return;
       }
-
-      event.res.headers.set('Content-Type', 'application/json');
-
-      // Parse JSON-RPC request
-      let body: { method?: string; params?: unknown; id?: string | number } | undefined;
       try {
-        body = await event.req.json();
+        resolve(JSON.parse(raw));
       } catch {
-        event.res.status = 400;
-        return jsonRpcError(-32700, 'Parse error: Invalid JSON');
+        resolve(null);
       }
+    });
+    req.on('error', () => resolve(null));
+  });
+}
 
-      if (!body || typeof body !== 'object') {
-        event.res.status = 400;
-        return jsonRpcError(-32700, 'Parse error: Invalid JSON');
-      }
+/**
+ * Create a Node.js HTTP request handler that routes between MCP transport and h3.
+ *
+ * - POST/GET/DELETE /mcp → StreamableHTTPServerTransport (MCP SDK)
+ * - Everything else → h3 (OAuth, health, metadata)
+ */
+export function createHttpHandler(): (req: IncomingMessage, res: ServerResponse) => void {
+  const app = createHttpApp();
+  const sessions: SessionMap = new Map();
 
-      const { method, params, id } = body;
+  // h3 handler for non-MCP routes
+  let h3Handler: ((req: IncomingMessage, res: ServerResponse) => void) | null = null;
+  const getH3Handler = async () => {
+    if (!h3Handler) {
+      const { toNodeHandler } = await import('h3');
+      h3Handler = toNodeHandler(app);
+    }
+    return h3Handler;
+  };
+
+  return async (req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url || '/';
+    const method = req.method || 'GET';
+
+    // Route MCP requests to StreamableHTTPServerTransport
+    if (url === '/mcp' || url.startsWith('/mcp?')) {
+      // Authenticate first
+      const credentials = authenticateRequest(req, res);
+      if (!credentials) return;
 
       try {
-        if (method === 'initialize') {
-          return jsonRpcSuccess(handleInitialize(), id ?? null);
+        if (method === 'POST') {
+          await handleMcpPost(req, res, credentials, sessions);
+        } else if (method === 'GET') {
+          await handleMcpGet(req, res, credentials, sessions);
+        } else if (method === 'DELETE') {
+          await handleMcpDelete(req, res, credentials, sessions);
+        } else {
+          sendJson(res, 405, { error: 'Method not allowed' });
         }
-
-        if (method === 'tools/list') {
-          return jsonRpcSuccess(handleToolsList(), id ?? null);
-        }
-
-        if (method === 'tools/call') {
-          const { name, arguments: args } = params as {
-            name: string;
-            arguments?: Record<string, unknown>;
-          };
-          const result = await executeToolWithCredentials(name, args || {}, credentials);
-          return jsonRpcSuccess(result, id ?? null);
-        }
-
-        if (method === 'resources/list') {
-          return jsonRpcSuccess({ resources: listResources() }, id ?? null);
-        }
-
-        if (method === 'resources/templates/list') {
-          return jsonRpcSuccess({ resourceTemplates: listResourceTemplates() }, id ?? null);
-        }
-
-        if (method === 'resources/read') {
-          const { uri } = (params as { uri: string }) ?? {};
-          if (!uri) {
-            return jsonRpcError(-32602, 'Invalid params: uri is required', id ?? null);
-          }
-          const result = await readResource(uri, credentials);
-          return jsonRpcSuccess(result, id ?? null);
-        }
-
-        // Unknown method
-        return jsonRpcError(-32601, `Method not found: ${method}`, id ?? null);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        return jsonRpcError(-32603, `Internal error: ${message}`, id ?? null);
+        if (!res.headersSent) {
+          sendJson(res, 500, {
+            jsonrpc: '2.0',
+            error: { code: -32603, message: `Internal error: ${message}` },
+            id: null,
+          });
+        }
       }
-    }),
-  );
+      return;
+    }
 
-  // SSE endpoint for server-sent events (optional, for streaming responses)
-  app.get(
-    '/mcp/sse',
-    defineHandler(async (event) => {
-      const authHeader = event.req.headers.get('authorization');
-      const credentials = parseAuthHeader(authHeader);
-
-      if (!credentials) {
-        // RFC 6750: Return WWW-Authenticate header to trigger OAuth flow
-        const baseUrl = getBaseUrl(event);
-
-        event.res.headers.set(
-          'WWW-Authenticate',
-          `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`,
-        );
-        event.res.status = 401;
-        return { error: 'Authentication required' };
-      }
-
-      // Node.js-specific SSE: access raw res for streaming
-      const nodeRuntime = event.runtime?.node;
-      const nodeRes = nodeRuntime?.res as import('node:http').ServerResponse | undefined;
-      if (!nodeRes) {
-        event.res.status = 501;
-        return { error: 'SSE requires Node.js runtime' };
-      }
-
-      // Write SSE headers directly to Node.js response (bypassing h3's pipeline)
-      nodeRes.writeHead(200, {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        Connection: 'keep-alive',
-      });
-
-      // Generate session ID and send it
-      const sessionId = crypto.randomUUID();
-
-      // Send initial session event
-      nodeRes.write(`event: session\ndata: ${JSON.stringify({ sessionId })}\n\n`);
-
-      // Keep connection alive
-      const keepAlive = setInterval(() => {
-        nodeRes.write(': keepalive\n\n');
-      }, 30000);
-
-      // Clean up on close
-      nodeRuntime?.req.on('close', () => {
-        clearInterval(keepAlive);
-      });
-
-      // Don't end the response - keep it open for SSE
-      return new Promise(() => {});
-    }),
-  );
-
-  return app;
+    // Everything else goes to h3
+    const handler = await getH3Handler();
+    handler(req, res);
+  };
 }

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -3,7 +3,9 @@
 /**
  * Productive MCP Server - HTTP Transport
  *
- * This is the remote HTTP server mode for Claude Desktop custom connectors.
+ * Uses StreamableHTTPServerTransport from the MCP SDK for spec-compliant
+ * JSON-RPC over HTTP with SSE streaming support.
+ *
  * Credentials are passed via Bearer token in the Authorization header.
  *
  * Token format: base64(organizationId:apiToken) or base64(organizationId:apiToken:userId)
@@ -14,17 +16,11 @@
  * Usage:
  *   productive-mcp-server
  *   PORT=3000 productive-mcp-server
- *
- * Claude Desktop custom connector config:
- *   Name: Productive
- *   URL: https://productive.mcp.ikko.dev
- *   (No OAuth needed - uses Bearer token)
  */
 
-import { toNodeHandler } from 'h3';
 import { createServer, type Server } from 'node:http';
 
-import { createHttpApp } from './http.js';
+import { createHttpHandler } from './http.js';
 import { VERSION } from './version.js';
 
 const DEFAULT_PORT = 3000;
@@ -38,8 +34,8 @@ export function startHttpServer(
   host: string = DEFAULT_HOST,
 ): Promise<Server> {
   return new Promise((resolve) => {
-    const app = createHttpApp();
-    const server = createServer(toNodeHandler(app));
+    const handler = createHttpHandler();
+    const server = createServer(handler);
 
     server.listen(port, host, () => {
       const displayHost = host === '0.0.0.0' ? 'localhost' : host;
@@ -49,8 +45,10 @@ export function startHttpServer(
       console.log(`Running at http://${displayHost}:${port}`);
       console.log('');
       console.log('Endpoints:');
-      console.log(`  POST http://${displayHost}:${port}/mcp - MCP JSON-RPC endpoint`);
-      console.log(`  GET  http://${displayHost}:${port}/health - Health check`);
+      console.log(`  POST   http://${displayHost}:${port}/mcp - MCP JSON-RPC (SSE streaming)`);
+      console.log(`  GET    http://${displayHost}:${port}/mcp - SSE stream (server notifications)`);
+      console.log(`  DELETE http://${displayHost}:${port}/mcp - Session termination`);
+      console.log(`  GET    http://${displayHost}:${port}/health - Health check`);
       console.log('');
       console.log('OAuth 2.0 (MCP auth spec compliant):');
       console.log(`  GET  http://${displayHost}:${port}/.well-known/oauth-authorization-server`);


### PR DESCRIPTION
Closes #140

## Summary

Replace the custom JSON-RPC over HTTP implementation (~100 lines of manual method dispatch) with the MCP SDK's `StreamableHTTPServerTransport` for spec-compliant Streamable HTTP transport.

## Changes

### `packages/mcp/src/http.ts` (rewritten)
- **Remove** custom `jsonRpcError()`, `jsonRpcSuccess()`, `handleInitialize()`, `handleToolsList()` helpers
- **Remove** manual JSON-RPC method routing (initialize, tools/list, tools/call, resources/*)
- **Remove** custom SSE endpoint (`/mcp/sse`) — replaced by built-in SSE in StreamableHTTP
- **Add** `createMcpServer()` — creates an MCP SDK `Server` with tool/resource handlers that extract credentials from `authInfo.extra`
- **Add** session-based stateful transport: one `Server` + `StreamableHTTPServerTransport` per session
- **Add** `handleMcpPost/Get/Delete()` — route POST/GET/DELETE /mcp to the transport
- **Keep** h3 for OAuth, health, metadata endpoints (unchanged)

### `packages/mcp/src/server.ts` (simplified)
- Use `createHttpHandler()` directly with `createServer()` instead of h3's `toNodeHandler`
- Update endpoint documentation in startup logs (POST/GET/DELETE /mcp)

### Protocol & Architecture
- **Protocol version**: `2024-11-05` (StreamableHTTP spec)
- **Stateful sessions**: `mcp-session-id` header for request routing, `crypto.randomUUID()` for session IDs
- **Auth flow**: credentials injected via `req.auth` → passed through `authInfo.extra` to handlers
- **SSE streaming**: built-in via SDK (responses streamed as SSE events)

### Decisions
- **Stateful mode** chosen over stateless: the SDK transport requires MCP initialization handshake per session, and stateful mode avoids re-initialization overhead on every request
- **Keep h3** for non-MCP routes: OAuth, health check, protected resource metadata are not MCP protocol and don't need the SDK transport