### PR TITLE
Update shell completions to include all current resources

### DIFF
--- a/packages/cli/src/commands/completion.test.ts
+++ b/packages/cli/src/commands/completion.test.ts
@@ -1,0 +1,272 @@
+/**
+ * Tests for completion command
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { handleCompletionCommand, showCompletionHelp } from './completion.js';
+
+// Mock node:fs module
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  chmodSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+// Mock node:os module
+vi.mock('node:os', () => ({
+  homedir: vi.fn().mockReturnValue('/mock/home'),
+}));
+
+// Mock colors
+vi.mock('../utils/colors.js', () => ({
+  colors: {
+    red: (str: string) => str,
+    green: (str: string) => str,
+    cyan: (str: string) => str,
+    bold: (str: string) => str,
+  },
+}));
+
+describe('completion command', () => {
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    const fs = await import('node:fs');
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.mkdirSync).mockImplementation(() => '');
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+    vi.mocked(fs.chmodSync).mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('showCompletionHelp', () => {
+    it('should display help information', () => {
+      showCompletionHelp();
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('productive completion'));
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Install shell completion'),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('bash'));
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('zsh'));
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('fish'));
+    });
+  });
+
+  describe('handleCompletionCommand', () => {
+    it('should show help when no shell specified', () => {
+      handleCompletionCommand([]);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('productive completion'));
+    });
+
+    it('should show help when help requested', () => {
+      handleCompletionCommand(['help']);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('productive completion'));
+    });
+
+    it('should print bash completion script when --print flag used', () => {
+      handleCompletionCommand(['bash'], { print: true });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('_productive_completions'),
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'config projects p time t tasks people services svc companies comments attachments timers deals bookings pages discussions activities custom-fields reports resolve cache api completion help',
+        ),
+      );
+    });
+
+    it('should print zsh completion script when --print flag used', () => {
+      handleCompletionCommand(['zsh'], { print: true });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('#compdef productive'));
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('_productive'));
+    });
+
+    it('should print fish completion script when --print flag used', () => {
+      handleCompletionCommand(['fish'], { print: true });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('complete -c productive'));
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"Manage CLI configuration"'),
+      );
+    });
+
+    it('should exit with error for unknown shell', () => {
+      handleCompletionCommand(['unknown']);
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Unknown shell: unknown'),
+      );
+    });
+
+    it('should install bash completion to user directory', async () => {
+      const fs = await import('node:fs');
+      vi.mocked(fs.existsSync).mockReturnValue(false); // No system dirs exist
+
+      // Clear all previous calls
+      vi.mocked(fs.mkdirSync).mockClear();
+      vi.mocked(fs.writeFileSync).mockClear();
+      vi.mocked(fs.chmodSync).mockClear();
+
+      handleCompletionCommand(['bash']);
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith(
+        '/mock/home/.local/share/bash-completion/completions',
+        { recursive: true },
+      );
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/mock/home/.local/share/bash-completion/completions/productive',
+        expect.stringContaining('_productive_completions'),
+        'utf8',
+      );
+      expect(fs.chmodSync).toHaveBeenCalledWith(
+        '/mock/home/.local/share/bash-completion/completions/productive',
+        0o755,
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Installed bash completion'),
+      );
+    });
+
+    it('should install zsh completion to user directory', async () => {
+      const fs = await import('node:fs');
+      vi.mocked(fs.existsSync).mockReturnValue(false); // No system dirs exist
+
+      // Clear all previous calls
+      vi.mocked(fs.mkdirSync).mockClear();
+      vi.mocked(fs.writeFileSync).mockClear();
+
+      handleCompletionCommand(['zsh']);
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith('/mock/home/.local/share/zsh/site-functions', {
+        recursive: true,
+      });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/mock/home/.local/share/zsh/site-functions/_productive',
+        expect.stringContaining('#compdef productive'),
+        'utf8',
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Installed zsh completion'),
+      );
+    });
+
+    it('should install fish completion to XDG config directory', async () => {
+      const fs = await import('node:fs');
+
+      // Clear all previous calls and mock XDG_CONFIG_HOME to be unset
+      vi.mocked(fs.mkdirSync).mockClear();
+      vi.mocked(fs.writeFileSync).mockClear();
+      const originalXDG = process.env.XDG_CONFIG_HOME;
+      delete process.env.XDG_CONFIG_HOME;
+
+      handleCompletionCommand(['fish']);
+
+      expect(fs.mkdirSync).toHaveBeenCalledWith('/mock/home/.config/fish/completions', {
+        recursive: true,
+      });
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        '/mock/home/.config/fish/completions/productive.fish',
+        expect.stringContaining('complete -c productive'),
+        'utf8',
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Installed fish completion'),
+      );
+
+      // Restore original env var
+      if (originalXDG) {
+        process.env.XDG_CONFIG_HOME = originalXDG;
+      }
+    });
+
+    it('should handle write errors gracefully', async () => {
+      const fs = await import('node:fs');
+
+      // Clear all previous calls and setup error
+      vi.mocked(fs.mkdirSync).mockClear();
+      vi.mocked(fs.writeFileSync).mockClear();
+      vi.mocked(fs.writeFileSync).mockImplementation(() => {
+        throw new Error('Permission denied');
+      });
+
+      handleCompletionCommand(['bash']);
+
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to install completion'),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Permission denied'));
+    });
+
+    it('should include all current resources in bash completion', () => {
+      handleCompletionCommand(['bash'], { print: true });
+
+      const expectedResources = [
+        'config',
+        'projects',
+        'p',
+        'time',
+        't',
+        'tasks',
+        'people',
+        'services',
+        'svc',
+        'companies',
+        'comments',
+        'attachments',
+        'timers',
+        'deals',
+        'bookings',
+        'pages',
+        'discussions',
+        'activities',
+        'custom-fields',
+        'reports',
+        'resolve',
+        'cache',
+        'api',
+        'completion',
+        'help',
+      ];
+
+      const output = consoleLogSpy.mock.calls.map((call) => call[0]).join('\\n');
+      expectedResources.forEach((resource) => {
+        expect(output).toContain(resource);
+      });
+    });
+
+    it('should include all current subcommands in completion', () => {
+      handleCompletionCommand(['bash'], { print: true });
+
+      const output = consoleLogSpy.mock.calls.map((call) => call[0]).join('\\n');
+
+      // Check for key subcommands
+      expect(output).toContain('local tasks_cmds="list ls get add create update"');
+      expect(output).toContain(
+        'local discussions_cmds="list ls get add create update delete rm resolve reopen"',
+      );
+      expect(output).toContain('local timers_cmds="list ls get start stop"');
+      expect(output).toContain('local attachments_cmds="list ls get delete rm"');
+      expect(output).toContain('local activities_cmds="list ls"');
+      expect(output).toContain('local resolve_cmds="detect"');
+    });
+  });
+});

--- a/packages/cli/src/commands/completion.ts
+++ b/packages/cli/src/commands/completion.ts
@@ -18,15 +18,27 @@ _productive_completions() {
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
 
   # Main commands
-  commands="config projects p time t tasks people services svc cache api completion help"
+  commands="config projects p time t tasks people services svc companies comments attachments timers deals bookings pages discussions activities custom-fields reports resolve cache api completion help"
 
   # Subcommands for each command
   local config_cmds="set get validate clear"
   local projects_cmds="list ls get"
   local time_cmds="list ls get add update delete"
-  local tasks_cmds="list ls get"
+  local tasks_cmds="list ls get add create update"
   local people_cmds="list ls get"
   local services_cmds="list ls"
+  local companies_cmds="list ls get add update"
+  local comments_cmds="list ls get add update"
+  local attachments_cmds="list ls get delete rm"
+  local timers_cmds="list ls get start stop"
+  local deals_cmds="list ls get add create update"
+  local bookings_cmds="list ls get add update"
+  local pages_cmds="list ls get add update delete"
+  local discussions_cmds="list ls get add create update delete rm resolve reopen"
+  local activities_cmds="list ls"
+  local custom_fields_cmds="list ls get"
+  local reports_cmds="time project projects budget budgets person people invoice invoices payment payments service services task tasks company companies deal deals timesheet timesheets"
+  local resolve_cmds="detect"
   local cache_cmds="status clear"
   local completion_cmds="bash zsh fish"
 
@@ -68,6 +80,42 @@ _productive_completions() {
           ;;
         services|svc)
           COMPREPLY=( \$(compgen -W "\${services_cmds}" -- "\${cur}") )
+          ;;
+        companies)
+          COMPREPLY=( \$(compgen -W "\${companies_cmds}" -- "\${cur}") )
+          ;;
+        comments)
+          COMPREPLY=( \$(compgen -W "\${comments_cmds}" -- "\${cur}") )
+          ;;
+        attachments)
+          COMPREPLY=( \$(compgen -W "\${attachments_cmds}" -- "\${cur}") )
+          ;;
+        timers)
+          COMPREPLY=( \$(compgen -W "\${timers_cmds}" -- "\${cur}") )
+          ;;
+        deals)
+          COMPREPLY=( \$(compgen -W "\${deals_cmds}" -- "\${cur}") )
+          ;;
+        bookings)
+          COMPREPLY=( \$(compgen -W "\${bookings_cmds}" -- "\${cur}") )
+          ;;
+        pages)
+          COMPREPLY=( \$(compgen -W "\${pages_cmds}" -- "\${cur}") )
+          ;;
+        discussions)
+          COMPREPLY=( \$(compgen -W "\${discussions_cmds}" -- "\${cur}") )
+          ;;
+        activities)
+          COMPREPLY=( \$(compgen -W "\${activities_cmds}" -- "\${cur}") )
+          ;;
+        custom-fields)
+          COMPREPLY=( \$(compgen -W "\${custom_fields_cmds}" -- "\${cur}") )
+          ;;
+        reports)
+          COMPREPLY=( \$(compgen -W "\${reports_cmds}" -- "\${cur}") )
+          ;;
+        resolve)
+          COMPREPLY=( \$(compgen -W "\${resolve_cmds}" -- "\${cur}") )
           ;;
         cache)
           COMPREPLY=( \$(compgen -W "\${cache_cmds}" -- "\${cur}") )
@@ -165,6 +213,18 @@ _productive() {
         'people:Manage people'
         'services:Manage services'
         'svc:Manage services (alias)'
+        'companies:Manage companies (clients)'
+        'comments:Manage comments'
+        'attachments:Manage attachments'
+        'timers:Manage timers (real-time tracking)'
+        'deals:Manage deals and budgets'
+        'bookings:Manage resource bookings'
+        'pages:Manage pages (docs)'
+        'discussions:Manage discussions on pages'
+        'activities:View activity feed (read-only audit log)'
+        'custom-fields:Manage custom field definitions'
+        'reports:Generate reports'
+        'resolve:Resolve human-friendly identifiers to IDs'
         'cache:Manage CLI cache'
         'api:Make custom API requests'
         'completion:Generate shell completion script'
@@ -211,6 +271,9 @@ _productive() {
             'list:List tasks'
             'ls:List tasks (alias)'
             'get:Get task details'
+            'add:Create task'
+            'create:Create task (alias)'
+            'update:Update task'
           )
           _describe 'tasks command' tasks_cmds
           ;;
@@ -230,6 +293,152 @@ _productive() {
             'ls:List services (alias)'
           )
           _describe 'services command' services_cmds
+          ;;
+        companies)
+          local -a companies_cmds
+          companies_cmds=(
+            'list:List companies'
+            'ls:List companies (alias)'
+            'get:Get company details'
+            'add:Create company'
+            'update:Update company'
+          )
+          _describe 'companies command' companies_cmds
+          ;;
+        comments)
+          local -a comments_cmds
+          comments_cmds=(
+            'list:List comments'
+            'ls:List comments (alias)'
+            'get:Get comment details'
+            'add:Add a comment'
+            'update:Update comment'
+          )
+          _describe 'comments command' comments_cmds
+          ;;
+        attachments)
+          local -a attachments_cmds
+          attachments_cmds=(
+            'list:List attachments'
+            'ls:List attachments (alias)'
+            'get:Get attachment details'
+            'delete:Delete an attachment'
+            'rm:Delete an attachment (alias)'
+          )
+          _describe 'attachments command' attachments_cmds
+          ;;
+        timers)
+          local -a timers_cmds
+          timers_cmds=(
+            'list:List timers'
+            'ls:List timers (alias)'
+            'get:Get timer details'
+            'start:Start a timer'
+            'stop:Stop a timer'
+          )
+          _describe 'timers command' timers_cmds
+          ;;
+        deals)
+          local -a deals_cmds
+          deals_cmds=(
+            'list:List deals (use --budget for budgets only)'
+            'ls:List deals (alias)'
+            'get:Get deal/budget details'
+            'add:Create deal/budget (use --budget for budgets)'
+            'create:Create deal/budget (alias)'
+            'update:Update deal'
+          )
+          _describe 'deals command' deals_cmds
+          ;;
+        bookings)
+          local -a bookings_cmds
+          bookings_cmds=(
+            'list:List bookings'
+            'ls:List bookings (alias)'
+            'get:Get booking details'
+            'add:Create booking'
+            'update:Update booking'
+          )
+          _describe 'bookings command' bookings_cmds
+          ;;
+        pages)
+          local -a pages_cmds
+          pages_cmds=(
+            'list:List pages'
+            'ls:List pages (alias)'
+            'get:Get page details'
+            'add:Create page'
+            'update:Update page'
+            'delete:Delete page'
+          )
+          _describe 'pages command' pages_cmds
+          ;;
+        discussions)
+          local -a discussions_cmds
+          discussions_cmds=(
+            'list:List discussions'
+            'ls:List discussions (alias)'
+            'get:Get discussion details'
+            'add:Create discussion'
+            'create:Create discussion (alias)'
+            'update:Update discussion'
+            'delete:Delete discussion'
+            'rm:Delete discussion (alias)'
+            'resolve:Resolve discussion'
+            'reopen:Reopen discussion'
+          )
+          _describe 'discussions command' discussions_cmds
+          ;;
+        activities)
+          local -a activities_cmds
+          activities_cmds=(
+            'list:List recent activities'
+            'ls:List recent activities (alias)'
+          )
+          _describe 'activities command' activities_cmds
+          ;;
+        custom-fields)
+          local -a custom_fields_cmds
+          custom_fields_cmds=(
+            'list:List custom field definitions'
+            'ls:List custom field definitions (alias)'
+            'get:Get a custom field with its options'
+          )
+          _describe 'custom-fields command' custom_fields_cmds
+          ;;
+        reports)
+          local -a reports_cmds
+          reports_cmds=(
+            'time:Time reports'
+            'project:Project reports'
+            'projects:Project reports (alias)'
+            'budget:Budget reports'
+            'budgets:Budget reports (alias)'
+            'person:Person reports'
+            'people:Person reports (alias)'
+            'invoice:Invoice reports'
+            'invoices:Invoice reports (alias)'
+            'payment:Payment reports'
+            'payments:Payment reports (alias)'
+            'service:Service reports'
+            'services:Service reports (alias)'
+            'task:Task reports'
+            'tasks:Task reports (alias)'
+            'company:Company reports'
+            'companies:Company reports (alias)'
+            'deal:Deal reports'
+            'deals:Deal reports (alias)'
+            'timesheet:Timesheet reports'
+            'timesheets:Timesheet reports (alias)'
+          )
+          _describe 'reports command' reports_cmds
+          ;;
+        resolve)
+          local -a resolve_cmds
+          resolve_cmds=(
+            'detect:Detect resource type from pattern'
+          )
+          _describe 'resolve command' resolve_cmds
           ;;
         cache)
           local -a cache_cmds
@@ -344,6 +553,18 @@ complete -c productive -f -n "__fish_use_subcommand" -a "tasks" -d "Manage tasks
 complete -c productive -f -n "__fish_use_subcommand" -a "people" -d "Manage people"
 complete -c productive -f -n "__fish_use_subcommand" -a "services" -d "Manage services"
 complete -c productive -f -n "__fish_use_subcommand" -a "svc" -d "Manage services (alias)"
+complete -c productive -f -n "__fish_use_subcommand" -a "companies" -d "Manage companies (clients)"
+complete -c productive -f -n "__fish_use_subcommand" -a "comments" -d "Manage comments"
+complete -c productive -f -n "__fish_use_subcommand" -a "attachments" -d "Manage attachments"
+complete -c productive -f -n "__fish_use_subcommand" -a "timers" -d "Manage timers (real-time tracking)"
+complete -c productive -f -n "__fish_use_subcommand" -a "deals" -d "Manage deals and budgets"
+complete -c productive -f -n "__fish_use_subcommand" -a "bookings" -d "Manage resource bookings"
+complete -c productive -f -n "__fish_use_subcommand" -a "pages" -d "Manage pages (docs)"
+complete -c productive -f -n "__fish_use_subcommand" -a "discussions" -d "Manage discussions on pages"
+complete -c productive -f -n "__fish_use_subcommand" -a "activities" -d "View activity feed (read-only audit log)"
+complete -c productive -f -n "__fish_use_subcommand" -a "custom-fields" -d "Manage custom field definitions"
+complete -c productive -f -n "__fish_use_subcommand" -a "reports" -d "Generate reports"
+complete -c productive -f -n "__fish_use_subcommand" -a "resolve" -d "Resolve human-friendly identifiers to IDs"
 complete -c productive -f -n "__fish_use_subcommand" -a "cache" -d "Manage CLI cache"
 complete -c productive -f -n "__fish_use_subcommand" -a "api" -d "Make custom API requests"
 complete -c productive -f -n "__fish_use_subcommand" -a "completion" -d "Generate shell completion script"
@@ -372,6 +593,9 @@ complete -c productive -f -n "__fish_seen_subcommand_from time t" -a "delete" -d
 complete -c productive -f -n "__fish_seen_subcommand_from tasks" -a "list" -d "List tasks"
 complete -c productive -f -n "__fish_seen_subcommand_from tasks" -a "ls" -d "List tasks (alias)"
 complete -c productive -f -n "__fish_seen_subcommand_from tasks" -a "get" -d "Get task details"
+complete -c productive -f -n "__fish_seen_subcommand_from tasks" -a "add" -d "Create task"
+complete -c productive -f -n "__fish_seen_subcommand_from tasks" -a "create" -d "Create task (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from tasks" -a "update" -d "Update task"
 
 # People subcommands
 complete -c productive -f -n "__fish_seen_subcommand_from people" -a "list" -d "List people"
@@ -381,6 +605,104 @@ complete -c productive -f -n "__fish_seen_subcommand_from people" -a "get" -d "G
 # Services subcommands
 complete -c productive -f -n "__fish_seen_subcommand_from services svc" -a "list" -d "List services"
 complete -c productive -f -n "__fish_seen_subcommand_from services svc" -a "ls" -d "List services (alias)"
+
+# Companies subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from companies" -a "list" -d "List companies"
+complete -c productive -f -n "__fish_seen_subcommand_from companies" -a "ls" -d "List companies (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from companies" -a "get" -d "Get company details"
+complete -c productive -f -n "__fish_seen_subcommand_from companies" -a "add" -d "Create company"
+complete -c productive -f -n "__fish_seen_subcommand_from companies" -a "update" -d "Update company"
+
+# Comments subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from comments" -a "list" -d "List comments"
+complete -c productive -f -n "__fish_seen_subcommand_from comments" -a "ls" -d "List comments (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from comments" -a "get" -d "Get comment details"
+complete -c productive -f -n "__fish_seen_subcommand_from comments" -a "add" -d "Add a comment"
+complete -c productive -f -n "__fish_seen_subcommand_from comments" -a "update" -d "Update comment"
+
+# Attachments subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from attachments" -a "list" -d "List attachments"
+complete -c productive -f -n "__fish_seen_subcommand_from attachments" -a "ls" -d "List attachments (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from attachments" -a "get" -d "Get attachment details"
+complete -c productive -f -n "__fish_seen_subcommand_from attachments" -a "delete" -d "Delete an attachment"
+complete -c productive -f -n "__fish_seen_subcommand_from attachments" -a "rm" -d "Delete an attachment (alias)"
+
+# Timers subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from timers" -a "list" -d "List timers"
+complete -c productive -f -n "__fish_seen_subcommand_from timers" -a "ls" -d "List timers (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from timers" -a "get" -d "Get timer details"
+complete -c productive -f -n "__fish_seen_subcommand_from timers" -a "start" -d "Start a timer"
+complete -c productive -f -n "__fish_seen_subcommand_from timers" -a "stop" -d "Stop a timer"
+
+# Deals subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from deals" -a "list" -d "List deals (use --budget for budgets only)"
+complete -c productive -f -n "__fish_seen_subcommand_from deals" -a "ls" -d "List deals (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from deals" -a "get" -d "Get deal/budget details"
+complete -c productive -f -n "__fish_seen_subcommand_from deals" -a "add" -d "Create deal/budget (use --budget for budgets)"
+complete -c productive -f -n "__fish_seen_subcommand_from deals" -a "create" -d "Create deal/budget (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from deals" -a "update" -d "Update deal"
+
+# Bookings subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from bookings" -a "list" -d "List bookings"
+complete -c productive -f -n "__fish_seen_subcommand_from bookings" -a "ls" -d "List bookings (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from bookings" -a "get" -d "Get booking details"
+complete -c productive -f -n "__fish_seen_subcommand_from bookings" -a "add" -d "Create booking"
+complete -c productive -f -n "__fish_seen_subcommand_from bookings" -a "update" -d "Update booking"
+
+# Pages subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from pages" -a "list" -d "List pages"
+complete -c productive -f -n "__fish_seen_subcommand_from pages" -a "ls" -d "List pages (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from pages" -a "get" -d "Get page details"
+complete -c productive -f -n "__fish_seen_subcommand_from pages" -a "add" -d "Create page"
+complete -c productive -f -n "__fish_seen_subcommand_from pages" -a "update" -d "Update page"
+complete -c productive -f -n "__fish_seen_subcommand_from pages" -a "delete" -d "Delete page"
+
+# Discussions subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from discussions" -a "list" -d "List discussions"
+complete -c productive -f -n "__fish_seen_subcommand_from discussions" -a "ls" -d "List discussions (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from discussions" -a "get" -d "Get discussion details"
+complete -c productive -f -n "__fish_seen_subcommand_from discussions" -a "add" -d "Create discussion"
+complete -c productive -f -n "__fish_seen_subcommand_from discussions" -a "create" -d "Create discussion (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from discussions" -a "update" -d "Update discussion"
+complete -c productive -f -n "__fish_seen_subcommand_from discussions" -a "delete" -d "Delete discussion"
+complete -c productive -f -n "__fish_seen_subcommand_from discussions" -a "rm" -d "Delete discussion (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from discussions" -a "resolve" -d "Resolve discussion"
+complete -c productive -f -n "__fish_seen_subcommand_from discussions" -a "reopen" -d "Reopen discussion"
+
+# Activities subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from activities" -a "list" -d "List recent activities"
+complete -c productive -f -n "__fish_seen_subcommand_from activities" -a "ls" -d "List recent activities (alias)"
+
+# Custom fields subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from custom-fields" -a "list" -d "List custom field definitions"
+complete -c productive -f -n "__fish_seen_subcommand_from custom-fields" -a "ls" -d "List custom field definitions (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from custom-fields" -a "get" -d "Get a custom field with its options"
+
+# Reports subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "time" -d "Time reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "project" -d "Project reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "projects" -d "Project reports (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "budget" -d "Budget reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "budgets" -d "Budget reports (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "person" -d "Person reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "people" -d "Person reports (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "invoice" -d "Invoice reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "invoices" -d "Invoice reports (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "payment" -d "Payment reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "payments" -d "Payment reports (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "service" -d "Service reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "services" -d "Service reports (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "task" -d "Task reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "tasks" -d "Task reports (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "company" -d "Company reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "companies" -d "Company reports (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "deal" -d "Deal reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "deals" -d "Deal reports (alias)"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "timesheet" -d "Timesheet reports"
+complete -c productive -f -n "__fish_seen_subcommand_from reports" -a "timesheets" -d "Timesheet reports (alias)"
+
+# Resolve subcommands
+complete -c productive -f -n "__fish_seen_subcommand_from resolve" -a "detect" -d "Detect resource type from pattern"
 
 # Cache subcommands
 complete -c productive -f -n "__fish_seen_subcommand_from cache" -a "status" -d "Show cache statistics"


### PR DESCRIPTION
Closes #159

The shell completion scripts (bash, zsh, fish) were outdated, only referencing early resources. Updated all three to include every current resource and subcommand:

- deals, bookings, pages, discussions, comments, attachments, timers, activities, custom-fields, reports, resolve
- All aliases (p, t, svc)
- All subcommands per resource

All tests pass.