### PR TITLE
Implement stdin support for productive api --input -

### DIFF
--- a/packages/cli/src/commands/api.test.ts
+++ b/packages/cli/src/commands/api.test.ts
@@ -1,6 +1,8 @@
 import { vol } from 'memfs';
+import { EventEmitter } from 'node:events';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
+import { clearStdinCache } from '../utils/stdin.js';
 import { handleApiCommand } from './api.js';
 
 // Mock fetch globally
@@ -417,6 +419,250 @@ describe('api command', () => {
           input: '/tmp/invalid.json',
         }),
       ).rejects.toThrow();
+    });
+  });
+
+  describe('stdin input', () => {
+    let mockStdin: EventEmitter;
+    let originalStdin: any;
+    let originalIsTTY: boolean;
+
+    beforeEach(() => {
+      // Clear stdin cache before each test
+      clearStdinCache();
+
+      mockStdin = new EventEmitter();
+      originalStdin = process.stdin;
+      originalIsTTY = process.stdin.isTTY;
+
+      // Mock process.stdin
+      Object.defineProperty(process, 'stdin', {
+        value: mockStdin,
+        writable: true,
+        configurable: true,
+      });
+
+      // Add required methods to mockStdin
+      (mockStdin as any).resume = vi.fn();
+      (mockStdin as any).isTTY = false;
+    });
+
+    afterEach(() => {
+      // Restore original stdin
+      Object.defineProperty(process, 'stdin', {
+        value: originalStdin,
+        writable: true,
+        configurable: true,
+      });
+      process.stdin.isTTY = originalIsTTY;
+    });
+
+    it('should read body from stdin with --input -', async () => {
+      const testData = JSON.stringify({
+        data: { type: 'test', attributes: { name: 'stdin-value' } },
+      });
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const commandPromise = handleApiCommand(['/test'], {
+        method: 'POST',
+        input: '-',
+      });
+
+      // Simulate stdin data
+      process.nextTick(() => {
+        mockStdin.emit('data', Buffer.from(testData));
+        mockStdin.emit('end');
+      });
+
+      await commandPromise;
+
+      const call = mockFetch.mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body).toEqual({
+        data: { type: 'test', attributes: { name: 'stdin-value' } },
+      });
+    });
+
+    it('should read field value from stdin with @-', async () => {
+      const testData = '{"title": "Task from stdin"}';
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const commandPromise = handleApiCommand(['/test'], {
+        field: ['task_data=@-'],
+      });
+
+      // Simulate stdin data
+      process.nextTick(() => {
+        mockStdin.emit('data', Buffer.from(testData));
+        mockStdin.emit('end');
+      });
+
+      await commandPromise;
+
+      const call = mockFetch.mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body).toEqual({
+        task_data: { title: 'Task from stdin' },
+      });
+    });
+
+    it('should read plain text from stdin with @- when not valid JSON', async () => {
+      const testData = 'plain text content';
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const commandPromise = handleApiCommand(['/test'], {
+        field: ['note=@-'],
+      });
+
+      // Simulate stdin data
+      process.nextTick(() => {
+        mockStdin.emit('data', Buffer.from(testData));
+        mockStdin.emit('end');
+      });
+
+      await commandPromise;
+
+      const call = mockFetch.mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body).toEqual({
+        note: 'plain text content',
+      });
+    });
+
+    it('should handle multiple @- references sharing same stdin data', async () => {
+      const testData = '{"shared": "data"}';
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const commandPromise = handleApiCommand(['/test'], {
+        field: ['field1=@-', 'field2=@-'],
+      });
+
+      // Simulate stdin data - stdin is only read once and shared
+      process.nextTick(() => {
+        mockStdin.emit('data', Buffer.from(testData));
+        mockStdin.emit('end');
+      });
+
+      await commandPromise;
+
+      const call = mockFetch.mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body).toEqual({
+        field1: { shared: 'data' },
+        field2: { shared: 'data' },
+      });
+    }, 10000); // Increase timeout for this test
+
+    it('should throw error when stdin is a TTY', async () => {
+      (process.stdin as any).isTTY = true;
+
+      await expect(
+        handleApiCommand(['/test'], {
+          input: '-',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('should throw error for invalid JSON from stdin with --input -', async () => {
+      const testData = 'not valid json';
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const commandPromise = handleApiCommand(['/test'], {
+        method: 'POST',
+        input: '-',
+      });
+
+      // Simulate stdin data
+      process.nextTick(() => {
+        mockStdin.emit('data', Buffer.from(testData));
+        mockStdin.emit('end');
+      });
+
+      await expect(commandPromise).rejects.toThrow();
+    });
+
+    it('should handle empty stdin', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const commandPromise = handleApiCommand(['/test'], {
+        field: ['note=@-'],
+      });
+
+      // Simulate empty stdin
+      process.nextTick(() => {
+        mockStdin.emit('end');
+      });
+
+      await commandPromise;
+
+      const call = mockFetch.mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body).toEqual({
+        note: '',
+      });
+    });
+
+    it('should handle stdin errors', async () => {
+      const commandPromise = handleApiCommand(['/test'], {
+        input: '-',
+      });
+
+      // Simulate stdin error
+      process.nextTick(() => {
+        mockStdin.emit('error', new Error('Stdin error'));
+      });
+
+      await expect(commandPromise).rejects.toThrow();
+    });
+
+    it('should trim whitespace from plain text stdin content', async () => {
+      const testData = '  whitespace content  \n';
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: {} }),
+      });
+
+      const commandPromise = handleApiCommand(['/test'], {
+        field: ['note=@-'],
+      });
+
+      // Simulate stdin data
+      process.nextTick(() => {
+        mockStdin.emit('data', Buffer.from(testData));
+        mockStdin.emit('end');
+      });
+
+      await commandPromise;
+
+      const call = mockFetch.mock.calls[0];
+      const body = JSON.parse(call[1].body);
+      expect(body).toEqual({
+        note: 'whitespace content',
+      });
     });
   });
 

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -7,8 +7,9 @@ import { runCommand, exitWithValidationError } from '../error-handler.js';
 import { ConfigError, ValidationError, ApiError } from '../errors.js';
 import { OutputFormatter, createSpinner } from '../output.js';
 import { colors } from '../utils/colors.js';
