### PR TITLE
Add --quiet/-q flag to suppress non-data output

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -149,6 +149,7 @@ ${colors.bold('COMMANDS:')}
 
 ${colors.bold('OPTIONS:')}
   -f, --format <fmt>  Output format: json, human, csv, table (default: human)
+  -q, --quiet         Suppress non-data output (spinners, status messages)
   --no-color          Disable colored output
   --no-cache          Bypass cache for this request
   --refresh           Force refresh cached data

--- a/packages/cli/src/commands/time/handlers.ts
+++ b/packages/cli/src/commands/time/handlers.ts
@@ -221,10 +221,7 @@ export async function timeAdd(ctx: CommandContext): Promise<void> {
 
     const format = ctx.options.format || ctx.options.f || 'human';
     if (format === 'json') {
-      ctx.formatter.output({
-        status: 'success',
-        ...formatTimeEntry(entry),
-      });
+      ctx.formatter.successWithData('Time entry created', formatTimeEntry(entry));
     } else {
       ctx.formatter.success('Time entry created');
       console.log(colors.cyan('ID:'), entry.id);
@@ -268,7 +265,7 @@ export async function timeUpdate(args: string[], ctx: CommandContext): Promise<v
 
       const format = ctx.options.format || ctx.options.f || 'human';
       if (format === 'json') {
-        ctx.formatter.output({ status: 'success', id: result.data.id });
+        ctx.formatter.successWithData(`Time entry ${id} updated`, { id: result.data.id });
       } else {
         ctx.formatter.success(`Time entry ${id} updated`);
       }

--- a/packages/cli/src/context.quiet.test.ts
+++ b/packages/cli/src/context.quiet.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { createTestContext } from './context.js';
+
+// Mock console methods for testing
+const consoleMocks = {
+  log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+  error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+};
+
+describe('CommandContext with --quiet flag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createTestContext', () => {
+    it('should create context with quiet=true when --quiet flag is provided', () => {
+      const ctx = createTestContext({
+        options: { quiet: true, format: 'human' },
+      });
+
+      // Test that formatter suppresses messages in quiet mode
+      ctx.formatter.success('Test message');
+      expect(consoleMocks.log).not.toHaveBeenCalled();
+    });
+
+    it('should create context with quiet=true when -q flag is provided', () => {
+      const ctx = createTestContext({
+        options: { q: true, format: 'human' },
+      });
+
+      // Test that formatter suppresses messages in quiet mode
+      ctx.formatter.success('Test message');
+      expect(consoleMocks.log).not.toHaveBeenCalled();
+    });
+
+    it('should create context with quiet=false when no quiet flags are provided', () => {
+      const ctx = createTestContext({
+        options: { format: 'human' },
+      });
+
+      // Test that formatter shows messages in normal mode
+      ctx.formatter.success('Test message');
+      expect(consoleMocks.log).toHaveBeenCalledWith(expect.stringContaining('Test message'));
+    });
+
+    it('should prefer --quiet over -q when both are provided', () => {
+      const ctx = createTestContext({
+        options: { quiet: true, q: false, format: 'human' },
+      });
+
+      // Should still be quiet since quiet=true takes precedence
+      ctx.formatter.success('Test message');
+      expect(consoleMocks.log).not.toHaveBeenCalled();
+    });
+
+    it('should create no-op spinner in quiet mode', () => {
+      const ctx = createTestContext({
+        options: { quiet: true, format: 'human' },
+      });
+      const spinner = ctx.createSpinner('Loading...');
+
+      // Should return a no-op spinner
+      expect(spinner.start()).toBe(spinner);
+      expect(spinner.succeed()).toBe(spinner);
+    });
+
+    it('should create regular spinner in normal mode', () => {
+      const ctx = createTestContext({
+        options: { quiet: false, format: 'human' },
+      });
+      const spinner = ctx.createSpinner('Loading...');
+
+      // Should return a real spinner (check it has expected methods)
+      expect(spinner).toHaveProperty('start');
+      expect(spinner).toHaveProperty('succeed');
+      expect(spinner).toHaveProperty('fail');
+      expect(spinner).toHaveProperty('stop');
+      expect(spinner).toHaveProperty('setText');
+    });
+  });
+
+  describe('formatter with explicit options', () => {
+    it('should create formatter with quiet=true when quiet option is provided', () => {
+      const ctx = createTestContext({
+        options: { quiet: true, format: 'json' },
+      });
+
+      // Test that formatter suppresses messages in quiet mode
+      ctx.formatter.success('Test message');
+      expect(consoleMocks.log).not.toHaveBeenCalled();
+    });
+
+    it('should create formatter with quiet=false when no quiet option is provided', () => {
+      const ctx = createTestContext({
+        options: { format: 'json' },
+      });
+
+      // Test that formatter shows messages in normal mode
+      ctx.formatter.success('Test message');
+      expect(consoleMocks.log).toHaveBeenCalledWith(
+        JSON.stringify({ status: 'success', message: 'Test message' }),
+      );
+    });
+  });
+
+  describe('options parsing', () => {
+    it('should handle quiet option correctly in option parsing', () => {
+      const ctx = createTestContext({
+        options: { quiet: true, format: 'json' },
+      });
+
+      expect(ctx.options.quiet).toBe(true);
+    });
+
+    it('should handle -q short flag correctly', () => {
+      const ctx = createTestContext({
+        options: { q: true, format: 'json' },
+      });
+
+      expect(ctx.options.q).toBe(true);
+    });
+
+    it('should handle boolean false values correctly', () => {
+      const ctx = createTestContext({
+        options: { quiet: false, format: 'json' },
+      });
+
+      expect(ctx.options.quiet).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -68,6 +68,8 @@ export interface CommandOptions {
   size?: string | number;
   s?: string | number;
   sort?: string;
+  quiet?: boolean;
+  q?: boolean;
 }
 
 /**
@@ -140,9 +142,10 @@ export interface CommandContext {
 export function createContext(options: CommandOptions = {}): CommandContext {
   const format = (options.format || options.f || 'human') as OutputFormat;
   const noColor = options['no-color'] === true;
+  const quiet = options.quiet === true || options.q === true;
 
   const config = getConfig(options as Record<string, string | boolean | string[]>);
-  const formatter = new OutputFormatter(format, noColor);
+  const formatter = new OutputFormatter(format, noColor, quiet);
   const api = new ProductiveApi(options as Record<string, string | boolean | string[]>);
   const cache = getCache(options['no-cache'] !== true);
 
@@ -154,7 +157,7 @@ export function createContext(options: CommandOptions = {}): CommandContext {
     options,
 
     createSpinner(message: string): Spinner {
-      return createSpinner(message, format);
+      return createSpinner(message, format, quiet);
     },
 
     getPagination(): { page: number; perPage: number } {
@@ -251,7 +254,8 @@ export function createTestContext(overrides: Partial<CommandContext> = {}): Comm
   const opts = overrides.options ?? defaultOptions;
   const format = (opts.format || opts.f || 'json') as OutputFormat;
   const noColor = opts['no-color'] !== false;
-  const formatter = overrides.formatter ?? new OutputFormatter(format, noColor);
+  const quiet = opts.quiet === true || opts.q === true;
+  const formatter = overrides.formatter ?? new OutputFormatter(format, noColor, quiet);
 
   return {
     api: overrides.api ?? mockApi,

--- a/packages/cli/src/output.quiet.test.ts
+++ b/packages/cli/src/output.quiet.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+import { OutputFormatter, createSpinner } from './output.js';
+
+// Mock console methods
+const consoleMocks = {
+  log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+  error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+};
+
+describe('OutputFormatter with --quiet flag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('success messages', () => {
+    it('should suppress success messages in quiet mode', () => {
+      const formatter = new OutputFormatter('human', false, true);
+      formatter.success('Operation completed');
+      expect(consoleMocks.log).not.toHaveBeenCalled();
+    });
+
+    it('should show success messages in normal mode', () => {
+      const formatter = new OutputFormatter('human', false, false);
+      formatter.success('Operation completed');
+      expect(consoleMocks.log).toHaveBeenCalledWith(expect.stringContaining('Operation completed'));
+    });
+
+    it('should suppress JSON success messages in quiet mode', () => {
+      const formatter = new OutputFormatter('json', false, true);
+      formatter.success('Operation completed');
+      expect(consoleMocks.log).not.toHaveBeenCalled();
+    });
+
+    it('should show JSON success messages in normal mode', () => {
+      const formatter = new OutputFormatter('json', false, false);
+      formatter.success('Operation completed');
+      expect(consoleMocks.log).toHaveBeenCalledWith(
+        JSON.stringify({ status: 'success', message: 'Operation completed' }),
+      );
+    });
+  });
+
+  describe('warning messages', () => {
+    it('should suppress warning messages in quiet mode', () => {
+      const formatter = new OutputFormatter('human', false, true);
+      formatter.warning('This is a warning');
+      expect(consoleMocks.log).not.toHaveBeenCalled();
+    });
+
+    it('should show warning messages in normal mode', () => {
+      const formatter = new OutputFormatter('human', false, false);
+      formatter.warning('This is a warning');
+      expect(consoleMocks.log).toHaveBeenCalledWith(expect.stringContaining('This is a warning'));
+    });
+  });
+
+  describe('info messages', () => {
+    it('should suppress info messages in quiet mode', () => {
+      const formatter = new OutputFormatter('human', false, true);
+      formatter.info('Information message');
+      expect(consoleMocks.log).not.toHaveBeenCalled();
+    });
+
+    it('should show info messages in normal mode', () => {
+      const formatter = new OutputFormatter('human', false, false);
+      formatter.info('Information message');
+      expect(consoleMocks.log).toHaveBeenCalledWith(expect.stringContaining('Information message'));
+    });
+  });
+
+  describe('error messages', () => {
+    it('should still show error messages in quiet mode but without emoji', () => {
+      const formatter = new OutputFormatter('human', false, true);
+      formatter.error('Something went wrong');
+      // Check that the error was called once
+      expect(consoleMocks.error).toHaveBeenCalledTimes(1);
+      // Check that the message contains our text
+      const errorCall = consoleMocks.error.mock.calls[0][0];
+      expect(errorCall).toContain('Something went wrong');
+      // Check that it doesn't contain the emoji
+      expect(errorCall).not.toContain('✗');
+    });
+
+    it('should show error messages with emoji in normal mode', () => {
+      const formatter = new OutputFormatter('human', false, false);
+      formatter.error('Something went wrong');
+      expect(consoleMocks.error).toHaveBeenCalledWith(
+        expect.stringContaining('✗ Something went wrong'),
+      );
+    });
+
+    it('should show JSON error messages in both quiet and normal mode', () => {
+      const quietFormatter = new OutputFormatter('json', false, true);
+      const normalFormatter = new OutputFormatter('json', false, false);
+
+      quietFormatter.error('Error in quiet');
+      normalFormatter.error('Error in normal');
+
+      expect(consoleMocks.error).toHaveBeenCalledTimes(2);
+      expect(consoleMocks.error).toHaveBeenCalledWith(
+        JSON.stringify({ status: 'error', message: 'Error in quiet', details: undefined }),
+      );
+      expect(consoleMocks.error).toHaveBeenCalledWith(
+        JSON.stringify({ status: 'error', message: 'Error in normal', details: undefined }),
+      );
+    });
+  });
+
+  describe('data output', () => {
+    it('should still output data in quiet mode', () => {
+      const formatter = new OutputFormatter('json', false, true);
+      const data = { id: '123', name: 'Test' };
+      formatter.output(data);
+      expect(consoleMocks.log).toHaveBeenCalledWith(JSON.stringify(data, null, 2));
+    });
+
+    it('should output data in normal mode', () => {
+      const formatter = new OutputFormatter('json', false, false);
+      const data = { id: '123', name: 'Test' };
+      formatter.output(data);
+      expect(consoleMocks.log).toHaveBeenCalledWith(JSON.stringify(data, null, 2));
+    });
+  });
+
+  describe('successWithData', () => {
+    it('should output just data in quiet JSON mode', () => {
+      const formatter = new OutputFormatter('json', false, true);
+      const data = { id: '123', name: 'Test Resource' };
+      formatter.successWithData('Resource created', data);
+
+      expect(consoleMocks.log).toHaveBeenCalledWith(JSON.stringify(data, null, 2));
+      expect(consoleMocks.log).not.toHaveBeenCalledWith(expect.stringContaining('status'));
+    });
+
+    it('should output status wrapper in normal JSON mode', () => {
+      const formatter = new OutputFormatter('json', false, false);
+      const data = { id: '123', name: 'Test Resource' };
+      formatter.successWithData('Resource created', data);
+
+      expect(consoleMocks.log).toHaveBeenCalledWith(
+        JSON.stringify({ status: 'success', ...data }, null, 2),
+      );
+    });
+
+    it('should use regular success behavior in human format (quiet)', () => {
+      const formatter = new OutputFormatter('human', false, true);
+      const data = { id: '123', name: 'Test Resource' };
+      formatter.successWithData('Resource created', data);
+
+      // Should suppress the success message in quiet mode
+      expect(consoleMocks.log).not.toHaveBeenCalled();
+    });
+
+    it('should use regular success behavior in human format (normal)', () => {
+      const formatter = new OutputFormatter('human', false, false);
+      const data = { id: '123', name: 'Test Resource' };
+      formatter.successWithData('Resource created', data);
+
+      // Should show the success message in normal mode
+      expect(consoleMocks.log).toHaveBeenCalledWith(expect.stringContaining('Resource created'));
+    });
+  });
+});
+
+describe('createSpinner with --quiet flag', () => {
+  it('should return no-op spinner in quiet mode', () => {
+    const spinner = createSpinner('Loading...', 'human', true);
+
+    // Should return a no-op spinner
+    expect(spinner.start()).toBe(spinner);
+    expect(spinner.succeed()).toBe(spinner);
+    expect(spinner.fail()).toBe(spinner);
+    expect(spinner.stop()).toBe(spinner);
+    expect(spinner.setText()).toBe(spinner);
+  });
+
+  it('should return regular spinner in normal mode', () => {
+    const spinner = createSpinner('Loading...', 'human', false);
+
+    // Should return a real spinner (we can't test the exact type due to complex mocking,
+    // but we can at least verify it returns an object with the expected methods)
+    expect(spinner).toHaveProperty('start');
+    expect(spinner).toHaveProperty('succeed');
+    expect(spinner).toHaveProperty('fail');
+    expect(spinner).toHaveProperty('stop');
+    expect(spinner).toHaveProperty('setText');
+  });
+
+  it('should return no-op spinner for JSON format regardless of quiet flag', () => {
+    const quietSpinner = createSpinner('Loading...', 'json', true);
+    const normalSpinner = createSpinner('Loading...', 'json', false);
+
+    // Both should be no-op spinners
+    expect(quietSpinner.start()).toBe(quietSpinner);
+    expect(normalSpinner.start()).toBe(normalSpinner);
+  });
+});

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -7,6 +7,7 @@ export class OutputFormatter {
   constructor(
     private format: OutputFormat = 'human',
     private noColor: boolean = false,
+    private quiet: boolean = false,
   ) {
     if (noColor) {
       // Colors are already handled by the colors module
@@ -38,6 +39,9 @@ export class OutputFormatter {
   }
 
   success(message: string): void {
+    if (this.quiet) {
+      return; // Suppress success messages in quiet mode
+    }
     if (this.format === 'json') {
       console.log(JSON.stringify({ status: 'success', message }));
     } else {
@@ -45,11 +49,38 @@ export class OutputFormatter {
     }
   }
 
+  /**
+   * Output successful mutation result with data.
+   * In quiet + JSON mode: output just the data
+   * In regular JSON mode: output { status: 'success', ...data }
+   * In other formats: use regular success message
+   */
+  successWithData(message: string, data: unknown): void {
+    if (this.format === 'json') {
+      if (this.quiet) {
+        // In quiet mode, output just the data without wrapper
+        console.log(JSON.stringify(data, null, 2));
+      } else {
+        // In regular JSON mode, include status wrapper
+        const result =
+          typeof data === 'object' && data !== null
+            ? { status: 'success', ...data }
+            : { status: 'success', data };
+        console.log(JSON.stringify(result, null, 2));
+      }
+    } else {
+      // For other formats, use regular success behavior
+      this.success(message);
+    }
+  }
+
   error(message: string, details?: unknown): void {
     if (this.format === 'json') {
       console.error(JSON.stringify({ status: 'error', message, details }));
     } else {
-      console.error(colors.red(`✗ ${message}`));
+      // In quiet mode, suppress emoji but still output to stderr
+      const prefix = this.quiet ? '' : '✗ ';
+      console.error(colors.red(`${prefix}${message}`));
       if (details) {
         console.error(details);
       }
@@ -57,6 +88,9 @@ export class OutputFormatter {
   }
 
   warning(message: string): void {
+    if (this.quiet) {
+      return; // Suppress warning messages in quiet mode
+    }
     if (this.format === 'json') {
       console.log(JSON.stringify({ status: 'warning', message }));
     } else {
@@ -65,6 +99,9 @@ export class OutputFormatter {
   }
 
   info(message: string): void {
+    if (this.quiet) {
+      return; // Suppress info messages in quiet mode
+    }
     if (this.format === 'json') {
       console.log(JSON.stringify({ status: 'info', message }));
     } else {
@@ -110,11 +147,15 @@ export class OutputFormatter {
 
 /**
  * Create a spinner for long-running operations
- * Returns a no-op spinner for JSON format
+ * Returns a no-op spinner for JSON format or quiet mode
  */
-export function createSpinner(message: string, format: OutputFormat = 'human'): Spinner {
-  if (format === 'json') {
-    // No-op spinner for JSON output
+export function createSpinner(
+  message: string,
+  format: OutputFormat = 'human',
+  quiet: boolean = false,
+): Spinner {
+  if (format === 'json' || quiet) {
+    // No-op spinner for JSON output or quiet mode
     const noopSpinner = {
       start() {
         return this;


### PR DESCRIPTION
Closes #162

Adds a global `--quiet` / `-q` flag that suppresses spinners, status messages, and decorative output. Only data goes to stdout, errors to stderr.

- Spinners become no-ops when quiet
- `success()`, `warning()`, `info()` become no-ops
- `output()` still works (data flows through)
- `error()` still writes to stderr (without emoji)
- Documented in global --help

All tests pass (1603 tests across 97 files).