+import { readStdin } from '../utils/stdin.js';
 
-function parseFieldValue(value: string): unknown {
+async function parseFieldValue(value: string): Promise<unknown> {
   // Handle special values
   if (value === 'true') return true;
   if (value === 'false') return false;
@@ -26,8 +27,15 @@ function parseFieldValue(value: string): unknown {
   if (value.startsWith('@')) {
     const filename = value.slice(1);
     if (filename === '-') {
-      // Read from stdin - not implemented in this context
-      throw new ValidationError('Reading from stdin is not supported yet', 'field');
+      // Read from stdin
+      const content = await readStdin();
+      // Try to parse as JSON first
+      try {
+        return JSON.parse(content);
+      } catch {
+        // Return as string if not valid JSON
+        return content.trim();
+      }
     }
     try {
       const content = readFileSync(filename, 'utf-8');
@@ -47,7 +55,7 @@ function parseFieldValue(value: string): unknown {
   return value;
 }
 
-function parseFields(fields: string[]): Record<string, unknown> {
+async function parseFields(fields: string[]): Promise<Record<string, unknown>> {
   const result: Record<string, unknown> = {};
 
   for (const field of fields) {
@@ -59,7 +67,7 @@ function parseFields(fields: string[]): Record<string, unknown> {
     const key = field.slice(0, equalIndex);
     const value = field.slice(equalIndex + 1);
 
-    result[key] = parseFieldValue(value);
+    result[key] = await parseFieldValue(value);
   }
 
   return result;
@@ -284,7 +292,7 @@ export async function handleApiCommand(
     const fields = collectOption(options, 'field', 'F');
     const rawFields = collectOption(options, 'raw-field', 'f');
 
-    const parsedFields = parseFields(fields);
+    const parsedFields = await parseFields(fields);
     const parsedRawFields = parseRawFields(rawFields);
     const allFields = { ...parsedFields, ...parsedRawFields };
 
@@ -316,10 +324,7 @@ export async function handleApiCommand(
     if (options.input) {
       // Read body from file
       const inputFile = String(options.input);
-      const content =
-        inputFile === '-'
-          ? '' // stdin not implemented yet
-          : readFileSync(inputFile, 'utf-8');
+      const content = inputFile === '-' ? await readStdin() : readFileSync(inputFile, 'utf-8');
 
       try {
         body = JSON.parse(content);

--- a/packages/cli/src/utils/stdin.test.ts
+++ b/packages/cli/src/utils/stdin.test.ts
@@ -1,0 +1,185 @@
+import { EventEmitter } from 'node:events';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { readStdin, clearStdinCache } from './stdin.js';
+
+describe('readStdin', () => {
+  let mockStdin: EventEmitter;
+  let originalStdin: any;
+  let originalIsTTY: boolean;
+
+  beforeEach(() => {
+    // Clear stdin cache before each test
+    clearStdinCache();
+
+    mockStdin = new EventEmitter();
+    originalStdin = process.stdin;
+    originalIsTTY = process.stdin.isTTY;
+
+    // Mock process.stdin
+    Object.defineProperty(process, 'stdin', {
+      value: mockStdin,
+      writable: true,
+      configurable: true,
+    });
+
+    // Add required methods to mockStdin
+    (mockStdin as any).resume = vi.fn();
+    (mockStdin as any).isTTY = false;
+  });
+
+  afterEach(() => {
+    // Restore original stdin
+    Object.defineProperty(process, 'stdin', {
+      value: originalStdin,
+      writable: true,
+      configurable: true,
+    });
+    process.stdin.isTTY = originalIsTTY;
+  });
+
+  it('should read data from stdin', async () => {
+    const testData = 'test data from stdin';
+
+    const readPromise = readStdin();
+
+    // Simulate stdin data
+    process.nextTick(() => {
+      mockStdin.emit('data', Buffer.from(testData));
+      mockStdin.emit('end');
+    });
+
+    const result = await readPromise;
+    expect(result).toBe(testData);
+  });
+
+  it('should concatenate multiple data chunks', async () => {
+    const chunk1 = 'first chunk ';
+    const chunk2 = 'second chunk';
+
+    const readPromise = readStdin();
+
+    // Simulate multiple stdin chunks
+    process.nextTick(() => {
+      mockStdin.emit('data', Buffer.from(chunk1));
+      mockStdin.emit('data', Buffer.from(chunk2));
+      mockStdin.emit('end');
+    });
+
+    const result = await readPromise;
+    expect(result).toBe('first chunk second chunk');
+  });
+
+  it('should handle empty stdin', async () => {
+    const readPromise = readStdin();
+
+    // Simulate empty stdin
+    process.nextTick(() => {
+      mockStdin.emit('end');
+    });
+
+    const result = await readPromise;
+    expect(result).toBe('');
+  });
+
+  it('should throw error when stdin is a TTY', async () => {
+    (process.stdin as any).isTTY = true;
+
+    await expect(readStdin()).rejects.toThrow(
+      'Reading from stdin requires piped input (stdin is a terminal). Use: echo "data" | productive ... or productive ... < file.json',
+    );
+  });
+
+  it('should handle stdin errors', async () => {
+    const readPromise = readStdin();
+
+    // Simulate stdin error
+    process.nextTick(() => {
+      mockStdin.emit('error', new Error('Test error'));
+    });
+
+    await expect(readPromise).rejects.toThrow('Failed to read from stdin: Test error');
+  });
+
+  it('should call resume on stdin', async () => {
+    const resumeSpy = vi.fn();
+    (mockStdin as any).resume = resumeSpy;
+
+    const readPromise = readStdin();
+
+    // Simulate stdin data
+    process.nextTick(() => {
+      mockStdin.emit('data', Buffer.from('test'));
+      mockStdin.emit('end');
+    });
+
+    await readPromise;
+
+    expect(resumeSpy).toHaveBeenCalled();
+  });
+
+  it('should handle unicode data correctly', async () => {
+    const testData = 'Hello 世界 🌍';
+
+    const readPromise = readStdin();
+
+    // Simulate stdin data with unicode
+    process.nextTick(() => {
+      mockStdin.emit('data', Buffer.from(testData, 'utf-8'));
+      mockStdin.emit('end');
+    });
+
+    const result = await readPromise;
+    expect(result).toBe(testData);
+  });
+
+  it('should handle large data chunks', async () => {
+    const largeData = 'x'.repeat(10000);
+
+    const readPromise = readStdin();
+
+    // Simulate large stdin data
+    process.nextTick(() => {
+      mockStdin.emit('data', Buffer.from(largeData));
+      mockStdin.emit('end');
+    });
+
+    const result = await readPromise;
+    expect(result).toBe(largeData);
+  });
+
+  it('should cache stdin content for multiple reads', async () => {
+    const testData = 'cached data';
+
+    // First read
+    const readPromise1 = readStdin();
+
+    // Simulate stdin data
+    process.nextTick(() => {
+      mockStdin.emit('data', Buffer.from(testData));
+      mockStdin.emit('end');
+    });
+
+    const result1 = await readPromise1;
+    expect(result1).toBe(testData);
+
+    // Second read should return cached result immediately
+    const result2 = await readStdin();
+    expect(result2).toBe(testData);
+
+    // Third read should also return cached result
+    const result3 = await readStdin();
+    expect(result3).toBe(testData);
+  });
+
+  it('should clear cache properly', () => {
+    // Start a read (we don't wait for it, just testing cache clearing)
+    readStdin();
+
+    // Clear the cache
+    clearStdinCache();
+
+    // Next read should be fresh (this test just verifies the cache mechanism exists)
+    expect(() => clearStdinCache()).not.toThrow();
+  });
+});

--- a/packages/cli/src/utils/stdin.ts
+++ b/packages/cli/src/utils/stdin.ts
@@ -1,0 +1,53 @@
+import { ValidationError } from '../errors.js';
+
+// Cache to store stdin content once read
+let stdinCache: Promise<string> | null = null;
+
+/**
+ * Read data from stdin (cached after first read)
+ * @returns Promise that resolves to the stdin content as a string
+ */
+export async function readStdin(): Promise<string> {
+  // Return cached result if stdin was already read
+  if (stdinCache) {
+    return stdinCache;
+  }
+
+  // Check if stdin is a TTY (terminal)
+  if (process.stdin.isTTY) {
+    throw new ValidationError(
+      'Reading from stdin requires piped input (stdin is a terminal). Use: echo "data" | productive ... or productive ... < file.json',
+      'stdin',
+    );
+  }
+
+  // Create and cache the promise
+  stdinCache = new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+
+    process.stdin.on('data', (chunk) => {
+      chunks.push(chunk);
+    });
+
+    process.stdin.on('end', () => {
+      const content = Buffer.concat(chunks).toString('utf-8');
+      resolve(content);
+    });
+
+    process.stdin.on('error', (error) => {
+      reject(new ValidationError(`Failed to read from stdin: ${error.message}`, 'stdin'));
+    });
+
+    // Resume stdin in case it's in paused mode
+    process.stdin.resume();
+  });
+
+  return stdinCache;
+}
+
+/**
+ * Clear the stdin cache (primarily for testing)
+ */
+export function clearStdinCache(): void {
+  stdinCache = null;
+}


### PR DESCRIPTION
Closes #161

Implements stdin reading for the `productive api` command:

- `productive api /time_entries --method POST --input -` now reads JSON body from stdin
- `--field @-` reads a field value from stdin
- Detects TTY and fails fast with helpful error if stdin is a terminal
- New `readStdin()` utility in `packages/cli/src/utils/stdin.ts`

All tests pass (1591 tests).