### PR TITLE
Fix include/sort forwarding and cross-package consistency gaps (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI**: Document `--end-date` in the `deals add` command help — it was wired into the handler but undiscoverable ([f607546], [#175])
 - **Core**: Normalize a non-positive `page`/`perPage` (e.g. from `--size 0`) to the defaults in `buildListParams`, which previously forwarded an out-of-range 0 that `buildListQuery` then silently dropped ([2a9dde4], [#175])
 
+### Security
+
+- **MCP**: Update `@modelcontextprotocol/sdk` and `h3` and refresh the lockfile to patched transitive versions, clearing 5 advisories (high `fast-uri` path traversal/host confusion, plus `hono`, `ip-address`, `express-rate-limit` and `qs`) ([7a0dedc], [#175])
+
 [7a88366]: https://github.com/studiometa/productive-tools/commit/7a88366
 [77177b1]: https://github.com/studiometa/productive-tools/commit/77177b1
 [9433686]: https://github.com/studiometa/productive-tools/commit/9433686
@@ -57,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [82c6136]: https://github.com/studiometa/productive-tools/commit/82c6136
 [1082df4]: https://github.com/studiometa/productive-tools/commit/1082df4
 [2a9dde4]: https://github.com/studiometa/productive-tools/commit/2a9dde4
+[7a0dedc]: https://github.com/studiometa/productive-tools/commit/7a0dedc
 [#175]: https://github.com/studiometa/productive-tools/pull/175
 
 ## [0.10.12] - 2026.05.27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **API**: Route every list/get method through a shared `buildListQuery(ListParams)` helper (both now exported) so the common query params forward by construction and no method can silently drop one ([ebe09eb], [#175])
+- **Core**: Add a `buildListParams()` helper spread into every list executor, and promote `DEFAULT_PAGE_SIZE` to `@studiometa/productive-api` as the single cross-package default ([513ea65], [#175])
+- **SDK**: Alias every collection's `*ListOptions` to the shared `BaseListOptions` so the fluent builder and the option types can no longer drift apart ([eddfaa5], [#175])
+
 ### Fixed
 
 - **API**: Forward the `include` query param in `getProjects`/`getProject` and the previously-affected `getPeople`/`getPerson`, `getServices`, `getCompanies`/`getCompany`, `getAttachments`/`getAttachment`, `getPages`/`getPage`, `getDiscussions`/`getDiscussion` and `getCustomFieldOptions` methods ([7a88366], [#175])
@@ -28,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [09844e9]: https://github.com/studiometa/productive-tools/commit/09844e9
 [d50575a]: https://github.com/studiometa/productive-tools/commit/d50575a
 [93204e2]: https://github.com/studiometa/productive-tools/commit/93204e2
+[ebe09eb]: https://github.com/studiometa/productive-tools/commit/ebe09eb
+[513ea65]: https://github.com/studiometa/productive-tools/commit/513ea65
+[eddfaa5]: https://github.com/studiometa/productive-tools/commit/eddfaa5
 [#175]: https://github.com/studiometa/productive-tools/pull/175
 
 ## [0.10.12] - 2026.05.27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **API**: Route every list/get method through a shared `buildListQuery(ListParams)` helper (both now exported) so the common query params forward by construction and no method can silently drop one ([ebe09eb], [#175])
 - **Core**: Add a `buildListParams()` helper spread into every list executor, and promote `DEFAULT_PAGE_SIZE` to `@studiometa/productive-api` as the single cross-package default ([513ea65], [#175])
 - **SDK**: Alias every collection's `*ListOptions` to the shared `BaseListOptions` so the fluent builder and the option types can no longer drift apart ([eddfaa5], [#175])
+- **SDK**: Collapse the 13 identical `*GetOptions` interfaces into a shared, exported `IncludeOptions` type (the `include` half of `BaseListOptions`) ([a129c6e], [#175])
+- **SDK**: Remove the unused `createIterator` helper from `BaseCollection` — dead code that still hardcoded the pre-consolidation page size of 200 ([1866110], [#175])
 
 ### Fixed
 
@@ -42,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [519d8ca]: https://github.com/studiometa/productive-tools/commit/519d8ca
 [1b85cc1]: https://github.com/studiometa/productive-tools/commit/1b85cc1
 [3c8ae3d]: https://github.com/studiometa/productive-tools/commit/3c8ae3d
+[1866110]: https://github.com/studiometa/productive-tools/commit/1866110
+[a129c6e]: https://github.com/studiometa/productive-tools/commit/a129c6e
 [94802f7]: https://github.com/studiometa/productive-tools/commit/94802f7
 [f607546]: https://github.com/studiometa/productive-tools/commit/f607546
 [ebe09eb]: https://github.com/studiometa/productive-tools/commit/ebe09eb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SDK**: Alias every collection's `*ListOptions` to the shared `BaseListOptions` so the fluent builder and the option types can no longer drift apart ([eddfaa5], [#175])
 - **SDK**: Collapse the 13 identical `*GetOptions` interfaces into a shared, exported `IncludeOptions` type (the `include` half of `BaseListOptions`) ([a129c6e], [#175])
 - **SDK**: Remove the unused `createIterator` helper from `BaseCollection` — dead code that still hardcoded the pre-consolidation page size of 200 ([1866110], [#175])
+- **API**: Index each `included` array once (memoized by reference) instead of re-scanning it with `Array.find` per relationship, so resolving sideloads while formatting a list is O(records) rather than O(records × includes) ([82c6136], [#175])
+- **API/MCP**: Extract `applyIncluded()` and `withIncluded()` so the sideloaded-include threading lives in one place per package instead of being copy-pasted across the eight API formatters and sixteen MCP wrappers ([1082df4], [#175])
 
 ### Fixed
 
@@ -31,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **MCP**: Validate `include` values for the projects, people, companies, services, pages, discussions and attachments resources — a typo previously passed straight through to a raw API 400 instead of returning a helpful suggestion like every other resource ([3c8ae3d], [#175])
 - **CLI**: Add `--include` to the projects, people, companies, services, pages, discussions and attachments list/get commands (via a shared `ctx.getInclude()`) and surface the resolved relationships in the output ([94802f7], [#175])
 - **CLI**: Document `--end-date` in the `deals add` command help — it was wired into the handler but undiscoverable ([f607546], [#175])
+- **Core**: Normalize a non-positive `page`/`perPage` (e.g. from `--size 0`) to the defaults in `buildListParams`, which previously forwarded an out-of-range 0 that `buildListQuery` then silently dropped ([2a9dde4], [#175])
 
 [7a88366]: https://github.com/studiometa/productive-tools/commit/7a88366
 [77177b1]: https://github.com/studiometa/productive-tools/commit/77177b1
@@ -51,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [ebe09eb]: https://github.com/studiometa/productive-tools/commit/ebe09eb
 [513ea65]: https://github.com/studiometa/productive-tools/commit/513ea65
 [eddfaa5]: https://github.com/studiometa/productive-tools/commit/eddfaa5
+[82c6136]: https://github.com/studiometa/productive-tools/commit/82c6136
+[1082df4]: https://github.com/studiometa/productive-tools/commit/1082df4
+[2a9dde4]: https://github.com/studiometa/productive-tools/commit/2a9dde4
 [#175]: https://github.com/studiometa/productive-tools/pull/175
 
 ## [0.10.12] - 2026.05.27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SDK**: Add `timers.start()`/`timers.stop()` and `discussions.resolve()`/`discussions.reopen()`, which existed in every other layer but were missing from the SDK ([09844e9], [#175])
 - **API/Core/SDK/CLI**: Support `end_date` when creating a deal — it was settable on update but silently unavailable on create ([d50575a], [#175])
 - **SDK/Core**: Consolidate the default list page size to a shared `DEFAULT_PAGE_SIZE` (100); SDK `all()` iterators previously defaulted to 200 and two core executors to 25 ([93204e2], [#175])
+- **API/MCP**: Resolve sideloaded `include` relationships into the formatted output — the `include` param was forwarded and the `included` array returned, but the CLI/MCP formatters discarded it, so `project.company` (and `person.company`, `service.deal`, `page.creator`, etc.) never surfaced for any resource except tasks/deals/comments/bookings; add a shared `resolveRelationships()` helper wired into the project/person/company/service/time-entry/page/discussion/attachment formatters ([519d8ca], [#175])
+- **MCP**: Forward `include` in the `people` (get/me/list) and `services` list handlers, which never passed it to their executors, leaving the new include support unreachable from MCP for those two resources ([1b85cc1], [#175])
 
 [7a88366]: https://github.com/studiometa/productive-tools/commit/7a88366
 [77177b1]: https://github.com/studiometa/productive-tools/commit/77177b1
@@ -34,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [09844e9]: https://github.com/studiometa/productive-tools/commit/09844e9
 [d50575a]: https://github.com/studiometa/productive-tools/commit/d50575a
 [93204e2]: https://github.com/studiometa/productive-tools/commit/93204e2
+[519d8ca]: https://github.com/studiometa/productive-tools/commit/519d8ca
+[1b85cc1]: https://github.com/studiometa/productive-tools/commit/1b85cc1
 [ebe09eb]: https://github.com/studiometa/productive-tools/commit/ebe09eb
 [513ea65]: https://github.com/studiometa/productive-tools/commit/513ea65
 [eddfaa5]: https://github.com/studiometa/productive-tools/commit/eddfaa5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **API**: Forward the `include` query param in `getProjects`/`getProject` and the previously-affected `getPeople`/`getPerson`, `getServices`, `getCompanies`/`getCompany`, `getAttachments`/`getAttachment`, `getPages`/`getPage`, `getDiscussions`/`getDiscussion` and `getCustomFieldOptions` methods ([7a88366], [#175])
+- **SDK**: Expose and forward `include` on the projects, people, services, companies, attachments, pages and discussions collections (list/get) plus `time.get()`, so included relationships such as `project.company` resolve consistently ([77177b1], [#175])
+
+[7a88366]: https://github.com/studiometa/productive-tools/commit/7a88366
+[77177b1]: https://github.com/studiometa/productive-tools/commit/77177b1
+[#175]: https://github.com/studiometa/productive-tools/pull/175
+
 ## [0.10.12] - 2026.05.27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **API**: Forward the `include` query param in `getProjects`/`getProject` and the previously-affected `getPeople`/`getPerson`, `getServices`, `getCompanies`/`getCompany`, `getAttachments`/`getAttachment`, `getPages`/`getPage`, `getDiscussions`/`getDiscussion` and `getCustomFieldOptions` methods ([7a88366], [#175])
 - **SDK**: Expose and forward `include` on the projects, people, services, companies, attachments, pages and discussions collections (list/get) plus `time.get()`, so included relationships such as `project.company` resolve consistently ([77177b1], [#175])
+- **Core**: Forward `include` and return `included` from the projects, people, services, companies, attachments and time list/get executors — the MCP/CLI path silently dropped sideloads even when the include was validated as supported ([9433686], [#175])
+- **Core**: Return `included` from the comments, bookings and timers list executors, which forwarded `include` but discarded the sideloaded resources ([9ff9682], [#175])
+- **Core**: Forward `include` from the pages and discussions list/get executors, which returned an always-empty `included` because the param was never sent ([dbc5a0e], [#175])
+- **API/SDK**: Add the `sort` param to `getServices`, `getComments`, `getAttachments`, `getActivities`, `getCustomFields` and `getCustomFieldOptions`, and declare `sort` on the matching SDK list options so `QueryBuilder.orderBy()` is no longer silently dropped ([36aa8a8], [#175])
+- **SDK**: Add `timers.start()`/`timers.stop()` and `discussions.resolve()`/`discussions.reopen()`, which existed in every other layer but were missing from the SDK ([09844e9], [#175])
+- **API/Core/SDK/CLI**: Support `end_date` when creating a deal — it was settable on update but silently unavailable on create ([d50575a], [#175])
+- **SDK/Core**: Consolidate the default list page size to a shared `DEFAULT_PAGE_SIZE` (100); SDK `all()` iterators previously defaulted to 200 and two core executors to 25 ([93204e2], [#175])
 
 [7a88366]: https://github.com/studiometa/productive-tools/commit/7a88366
 [77177b1]: https://github.com/studiometa/productive-tools/commit/77177b1
+[9433686]: https://github.com/studiometa/productive-tools/commit/9433686
+[9ff9682]: https://github.com/studiometa/productive-tools/commit/9ff9682
+[dbc5a0e]: https://github.com/studiometa/productive-tools/commit/dbc5a0e
+[36aa8a8]: https://github.com/studiometa/productive-tools/commit/36aa8a8
+[09844e9]: https://github.com/studiometa/productive-tools/commit/09844e9
+[d50575a]: https://github.com/studiometa/productive-tools/commit/d50575a
+[93204e2]: https://github.com/studiometa/productive-tools/commit/93204e2
 [#175]: https://github.com/studiometa/productive-tools/pull/175
 
 ## [0.10.12] - 2026.05.27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SDK/Core**: Consolidate the default list page size to a shared `DEFAULT_PAGE_SIZE` (100); SDK `all()` iterators previously defaulted to 200 and two core executors to 25 ([93204e2], [#175])
 - **API/MCP**: Resolve sideloaded `include` relationships into the formatted output — the `include` param was forwarded and the `included` array returned, but the CLI/MCP formatters discarded it, so `project.company` (and `person.company`, `service.deal`, `page.creator`, etc.) never surfaced for any resource except tasks/deals/comments/bookings; add a shared `resolveRelationships()` helper wired into the project/person/company/service/time-entry/page/discussion/attachment formatters ([519d8ca], [#175])
 - **MCP**: Forward `include` in the `people` (get/me/list) and `services` list handlers, which never passed it to their executors, leaving the new include support unreachable from MCP for those two resources ([1b85cc1], [#175])
+- **MCP**: Validate `include` values for the projects, people, companies, services, pages, discussions and attachments resources — a typo previously passed straight through to a raw API 400 instead of returning a helpful suggestion like every other resource ([3c8ae3d], [#175])
+- **CLI**: Add `--include` to the projects, people, companies, services, pages, discussions and attachments list/get commands (via a shared `ctx.getInclude()`) and surface the resolved relationships in the output ([94802f7], [#175])
+- **CLI**: Document `--end-date` in the `deals add` command help — it was wired into the handler but undiscoverable ([f607546], [#175])
 
 [7a88366]: https://github.com/studiometa/productive-tools/commit/7a88366
 [77177b1]: https://github.com/studiometa/productive-tools/commit/77177b1
@@ -38,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [93204e2]: https://github.com/studiometa/productive-tools/commit/93204e2
 [519d8ca]: https://github.com/studiometa/productive-tools/commit/519d8ca
 [1b85cc1]: https://github.com/studiometa/productive-tools/commit/1b85cc1
+[3c8ae3d]: https://github.com/studiometa/productive-tools/commit/3c8ae3d
+[94802f7]: https://github.com/studiometa/productive-tools/commit/94802f7
+[f607546]: https://github.com/studiometa/productive-tools/commit/f607546
 [ebe09eb]: https://github.com/studiometa/productive-tools/commit/ebe09eb
 [513ea65]: https://github.com/studiometa/productive-tools/commit/513ea65
 [eddfaa5]: https://github.com/studiometa/productive-tools/commit/eddfaa5

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
         "oxfmt": "0.52.0",
         "oxlint": "1.67.0",
         "oxlint-tsgolint": "^0.23.0",
-        "vite": "^8.0.14",
-        "vitest": "^4.1.7"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.8"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -650,9 +650,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1438,9 +1438,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1455,9 +1455,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1472,9 +1472,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1489,9 +1489,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1506,9 +1506,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1523,9 +1523,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -1543,9 +1543,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -1563,9 +1563,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -1583,9 +1583,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -1603,9 +1603,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -1623,9 +1623,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -1643,9 +1643,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1660,9 +1660,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1679,9 +1679,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1696,9 +1696,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1934,14 +1934,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
-      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.7",
+        "@vitest/utils": "4.1.8",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -1955,8 +1955,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.7",
-        "vitest": "4.1.7"
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -1965,16 +1965,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
-      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1983,13 +1983,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
-      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.7",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2010,9 +2010,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
-      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2023,13 +2023,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
-      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.7",
+        "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2037,14 +2037,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
-      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2053,9 +2053,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
-      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2063,13 +2063,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
-      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
+        "@vitest/pretty-format": "4.1.8",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2176,9 +2176,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.2.tgz",
-      "integrity": "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2629,12 +2629,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -2653,9 +2653,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -2824,13 +2824,13 @@
       }
     },
     "node_modules/h3": {
-      "version": "2.0.1-rc.19",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.19.tgz",
-      "integrity": "sha512-47er/mh8eGA7+0nvNUloalj+yTJ1ku8M0BVzA2I1ZHSlpfbUNdBK4LpWztfH7TwW6kuhF8MfAvl0AwB+X9B+2w==",
+      "version": "2.0.1-rc.22",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.22.tgz",
+      "integrity": "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==",
       "license": "MIT",
       "dependencies": {
         "rou3": "^0.8.1",
-        "srvx": "^0.11.12"
+        "srvx": "^0.11.15"
       },
       "bin": {
         "h3": "bin/h3.mjs"
@@ -2882,9 +2882,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2966,9 +2966,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3907,9 +3907,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -3979,13 +3979,13 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -3995,21 +3995,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/rou3": {
@@ -4245,9 +4245,9 @@
       }
     },
     "node_modules/srvx": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.13.tgz",
-      "integrity": "sha512-oknN6qduuMPafxKtHucUeG32Q963pjriA5g3/Bl05cwEsUe5VVbIU4qR9LrALHbipSCyBe+VmfDGGydqazDRkw==",
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.16.tgz",
+      "integrity": "sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==",
       "license": "MIT",
       "bin": {
         "srvx": "bin/srvx.mjs"
@@ -4370,9 +4370,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4523,17 +4523,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
-      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.2",
-        "tinyglobby": "^0.2.16"
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4614,19 +4614,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
-      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.7",
-        "@vitest/mocker": "4.1.7",
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/runner": "4.1.7",
-        "@vitest/snapshot": "4.1.7",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4654,12 +4654,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.7",
-        "@vitest/browser-preview": "4.1.7",
-        "@vitest/browser-webdriverio": "4.1.7",
-        "@vitest/coverage-istanbul": "4.1.7",
-        "@vitest/coverage-v8": "4.1.7",
-        "@vitest/ui": "4.1.7",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4829,9 +4829,9 @@
       "version": "0.10.12",
       "license": "MIT",
       "devDependencies": {
-        "@vitest/coverage-v8": "^4.1.7",
-        "vite": "^8.0.14",
-        "vitest": "^4.1.7"
+        "@vitest/coverage-v8": "^4.1.8",
+        "vite": "^8.0.16",
+        "vitest": "^4.1.8"
       }
     },
     "packages/cli": {
@@ -4847,10 +4847,10 @@
         "productive": "dist/cli.js"
       },
       "devDependencies": {
-        "@vitest/coverage-v8": "^4.1.7",
+        "@vitest/coverage-v8": "^4.1.8",
         "memfs": "4.57.2",
-        "vite": "^8.0.14",
-        "vitest": "^4.1.7"
+        "vite": "^8.0.16",
+        "vitest": "^4.1.8"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -4864,9 +4864,9 @@
         "@studiometa/productive-api": "*"
       },
       "devDependencies": {
-        "@vitest/coverage-v8": "^4.1.7",
-        "vite": "^8.0.14",
-        "vitest": "^4.1.7"
+        "@vitest/coverage-v8": "^4.1.8",
+        "vite": "^8.0.16",
+        "vitest": "^4.1.8"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -4877,10 +4877,10 @@
       "version": "0.10.12",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@studiometa/productive-api": "*",
         "@studiometa/productive-core": "*",
-        "h3": "^2.0.1-rc.14",
+        "h3": "^2.0.1-rc.22",
         "zod": "4.3.6"
       },
       "bin": {
@@ -4888,9 +4888,9 @@
         "productive-mcp-server": "dist/server.js"
       },
       "devDependencies": {
-        "@vitest/coverage-v8": "^4.1.7",
-        "vite": "^8.0.14",
-        "vitest": "^4.1.7"
+        "@vitest/coverage-v8": "^4.1.8",
+        "vite": "^8.0.16",
+        "vitest": "^4.1.8"
       },
       "engines": {
         "node": ">=24.0.0"
@@ -4904,9 +4904,9 @@
         "@studiometa/productive-api": "*"
       },
       "devDependencies": {
-        "@vitest/coverage-v8": "^4.1.7",
-        "vite": "^8.0.14",
-        "vitest": "^4.1.7"
+        "@vitest/coverage-v8": "^4.1.8",
+        "vite": "^8.0.16",
+        "vitest": "^4.1.8"
       },
       "engines": {
         "node": ">=24.0.0"

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "oxfmt": "0.52.0",
     "oxlint": "1.67.0",
     "oxlint-tsgolint": "^0.23.0",
-    "vite": "^8.0.14",
-    "vitest": "^4.1.7"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   },
   "overrides": {
     "@hono/node-server": "1.19.13",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -35,8 +35,8 @@
     "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^4.1.7",
-    "vite": "^8.0.14",
-    "vitest": "^4.1.7"
+    "@vitest/coverage-v8": "^4.1.8",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/api/src/client.test.ts
+++ b/packages/api/src/client.test.ts
@@ -830,6 +830,14 @@ describe('ProductiveApi requests', () => {
       expect(body.data.attributes.budget).toBe(false);
     });
 
+    it('createDeal with end_date (Finding 7)', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: { id: '1' } });
+      await api.createDeal({ name: 'Deal', company_id: '10', end_date: '2026-12-31' });
+      const body = JSON.parse(fetchSpy.mock.calls[0][1]!.body as string);
+      expect(body.data.attributes.end_date).toBe('2026-12-31');
+    });
+
     it('updateDeal with relationships', async () => {
       const api = createApi();
       mockFetchResponse({ data: { id: '1' } });

--- a/packages/api/src/client.test.ts
+++ b/packages/api/src/client.test.ts
@@ -1,7 +1,37 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ProductiveApi } from './client.js';
+import { ProductiveApi, buildListQuery } from './client.js';
 import { ProductiveApiError } from './error.js';
+
+describe('buildListQuery', () => {
+  it('returns an empty object for no params', () => {
+    expect(buildListQuery()).toEqual({});
+    expect(buildListQuery({})).toEqual({});
+  });
+
+  it('maps every common list param to its JSON:API query key', () => {
+    expect(
+      buildListQuery({
+        page: 2,
+        perPage: 50,
+        sort: '-created_at',
+        filter: { project_id: '1', archived: 'false' },
+        include: ['company', 'memberships'],
+      }),
+    ).toEqual({
+      'page[number]': '2',
+      'page[size]': '50',
+      sort: '-created_at',
+      'filter[project_id]': '1',
+      'filter[archived]': 'false',
+      include: 'company,memberships',
+    });
+  });
+
+  it('omits include when the array is empty', () => {
+    expect(buildListQuery({ include: [] })).toEqual({});
+  });
+});
 
 const validConfig = {
   apiToken: 'test-token',

--- a/packages/api/src/client.test.ts
+++ b/packages/api/src/client.test.ts
@@ -574,6 +574,13 @@ describe('ProductiveApi requests', () => {
       expect(fetchSpy.mock.calls[0][0] as string).toContain('include=deal');
     });
 
+    it('getServices with sort', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getServices({ sort: 'name' });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('sort=name');
+    });
+
     it('getService by id', async () => {
       const api = createApi();
       mockFetchResponse({ data: { id: '42' } });
@@ -650,6 +657,13 @@ describe('ProductiveApi requests', () => {
       await api.getComments({ include: ['creator'], filter: { task_id: '1' } });
       const url = fetchSpy.mock.calls[0][0] as string;
       expect(url).toContain('include=creator');
+    });
+
+    it('getComments with sort', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getComments({ sort: '-created_at' });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('sort=-created_at');
     });
 
     it('getComment with include', async () => {
@@ -915,6 +929,13 @@ describe('ProductiveApi requests', () => {
       mockFetchResponse({ data: [] });
       await api.getAttachments({ include: ['task'] });
       expect(fetchSpy.mock.calls[0][0] as string).toContain('include=task');
+    });
+
+    it('getAttachments with sort', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getAttachments({ sort: '-created_at' });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('sort=-created_at');
     });
 
     it('getAttachment by id', async () => {
@@ -1200,6 +1221,13 @@ describe('ProductiveApi requests', () => {
       expect(url).toContain('include=options');
     });
 
+    it('getCustomFields with sort', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getCustomFields({ sort: 'name' });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('sort=name');
+    });
+
     it('getCustomField by ID', async () => {
       const api = createApi();
       mockFetchResponse({
@@ -1261,6 +1289,32 @@ describe('ProductiveApi requests', () => {
       mockFetchResponse({ data: [] });
       await api.getCustomFieldOptions({ include: ['custom_field'] });
       expect(fetchSpy.mock.calls[0][0] as string).toContain('include=custom_field');
+    });
+
+    it('getCustomFieldOptions with sort', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getCustomFieldOptions({ sort: 'name' });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('sort=name');
+    });
+  });
+
+  describe('activities', () => {
+    it('getActivities with filters and include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getActivities({ filter: { event: 'create' }, include: ['creator'] });
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain('/activities');
+      expect(url).toContain('filter%5Bevent%5D=create');
+      expect(url).toContain('include=creator');
+    });
+
+    it('getActivities with sort', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getActivities({ sort: '-created_at' });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('sort=-created_at');
     });
   });
 

--- a/packages/api/src/client.test.ts
+++ b/packages/api/src/client.test.ts
@@ -156,6 +156,27 @@ describe('ProductiveApi requests', () => {
     expect(url).toContain('filter%5Barchived%5D=false');
   });
 
+  it('fetches projects with include', async () => {
+    const api = createApi();
+    mockFetchResponse({ data: [] });
+
+    await api.getProjects({ include: ['company'] });
+
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain('include=company');
+  });
+
+  it('fetches a single project with include', async () => {
+    const api = createApi();
+    mockFetchResponse({ data: { id: '1' } });
+
+    await api.getProject('1', { include: ['company', 'memberships'] });
+
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain('/projects/1');
+    expect(url).toContain('include=company%2Cmemberships');
+  });
+
   it('creates time entry with relationships', async () => {
     const api = createApi();
     const mockResponse = { data: { id: '1', type: 'time_entries', attributes: {} } };
@@ -513,11 +534,27 @@ describe('ProductiveApi requests', () => {
       expect(url).toContain('sort=name');
     });
 
+    it('getPeople with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getPeople({ include: ['company'] });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('include=company');
+    });
+
     it('getPerson', async () => {
       const api = createApi();
       mockFetchResponse({ data: { id: '5' } });
       await api.getPerson('5');
       expect(fetchSpy.mock.calls[0][0] as string).toContain('/people/5');
+    });
+
+    it('getPerson with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: { id: '5' } });
+      await api.getPerson('5', { include: ['company'] });
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain('/people/5');
+      expect(url).toContain('include=company');
     });
   });
 
@@ -528,6 +565,13 @@ describe('ProductiveApi requests', () => {
       await api.getServices({ page: 1, perPage: 50, filter: { project_id: '1' } });
       const url = fetchSpy.mock.calls[0][0] as string;
       expect(url).toContain('/services');
+    });
+
+    it('getServices with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getServices({ include: ['deal'] });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('include=deal');
     });
 
     it('getService by id', async () => {
@@ -556,11 +600,27 @@ describe('ProductiveApi requests', () => {
       expect(url).toContain('/companies');
     });
 
+    it('getCompanies with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getCompanies({ include: ['contacts'] });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('include=contacts');
+    });
+
     it('getCompany', async () => {
       const api = createApi();
       mockFetchResponse({ data: { id: '1' } });
       await api.getCompany('1');
       expect(fetchSpy.mock.calls[0][0] as string).toContain('/companies/1');
+    });
+
+    it('getCompany with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: { id: '1' } });
+      await api.getCompany('1', { include: ['contacts'] });
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain('/companies/1');
+      expect(url).toContain('include=contacts');
     });
 
     it('createCompany', async () => {
@@ -850,6 +910,13 @@ describe('ProductiveApi requests', () => {
       expect(url).toContain('filter%5Btask_id%5D=123');
     });
 
+    it('getAttachments with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getAttachments({ include: ['task'] });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('include=task');
+    });
+
     it('getAttachment by id', async () => {
       const api = createApi();
       mockFetchResponse({
@@ -858,6 +925,15 @@ describe('ProductiveApi requests', () => {
       await api.getAttachment('1');
       const url = fetchSpy.mock.calls[0][0] as string;
       expect(url).toContain('/attachments/1');
+    });
+
+    it('getAttachment with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: { id: '1', type: 'attachments', attributes: {} } });
+      await api.getAttachment('1', { include: ['task'] });
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain('/attachments/1');
+      expect(url).toContain('include=task');
     });
 
     it('deleteAttachment by id', async () => {
@@ -908,6 +984,13 @@ describe('ProductiveApi requests', () => {
       expect(url).toContain('sort=-created_at');
     });
 
+    it('getPages with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getPages({ include: ['creator'] });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('include=creator');
+    });
+
     it('getPage', async () => {
       const api = createApi();
       mockFetchResponse({ data: { id: '1', type: 'pages', attributes: { title: 'Test' } } });
@@ -915,6 +998,15 @@ describe('ProductiveApi requests', () => {
       const url = fetchSpy.mock.calls[0][0] as string;
       expect(url).toContain('/pages/1');
       expect(result.data.id).toBe('1');
+    });
+
+    it('getPage with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: { id: '1', type: 'pages', attributes: {} } });
+      await api.getPage('1', { include: ['creator'] });
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain('/pages/1');
+      expect(url).toContain('include=creator');
     });
 
     it('createPage with all fields', async () => {
@@ -984,6 +1076,13 @@ describe('ProductiveApi requests', () => {
       expect(url).toContain('sort=-created_at');
     });
 
+    it('getDiscussions with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getDiscussions({ include: ['page'] });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('include=page');
+    });
+
     it('getDiscussion', async () => {
       const api = createApi();
       mockFetchResponse({
@@ -993,6 +1092,15 @@ describe('ProductiveApi requests', () => {
       const url = fetchSpy.mock.calls[0][0] as string;
       expect(url).toContain('/discussions/1');
       expect(result.data.id).toBe('1');
+    });
+
+    it('getDiscussion with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: { id: '1', type: 'discussions', attributes: {} } });
+      await api.getDiscussion('1', { include: ['page'] });
+      const url = fetchSpy.mock.calls[0][0] as string;
+      expect(url).toContain('/discussions/1');
+      expect(url).toContain('include=page');
     });
 
     it('createDiscussion with all fields', async () => {
@@ -1146,6 +1254,13 @@ describe('ProductiveApi requests', () => {
       expect(url).toContain('page%5Bnumber%5D=1');
       expect(url).toContain('page%5Bsize%5D=100');
       expect(url).toContain('filter%5Bid%5D=417421%2C417422');
+    });
+
+    it('getCustomFieldOptions with include', async () => {
+      const api = createApi();
+      mockFetchResponse({ data: [] });
+      await api.getCustomFieldOptions({ include: ['custom_field'] });
+      expect(fetchSpy.mock.calls[0][0] as string).toContain('include=custom_field');
     });
   });
 

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -204,6 +204,7 @@ export class ProductiveApi {
     perPage?: number;
     filter?: Record<string, string>;
     sort?: string;
+    include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveProject[]>> {
     const query: Record<string, string> = {};
 
@@ -215,12 +216,20 @@ export class ProductiveApi {
         query[`filter[${key}]`] = value;
       });
     }
+    if (params?.include?.length) {
+      query['include'] = params.include.join(',');
+    }
 
     return this.request<ProductiveApiResponse<ProductiveProject[]>>('/projects', { query });
   }
 
-  async getProject(id: string): Promise<ProductiveApiResponse<ProductiveProject>> {
-    return this.request<ProductiveApiResponse<ProductiveProject>>(`/projects/${id}`);
+  async getProject(
+    id: string,
+    params?: { include?: string[] },
+  ): Promise<ProductiveApiResponse<ProductiveProject>> {
+    const query: Record<string, string> = {};
+    if (params?.include?.length) query['include'] = params.include.join(',');
+    return this.request<ProductiveApiResponse<ProductiveProject>>(`/projects/${id}`, { query });
   }
 
   // Time Entries
@@ -479,6 +488,7 @@ export class ProductiveApi {
     perPage?: number;
     filter?: Record<string, string>;
     sort?: string;
+    include?: string[];
   }): Promise<ProductiveApiResponse<ProductivePerson[]>> {
     const query: Record<string, string> = {};
 
@@ -490,14 +500,22 @@ export class ProductiveApi {
         query[`filter[${key}]`] = value;
       });
     }
+    if (params?.include?.length) {
+      query['include'] = params.include.join(',');
+    }
 
     return this.request<ProductiveApiResponse<ProductivePerson[]>>('/people', {
       query,
     });
   }
 
-  async getPerson(id: string): Promise<ProductiveApiResponse<ProductivePerson>> {
-    return this.request<ProductiveApiResponse<ProductivePerson>>(`/people/${id}`);
+  async getPerson(
+    id: string,
+    params?: { include?: string[] },
+  ): Promise<ProductiveApiResponse<ProductivePerson>> {
+    const query: Record<string, string> = {};
+    if (params?.include?.length) query['include'] = params.include.join(',');
+    return this.request<ProductiveApiResponse<ProductivePerson>>(`/people/${id}`, { query });
   }
 
   // Services
@@ -505,6 +523,7 @@ export class ProductiveApi {
     page?: number;
     perPage?: number;
     filter?: Record<string, string>;
+    include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveService[]>> {
     const query: Record<string, string> = {};
 
@@ -514,6 +533,9 @@ export class ProductiveApi {
       Object.entries(params.filter).forEach(([key, value]) => {
         query[`filter[${key}]`] = value;
       });
+    }
+    if (params?.include?.length) {
+      query['include'] = params.include.join(',');
     }
 
     return this.request<ProductiveApiResponse<ProductiveService[]>>('/services', { query });
@@ -534,6 +556,7 @@ export class ProductiveApi {
     perPage?: number;
     filter?: Record<string, string>;
     sort?: string;
+    include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveCompany[]>> {
     const query: Record<string, string> = {};
 
@@ -545,12 +568,20 @@ export class ProductiveApi {
         query[`filter[${key}]`] = value;
       });
     }
+    if (params?.include?.length) {
+      query['include'] = params.include.join(',');
+    }
 
     return this.request<ProductiveApiResponse<ProductiveCompany[]>>('/companies', { query });
   }
 
-  async getCompany(id: string): Promise<ProductiveApiResponse<ProductiveCompany>> {
-    return this.request<ProductiveApiResponse<ProductiveCompany>>(`/companies/${id}`);
+  async getCompany(
+    id: string,
+    params?: { include?: string[] },
+  ): Promise<ProductiveApiResponse<ProductiveCompany>> {
+    const query: Record<string, string> = {};
+    if (params?.include?.length) query['include'] = params.include.join(',');
+    return this.request<ProductiveApiResponse<ProductiveCompany>>(`/companies/${id}`, { query });
   }
 
   async createCompany(data: {
@@ -1010,6 +1041,7 @@ export class ProductiveApi {
     page?: number;
     perPage?: number;
     filter?: Record<string, string>;
+    include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveAttachment[]>> {
     const query: Record<string, string> = {};
 
@@ -1020,12 +1052,22 @@ export class ProductiveApi {
         query[`filter[${key}]`] = value;
       });
     }
+    if (params?.include?.length) {
+      query['include'] = params.include.join(',');
+    }
 
     return this.request<ProductiveApiResponse<ProductiveAttachment[]>>('/attachments', { query });
   }
 
-  async getAttachment(id: string): Promise<ProductiveApiResponse<ProductiveAttachment>> {
-    return this.request<ProductiveApiResponse<ProductiveAttachment>>(`/attachments/${id}`);
+  async getAttachment(
+    id: string,
+    params?: { include?: string[] },
+  ): Promise<ProductiveApiResponse<ProductiveAttachment>> {
+    const query: Record<string, string> = {};
+    if (params?.include?.length) query['include'] = params.include.join(',');
+    return this.request<ProductiveApiResponse<ProductiveAttachment>>(`/attachments/${id}`, {
+      query,
+    });
   }
 
   async deleteAttachment(id: string): Promise<void> {
@@ -1040,6 +1082,7 @@ export class ProductiveApi {
     perPage?: number;
     filter?: Record<string, string>;
     sort?: string;
+    include?: string[];
   }): Promise<ProductiveApiResponse<ProductivePage[]>> {
     const query: Record<string, string> = {};
 
@@ -1051,12 +1094,20 @@ export class ProductiveApi {
         query[`filter[${key}]`] = value;
       });
     }
+    if (params?.include?.length) {
+      query['include'] = params.include.join(',');
+    }
 
     return this.request<ProductiveApiResponse<ProductivePage[]>>('/pages', { query });
   }
 
-  async getPage(id: string): Promise<ProductiveApiResponse<ProductivePage>> {
-    return this.request<ProductiveApiResponse<ProductivePage>>(`/pages/${id}`);
+  async getPage(
+    id: string,
+    params?: { include?: string[] },
+  ): Promise<ProductiveApiResponse<ProductivePage>> {
+    const query: Record<string, string> = {};
+    if (params?.include?.length) query['include'] = params.include.join(',');
+    return this.request<ProductiveApiResponse<ProductivePage>>(`/pages/${id}`, { query });
   }
 
   async createPage(data: {
@@ -1123,6 +1174,7 @@ export class ProductiveApi {
     perPage?: number;
     filter?: Record<string, string>;
     sort?: string;
+    include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveDiscussion[]>> {
     const query: Record<string, string> = {};
 
@@ -1134,12 +1186,22 @@ export class ProductiveApi {
         query[`filter[${key}]`] = value;
       });
     }
+    if (params?.include?.length) {
+      query['include'] = params.include.join(',');
+    }
 
     return this.request<ProductiveApiResponse<ProductiveDiscussion[]>>('/discussions', { query });
   }
 
-  async getDiscussion(id: string): Promise<ProductiveApiResponse<ProductiveDiscussion>> {
-    return this.request<ProductiveApiResponse<ProductiveDiscussion>>(`/discussions/${id}`);
+  async getDiscussion(
+    id: string,
+    params?: { include?: string[] },
+  ): Promise<ProductiveApiResponse<ProductiveDiscussion>> {
+    const query: Record<string, string> = {};
+    if (params?.include?.length) query['include'] = params.include.join(',');
+    return this.request<ProductiveApiResponse<ProductiveDiscussion>>(`/discussions/${id}`, {
+      query,
+    });
   }
 
   async createDiscussion(data: {
@@ -1320,6 +1382,7 @@ export class ProductiveApi {
     page?: number;
     perPage?: number;
     filter?: Record<string, string>;
+    include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveCustomFieldOption[]>> {
     const query: Record<string, string> = {};
 
@@ -1329,6 +1392,9 @@ export class ProductiveApi {
       Object.entries(params.filter).forEach(([key, value]) => {
         query[`filter[${key}]`] = value;
       });
+    }
+    if (params?.include?.length) {
+      query['include'] = params.include.join(',');
     }
 
     return this.request<ProductiveApiResponse<ProductiveCustomFieldOption[]>>(

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -523,12 +523,14 @@ export class ProductiveApi {
     page?: number;
     perPage?: number;
     filter?: Record<string, string>;
+    sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveService[]>> {
     const query: Record<string, string> = {};
 
     if (params?.page) query['page[number]'] = String(params.page);
     if (params?.perPage) query['page[size]'] = String(params.perPage);
+    if (params?.sort) query['sort'] = params.sort;
     if (params?.filter) {
       Object.entries(params.filter).forEach(([key, value]) => {
         query[`filter[${key}]`] = value;
@@ -650,12 +652,14 @@ export class ProductiveApi {
     page?: number;
     perPage?: number;
     filter?: Record<string, string>;
+    sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveComment[]>> {
     const query: Record<string, string> = {};
 
     if (params?.page) query['page[number]'] = String(params.page);
     if (params?.perPage) query['page[size]'] = String(params.perPage);
+    if (params?.sort) query['sort'] = params.sort;
     if (params?.filter) {
       Object.entries(params.filter).forEach(([key, value]) => {
         query[`filter[${key}]`] = value;
@@ -1041,12 +1045,14 @@ export class ProductiveApi {
     page?: number;
     perPage?: number;
     filter?: Record<string, string>;
+    sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveAttachment[]>> {
     const query: Record<string, string> = {};
 
     if (params?.page) query['page[number]'] = String(params.page);
     if (params?.perPage) query['page[size]'] = String(params.perPage);
+    if (params?.sort) query['sort'] = params.sort;
     if (params?.filter) {
       Object.entries(params.filter).forEach(([key, value]) => {
         query[`filter[${key}]`] = value;
@@ -1322,12 +1328,14 @@ export class ProductiveApi {
     page?: number;
     perPage?: number;
     filter?: Record<string, string>;
+    sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveActivity[]>> {
     const query: Record<string, string> = {};
 
     if (params?.page) query['page[number]'] = String(params.page);
     if (params?.perPage) query['page[size]'] = String(params.perPage);
+    if (params?.sort) query['sort'] = params.sort;
     if (params?.filter) {
       Object.entries(params.filter).forEach(([key, value]) => {
         query[`filter[${key}]`] = value;
@@ -1345,12 +1353,14 @@ export class ProductiveApi {
     page?: number;
     perPage?: number;
     filter?: Record<string, string>;
+    sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveCustomField[]>> {
     const query: Record<string, string> = {};
 
     if (params?.page) query['page[number]'] = String(params.page);
     if (params?.perPage) query['page[size]'] = String(params.perPage);
+    if (params?.sort) query['sort'] = params.sort;
     if (params?.filter) {
       Object.entries(params.filter).forEach(([key, value]) => {
         query[`filter[${key}]`] = value;
@@ -1382,12 +1392,14 @@ export class ProductiveApi {
     page?: number;
     perPage?: number;
     filter?: Record<string, string>;
+    sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveCustomFieldOption[]>> {
     const query: Record<string, string> = {};
 
     if (params?.page) query['page[number]'] = String(params.page);
     if (params?.perPage) query['page[size]'] = String(params.perPage);
+    if (params?.sort) query['sort'] = params.sort;
     if (params?.filter) {
       Object.entries(params.filter).forEach(([key, value]) => {
         query[`filter[${key}]`] = value;

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -854,6 +854,7 @@ export class ProductiveApi {
     name: string;
     company_id: string;
     date?: string;
+    end_date?: string;
     budget?: boolean;
     responsible_id?: string;
   }): Promise<ProductiveApiResponse<ProductiveDeal>> {
@@ -865,16 +866,19 @@ export class ProductiveApi {
       relationships.responsible = { data: { type: 'people', id: data.responsible_id } };
     }
 
+    const attributes: Record<string, unknown> = {
+      name: data.name,
+      date: data.date || new Date().toISOString().split('T')[0],
+      budget: data.budget || false,
+    };
+    if (data.end_date !== undefined) attributes.end_date = data.end_date;
+
     return this.request<ProductiveApiResponse<ProductiveDeal>>('/deals', {
       method: 'POST',
       body: {
         data: {
           type: 'deals',
-          attributes: {
-            name: data.name,
-            date: data.date || new Date().toISOString().split('T')[0],
-            budget: data.budget || false,
-          },
+          attributes,
           relationships,
         },
       },

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -39,6 +39,44 @@ export interface ApiOptions {
   rateLimit?: RateLimitConfig;
 }
 
+/**
+ * Common JSON:API query parameters shared by every collection (list) endpoint.
+ *
+ * Centralizing this shape — together with {@link buildListQuery} — is the single
+ * source of truth for list params, so no endpoint can silently drop `page`,
+ * `perPage`, `sort`, `filter` or `include` the way they historically did.
+ */
+export interface ListParams {
+  page?: number;
+  perPage?: number;
+  sort?: string;
+  filter?: Record<string, string>;
+  include?: string[];
+}
+
+/**
+ * Build the query object for a list (or single-resource `include`) request from
+ * the common {@link ListParams}. Every list/get method routes through this so the
+ * common params are forwarded uniformly by construction.
+ */
+export function buildListQuery(params?: ListParams): Record<string, string> {
+  const query: Record<string, string> = {};
+
+  if (params?.page) query['page[number]'] = String(params.page);
+  if (params?.perPage) query['page[size]'] = String(params.perPage);
+  if (params?.sort) query['sort'] = params.sort;
+  if (params?.filter) {
+    Object.entries(params.filter).forEach(([key, value]) => {
+      query[`filter[${key}]`] = value;
+    });
+  }
+  if (params?.include?.length) {
+    query['include'] = params.include.join(',');
+  }
+
+  return query;
+}
+
 export class ProductiveApi {
   private baseUrl: string;
   private apiToken: string;
@@ -206,19 +244,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveProject[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveProject[]>>('/projects', { query });
   }
@@ -227,8 +253,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveProject>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) query['include'] = params.include.join(',');
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveProject>>(`/projects/${id}`, { query });
   }
 
@@ -240,19 +265,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveTimeEntry[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveTimeEntry[]>>('/time_entries', { query });
   }
@@ -261,8 +274,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveTimeEntry>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) query['include'] = params.include.join(',');
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveTimeEntry>>(`/time_entries/${id}`, {
       query,
     });
@@ -342,19 +354,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveTask[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveTask[]>>('/tasks', {
       query,
@@ -365,10 +365,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveTask>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveTask>>(`/tasks/${id}`, {
       query,
     });
@@ -490,19 +487,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductivePerson[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductivePerson[]>>('/people', {
       query,
@@ -513,8 +498,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductivePerson>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) query['include'] = params.include.join(',');
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductivePerson>>(`/people/${id}`, { query });
   }
 
@@ -526,19 +510,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveService[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveService[]>>('/services', { query });
   }
@@ -547,8 +519,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveService>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) query['include'] = params.include.join(',');
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveService>>(`/services/${id}`, { query });
   }
 
@@ -560,19 +531,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveCompany[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveCompany[]>>('/companies', { query });
   }
@@ -581,8 +540,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveCompany>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) query['include'] = params.include.join(',');
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveCompany>>(`/companies/${id}`, { query });
   }
 
@@ -655,19 +613,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveComment[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveComment[]>>('/comments', { query });
   }
@@ -676,10 +622,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveComment>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveComment>>(`/comments/${id}`, { query });
   }
 
@@ -756,19 +699,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveTimer[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveTimer[]>>('/timers', { query });
   }
@@ -777,10 +708,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveTimer>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveTimer>>(`/timers/${id}`, { query });
   }
 
@@ -822,19 +750,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveDeal[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveDeal[]>>('/deals', { query });
   }
@@ -843,10 +759,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveDeal>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveDeal>>(`/deals/${id}`, { query });
   }
 
@@ -938,19 +851,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveBooking[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveBooking[]>>('/bookings', { query });
   }
@@ -959,10 +860,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveBooking>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveBooking>>(`/bookings/${id}`, { query });
   }
 
@@ -1052,19 +950,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveAttachment[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveAttachment[]>>('/attachments', { query });
   }
@@ -1073,8 +959,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveAttachment>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) query['include'] = params.include.join(',');
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveAttachment>>(`/attachments/${id}`, {
       query,
     });
@@ -1094,19 +979,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductivePage[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductivePage[]>>('/pages', { query });
   }
@@ -1115,8 +988,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductivePage>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) query['include'] = params.include.join(',');
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductivePage>>(`/pages/${id}`, { query });
   }
 
@@ -1186,19 +1058,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveDiscussion[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveDiscussion[]>>('/discussions', { query });
   }
@@ -1207,8 +1067,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveDiscussion>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) query['include'] = params.include.join(',');
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveDiscussion>>(`/discussions/${id}`, {
       query,
     });
@@ -1308,19 +1167,8 @@ export class ProductiveApi {
       include?: string[];
     },
   ): Promise<ProductiveApiResponse<ProductiveReport[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
+    const query = buildListQuery(params);
     if (params?.group) query['group'] = params.group;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
 
     return this.request<ProductiveApiResponse<ProductiveReport[]>>(`/reports/${reportType}`, {
       query,
@@ -1335,19 +1183,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveActivity[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveActivity[]>>('/activities', { query });
   }
@@ -1360,19 +1196,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveCustomField[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveCustomField[]>>('/custom_fields', {
       query,
@@ -1383,10 +1207,7 @@ export class ProductiveApi {
     id: string,
     params?: { include?: string[] },
   ): Promise<ProductiveApiResponse<ProductiveCustomField>> {
-    const query: Record<string, string> = {};
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
     return this.request<ProductiveApiResponse<ProductiveCustomField>>(`/custom_fields/${id}`, {
       query,
     });
@@ -1399,19 +1220,7 @@ export class ProductiveApi {
     sort?: string;
     include?: string[];
   }): Promise<ProductiveApiResponse<ProductiveCustomFieldOption[]>> {
-    const query: Record<string, string> = {};
-
-    if (params?.page) query['page[number]'] = String(params.page);
-    if (params?.perPage) query['page[size]'] = String(params.perPage);
-    if (params?.sort) query['sort'] = params.sort;
-    if (params?.filter) {
-      Object.entries(params.filter).forEach(([key, value]) => {
-        query[`filter[${key}]`] = value;
-      });
-    }
-    if (params?.include?.length) {
-      query['include'] = params.include.join(',');
-    }
+    const query = buildListQuery(params);
 
     return this.request<ProductiveApiResponse<ProductiveCustomFieldOption[]>>(
       '/custom_field_options',

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -11,6 +11,14 @@
  */
 
 /**
+ * Default page size for list/collection requests.
+ *
+ * Single source of truth shared by the core executors and the SDK `all()`
+ * iterators so the default batch size never diverges across layers.
+ */
+export const DEFAULT_PAGE_SIZE = 100;
+
+/**
  * A status/type map with bidirectional lookup capabilities.
  *
  * The base object contains SCREAMING_SNAKE_CASE keys mapping to API string values.

--- a/packages/api/src/formatters/attachment.test.ts
+++ b/packages/api/src/formatters/attachment.test.ts
@@ -86,3 +86,30 @@ describe('formatAttachment', () => {
     expect(r.attachable_type).toBeUndefined();
   });
 });
+
+describe('formatAttachment resolves included relationships', () => {
+  it('inlines the attachable relationship from the included array', () => {
+    const result = formatAttachment(
+      {
+        id: '1',
+        type: 'attachments',
+        attributes: { name: 'f.pdf', content_type: 'application/pdf', size: 1024, url: 'http://x' },
+        relationships: { attachable: { data: { type: 'tasks', id: '77' } } },
+      },
+      { included: [{ id: '77', type: 'tasks', attributes: { title: 'My Task' } }] },
+    );
+
+    expect(result.attachable).toEqual({ id: '77', type: 'tasks', title: 'My Task' });
+  });
+
+  it('adds no relationship object when nothing is sideloaded', () => {
+    const result = formatAttachment({
+      id: '1',
+      type: 'attachments',
+      attributes: { name: 'f.pdf', content_type: 'application/pdf', size: 1024, url: 'http://x' },
+      relationships: { attachable: { data: { type: 'tasks', id: '77' } } },
+    });
+
+    expect(result.attachable).toBeUndefined();
+  });
+});

--- a/packages/api/src/formatters/attachment.ts
+++ b/packages/api/src/formatters/attachment.ts
@@ -4,7 +4,7 @@
 
 import type { JsonApiResource, FormatOptions } from './types.js';
 
-import { resolveRelationships } from './included.js';
+import { applyIncluded } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 export interface FormattedAttachment {
@@ -60,9 +60,7 @@ export function formatAttachment(
     result.created_at = attrs.created_at ? String(attrs.created_at) : undefined;
   }
 
-  if (opts.included) {
-    Object.assign(result, resolveRelationships(attachment, opts.included));
-  }
+  applyIncluded(result, attachment, opts.included);
 
   return result;
 }

--- a/packages/api/src/formatters/attachment.ts
+++ b/packages/api/src/formatters/attachment.ts
@@ -4,6 +4,7 @@
 
 import type { JsonApiResource, FormatOptions } from './types.js';
 
+import { resolveRelationships } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 export interface FormattedAttachment {
@@ -57,6 +58,10 @@ export function formatAttachment(
 
   if (opts.includeTimestamps) {
     result.created_at = attrs.created_at ? String(attrs.created_at) : undefined;
+  }
+
+  if (opts.included) {
+    Object.assign(result, resolveRelationships(attachment, opts.included));
   }
 
   return result;

--- a/packages/api/src/formatters/company.test.ts
+++ b/packages/api/src/formatters/company.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
+import type { JsonApiResource } from './types.js';
+
 import { formatCompany } from './company.js';
 
 const full = {
@@ -69,5 +71,40 @@ describe('formatCompany', () => {
       attributes: { ...full.attributes, custom_fields: {} },
     });
     expect(r.custom_fields).toBeUndefined();
+  });
+});
+
+describe('formatCompany resolves included relationships', () => {
+  it('inlines a to-many contacts relationship from the included array', () => {
+    const company = {
+      id: '1',
+      type: 'companies',
+      attributes: { name: 'Acme' },
+      relationships: {
+        contacts: {
+          data: [
+            { type: 'contact_entries', id: '7' },
+            { type: 'contact_entries', id: '8' },
+          ],
+        },
+      },
+    } as unknown as JsonApiResource;
+
+    const result = formatCompany(company, {
+      included: [
+        { id: '7', type: 'contact_entries', attributes: { email: 'a@b.com' } },
+        { id: '8', type: 'contact_entries', attributes: { email: 'c@d.com' } },
+      ],
+    });
+
+    expect(result.contacts).toEqual([
+      { id: '7', type: 'contact_entries', email: 'a@b.com' },
+      { id: '8', type: 'contact_entries', email: 'c@d.com' },
+    ]);
+  });
+
+  it('adds no relationship object when nothing is sideloaded', () => {
+    const result = formatCompany({ id: '1', type: 'companies', attributes: { name: 'Acme' } });
+    expect(result.contacts).toBeUndefined();
   });
 });

--- a/packages/api/src/formatters/company.ts
+++ b/packages/api/src/formatters/company.ts
@@ -4,6 +4,7 @@
 
 import type { JsonApiResource, FormatOptions } from './types.js';
 
+import { resolveRelationships } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 export interface FormattedCompany {
@@ -49,6 +50,10 @@ export function formatCompany(company: JsonApiResource, options?: FormatOptions)
   if (opts.includeTimestamps) {
     result.created_at = attrs.created_at ? String(attrs.created_at) : undefined;
     result.updated_at = attrs.updated_at ? String(attrs.updated_at) : undefined;
+  }
+
+  if (opts.included) {
+    Object.assign(result, resolveRelationships(company, opts.included));
   }
 
   return result;

--- a/packages/api/src/formatters/company.ts
+++ b/packages/api/src/formatters/company.ts
@@ -4,7 +4,7 @@
 
 import type { JsonApiResource, FormatOptions } from './types.js';
 
-import { resolveRelationships } from './included.js';
+import { applyIncluded } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 export interface FormattedCompany {
@@ -52,9 +52,7 @@ export function formatCompany(company: JsonApiResource, options?: FormatOptions)
     result.updated_at = attrs.updated_at ? String(attrs.updated_at) : undefined;
   }
 
-  if (opts.included) {
-    Object.assign(result, resolveRelationships(company, opts.included));
-  }
+  applyIncluded(result, company, opts.included);
 
   return result;
 }

--- a/packages/api/src/formatters/discussion.test.ts
+++ b/packages/api/src/formatters/discussion.test.ts
@@ -102,3 +102,18 @@ describe('formatDiscussion', () => {
     expect(r.status).toBe('active');
   });
 });
+
+describe('formatDiscussion resolves included relationships', () => {
+  it('inlines the page relationship from the included array', () => {
+    const result = formatDiscussion(fullDiscussion, {
+      included: [{ id: '10', type: 'pages', attributes: { title: 'Parent Page' } }],
+    });
+
+    expect(result.page).toEqual({ id: '10', type: 'pages', title: 'Parent Page' });
+  });
+
+  it('adds no relationship object when nothing is sideloaded', () => {
+    const result = formatDiscussion(fullDiscussion);
+    expect(result.page).toBeUndefined();
+  });
+});

--- a/packages/api/src/formatters/discussion.ts
+++ b/packages/api/src/formatters/discussion.ts
@@ -5,7 +5,7 @@
 import type { JsonApiResource, FormatOptions } from './types.js';
 
 import { stripHtml } from '../utils/html.js';
-import { resolveRelationships } from './included.js';
+import { applyIncluded } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 const STATUS_LABELS: Record<number, string> = {
@@ -61,9 +61,7 @@ export function formatDiscussion(
     result.updated_at = attrs.updated_at ? String(attrs.updated_at) : undefined;
   }
 
-  if (opts.included) {
-    Object.assign(result, resolveRelationships(discussion, opts.included));
-  }
+  applyIncluded(result, discussion, opts.included);
 
   return result;
 }

--- a/packages/api/src/formatters/discussion.ts
+++ b/packages/api/src/formatters/discussion.ts
@@ -5,6 +5,7 @@
 import type { JsonApiResource, FormatOptions } from './types.js';
 
 import { stripHtml } from '../utils/html.js';
+import { resolveRelationships } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 const STATUS_LABELS: Record<number, string> = {
@@ -58,6 +59,10 @@ export function formatDiscussion(
   if (opts.includeTimestamps) {
     result.created_at = attrs.created_at ? String(attrs.created_at) : undefined;
     result.updated_at = attrs.updated_at ? String(attrs.updated_at) : undefined;
+  }
+
+  if (opts.included) {
+    Object.assign(result, resolveRelationships(discussion, opts.included));
   }
 
   return result;

--- a/packages/api/src/formatters/included.test.ts
+++ b/packages/api/src/formatters/included.test.ts
@@ -22,6 +22,38 @@ describe('getIncludedResource', () => {
     expect(getIncludedResource(included, undefined, '99')).toBeUndefined();
     expect(getIncludedResource(undefined, 'companies', '99')).toBeUndefined();
   });
+
+  it('indexes the included array once and reuses it across lookups', () => {
+    let typeReads = 0;
+    const probe = included.map(
+      (resource) =>
+        new Proxy(resource, {
+          get(target, prop, receiver) {
+            if (prop === 'type') typeReads += 1;
+            return Reflect.get(target, prop, receiver);
+          },
+        }) as JsonApiResource,
+    );
+
+    // Three lookups against the same `included` reference must build the
+    // type/id index a single time — reading each entry's `type` exactly once —
+    // instead of re-scanning the array linearly on every lookup.
+    getIncludedResource(probe, 'people', '5');
+    getIncludedResource(probe, 'contact_entries', '8');
+    getIncludedResource(probe, 'companies', '99');
+
+    expect(typeReads).toBe(probe.length);
+  });
+
+  it('keeps the first match when included has duplicate type/id entries', () => {
+    const dupes: JsonApiResource[] = [
+      { id: '1', type: 'companies', attributes: { name: 'First' } },
+      { id: '1', type: 'companies', attributes: { name: 'Second' } },
+    ];
+    expect(getIncludedResource(dupes, 'companies', '1')).toMatchObject({
+      attributes: { name: 'First' },
+    });
+  });
 });
 
 describe('resolveRelationships', () => {

--- a/packages/api/src/formatters/included.test.ts
+++ b/packages/api/src/formatters/included.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import type { JsonApiResource } from './types.js';
+
+import { getIncludedResource, resolveRelationships } from './included.js';
+
+const included: JsonApiResource[] = [
+  { id: '99', type: 'companies', attributes: { name: 'Acme Inc.' } },
+  { id: '5', type: 'people', attributes: { first_name: 'Jane', last_name: 'Doe' } },
+  { id: '7', type: 'contact_entries', attributes: { email: 'a@b.com' } },
+  { id: '8', type: 'contact_entries', attributes: { email: 'c@d.com' } },
+];
+
+describe('getIncludedResource', () => {
+  it('finds a sideloaded resource by type and id', () => {
+    expect(getIncludedResource(included, 'companies', '99')).toMatchObject({ id: '99' });
+  });
+
+  it('returns undefined when not found or when args are missing', () => {
+    expect(getIncludedResource(included, 'companies', '1')).toBeUndefined();
+    expect(getIncludedResource(included, 'companies', undefined)).toBeUndefined();
+    expect(getIncludedResource(included, undefined, '99')).toBeUndefined();
+    expect(getIncludedResource(undefined, 'companies', '99')).toBeUndefined();
+  });
+});
+
+describe('resolveRelationships', () => {
+  it('inlines a to-one relationship that has a match in included', () => {
+    const resource: JsonApiResource = {
+      id: '1',
+      type: 'projects',
+      attributes: { name: 'P' },
+      relationships: { company: { data: { type: 'companies', id: '99' } } },
+    };
+
+    expect(resolveRelationships(resource, included)).toEqual({
+      company: { id: '99', type: 'companies', name: 'Acme Inc.' },
+    });
+  });
+
+  it('inlines a to-many relationship as an array', () => {
+    const resource = {
+      id: '1',
+      type: 'companies',
+      attributes: { name: 'Acme' },
+      relationships: {
+        contacts: {
+          data: [
+            { type: 'contact_entries', id: '7' },
+            { type: 'contact_entries', id: '8' },
+          ],
+        },
+      },
+    };
+
+    expect(resolveRelationships(resource, included)).toEqual({
+      contacts: [
+        { id: '7', type: 'contact_entries', email: 'a@b.com' },
+        { id: '8', type: 'contact_entries', email: 'c@d.com' },
+      ],
+    });
+  });
+
+  it('keeps id and type authoritative even if attributes collide', () => {
+    const withCollision: JsonApiResource[] = [
+      { id: '99', type: 'companies', attributes: { id: 'WRONG', type: 'WRONG', name: 'Acme' } },
+    ];
+    const resource: JsonApiResource = {
+      id: '1',
+      type: 'projects',
+      attributes: {},
+      relationships: { company: { data: { type: 'companies', id: '99' } } },
+    };
+
+    expect(resolveRelationships(resource, withCollision)).toEqual({
+      company: { id: '99', type: 'companies', name: 'Acme' },
+    });
+  });
+
+  it('skips relationships with no match, null data, or no included', () => {
+    const resource: JsonApiResource = {
+      id: '1',
+      type: 'projects',
+      attributes: {},
+      relationships: {
+        company: { data: { type: 'companies', id: 'missing' } },
+        responsible: { data: null },
+      },
+    };
+
+    expect(resolveRelationships(resource, included)).toEqual({});
+    expect(resolveRelationships(resource, undefined)).toEqual({});
+    expect(resolveRelationships({ id: '1', type: 'projects', attributes: {} }, included)).toEqual(
+      {},
+    );
+  });
+
+  it('resolves several relationships and drops array entries with no match', () => {
+    const resource = {
+      id: '1',
+      type: 'pages',
+      attributes: {},
+      relationships: {
+        creator: { data: { type: 'people', id: '5' } },
+        contacts: {
+          data: [
+            { type: 'contact_entries', id: '7' },
+            { type: 'contact_entries', id: 'nope' },
+          ],
+        },
+      },
+    };
+
+    expect(resolveRelationships(resource, included)).toEqual({
+      creator: { id: '5', type: 'people', first_name: 'Jane', last_name: 'Doe' },
+      contacts: [{ id: '7', type: 'contact_entries', email: 'a@b.com' }],
+    });
+  });
+});

--- a/packages/api/src/formatters/included.test.ts
+++ b/packages/api/src/formatters/included.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { JsonApiResource } from './types.js';
 
-import { getIncludedResource, resolveRelationships } from './included.js';
+import { applyIncluded, getIncludedResource, resolveRelationships } from './included.js';
 
 const included: JsonApiResource[] = [
   { id: '99', type: 'companies', attributes: { name: 'Acme Inc.' } },
@@ -147,5 +147,35 @@ describe('resolveRelationships', () => {
       creator: { id: '5', type: 'people', first_name: 'Jane', last_name: 'Doe' },
       contacts: [{ id: '7', type: 'contact_entries', email: 'a@b.com' }],
     });
+  });
+});
+
+describe('applyIncluded', () => {
+  it('inlines resolved relationships onto the target in place', () => {
+    const resource: JsonApiResource = {
+      id: '1',
+      type: 'projects',
+      attributes: { name: 'P' },
+      relationships: { company: { data: { type: 'companies', id: '99' } } },
+    };
+    const target: Record<string, unknown> = { id: '1', name: 'P' };
+
+    applyIncluded(target, resource, included);
+
+    expect(target.company).toMatchObject({ id: '99', type: 'companies', name: 'Acme Inc.' });
+  });
+
+  it('is a no-op when included is undefined', () => {
+    const resource: JsonApiResource = {
+      id: '1',
+      type: 'projects',
+      attributes: {},
+      relationships: { company: { data: { type: 'companies', id: '99' } } },
+    };
+    const target: Record<string, unknown> = { id: '1' };
+
+    applyIncluded(target, resource, undefined);
+
+    expect(target).toEqual({ id: '1' });
   });
 });

--- a/packages/api/src/formatters/included.ts
+++ b/packages/api/src/formatters/included.ts
@@ -20,6 +20,30 @@ export interface ResolvedRelationship {
 }
 
 /**
+ * Index of an `included` array keyed by `${type}\0${id}`, memoized per array
+ * reference. A list response hands the *same* `included` array to every record's
+ * formatter, so indexing once turns the formatting pass from O(records × includes)
+ * linear scans into O(records) O(1) lookups over a single shared index.
+ */
+const lookupCache = new WeakMap<JsonApiResource[], Map<string, JsonApiResource>>();
+
+const lookupKey = (type: string, id: string): string => `${type}\0${id}`;
+
+function getLookup(included: JsonApiResource[]): Map<string, JsonApiResource> {
+  const cached = lookupCache.get(included);
+  if (cached) return cached;
+
+  const lookup = new Map<string, JsonApiResource>();
+  for (const resource of included) {
+    const key = lookupKey(resource.type, resource.id);
+    // First entry wins, matching the previous Array.find semantics.
+    if (!lookup.has(key)) lookup.set(key, resource);
+  }
+  lookupCache.set(included, lookup);
+  return lookup;
+}
+
+/**
  * Find a sideloaded resource in the `included` array by type and id.
  */
 export function getIncludedResource(
@@ -28,7 +52,7 @@ export function getIncludedResource(
   id: string | undefined,
 ): JsonApiResource | undefined {
   if (!included || !type || !id) return undefined;
-  return included.find((resource) => resource.type === type && resource.id === id);
+  return getLookup(included).get(lookupKey(type, id));
 }
 
 interface ResourceRef {

--- a/packages/api/src/formatters/included.ts
+++ b/packages/api/src/formatters/included.ts
@@ -103,3 +103,18 @@ export function resolveRelationships(
 
   return resolved;
 }
+
+/**
+ * Inline any sideloaded relationships from `included` onto `target` in place.
+ * A no-op when `included` is absent, so every resource formatter shares one
+ * guarded call instead of repeating the `if (opts.included) Object.assign(...)`
+ * block.
+ */
+export function applyIncluded(
+  target: Record<string, unknown>,
+  resource: Parameters<typeof resolveRelationships>[0],
+  included: JsonApiResource[] | undefined,
+): void {
+  if (!included) return;
+  Object.assign(target, resolveRelationships(resource, included));
+}

--- a/packages/api/src/formatters/included.ts
+++ b/packages/api/src/formatters/included.ts
@@ -1,0 +1,81 @@
+/**
+ * Resolving JSON:API `included` (sideloaded) resources into a formatted result.
+ *
+ * When a list/get request forwards an `include` param, the API returns the
+ * related resources in a top-level `included` array. These helpers inline those
+ * relationships into the formatted output so consumers (CLI, MCP) actually see
+ * e.g. a project's `company` instead of just a dangling relationship id.
+ */
+
+import type { JsonApiResource } from './types.js';
+
+/**
+ * A relationship inlined from the `included` array: the resource's `id` and
+ * `type` plus its attributes flattened to the top level.
+ */
+export interface ResolvedRelationship {
+  id: string;
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Find a sideloaded resource in the `included` array by type and id.
+ */
+export function getIncludedResource(
+  included: JsonApiResource[] | undefined,
+  type: string | undefined,
+  id: string | undefined,
+): JsonApiResource | undefined {
+  if (!included || !type || !id) return undefined;
+  return included.find((resource) => resource.type === type && resource.id === id);
+}
+
+interface ResourceRef {
+  type: string;
+  id: string;
+}
+
+function inline(
+  ref: ResourceRef | undefined,
+  included: JsonApiResource[],
+): ResolvedRelationship | undefined {
+  const found = getIncludedResource(included, ref?.type, ref?.id);
+  if (!found) return undefined;
+  // `id`/`type` stay authoritative even if the attributes happen to repeat them.
+  return { ...found.attributes, id: found.id, type: found.type };
+}
+
+/**
+ * Resolve every relationship on `resource` that has a matching entry in
+ * `included`, returning a map keyed by relationship name. Only relationships
+ * actually sideloaded (present in `included`) are returned, so this inlines
+ * exactly what the caller requested via `include`. To-one relationships resolve
+ * to a single object; to-many relationships resolve to an array.
+ */
+export function resolveRelationships(
+  resource: {
+    relationships?: Record<string, { data?: ResourceRef | ResourceRef[] | null }>;
+  },
+  included: JsonApiResource[] | undefined,
+): Record<string, ResolvedRelationship | ResolvedRelationship[]> {
+  const resolved: Record<string, ResolvedRelationship | ResolvedRelationship[]> = {};
+  if (!included || !resource.relationships) return resolved;
+
+  for (const [name, rel] of Object.entries(resource.relationships)) {
+    const data = rel?.data;
+    if (!data) continue;
+
+    if (Array.isArray(data)) {
+      const items = data
+        .map((ref) => inline(ref, included))
+        .filter((item): item is ResolvedRelationship => item !== undefined);
+      if (items.length > 0) resolved[name] = items;
+    } else {
+      const item = inline(data, included);
+      if (item) resolved[name] = item;
+    }
+  }
+
+  return resolved;
+}

--- a/packages/api/src/formatters/page.test.ts
+++ b/packages/api/src/formatters/page.test.ts
@@ -83,3 +83,25 @@ describe('formatPage', () => {
     expect(r.public).toBe(false);
   });
 });
+
+describe('formatPage resolves included relationships', () => {
+  it('inlines the creator relationship from the included array', () => {
+    const result = formatPage(fullPage, {
+      included: [
+        { id: '20', type: 'people', attributes: { first_name: 'Jane', last_name: 'Doe' } },
+      ],
+    });
+
+    expect(result.creator).toEqual({
+      id: '20',
+      type: 'people',
+      first_name: 'Jane',
+      last_name: 'Doe',
+    });
+  });
+
+  it('adds no relationship object when nothing is sideloaded', () => {
+    const result = formatPage(fullPage);
+    expect(result.creator).toBeUndefined();
+  });
+});

--- a/packages/api/src/formatters/page.ts
+++ b/packages/api/src/formatters/page.ts
@@ -5,6 +5,7 @@
 import type { JsonApiResource, FormatOptions } from './types.js';
 
 import { stripHtml } from '../utils/html.js';
+import { resolveRelationships } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 export interface FormattedPage {
@@ -53,6 +54,10 @@ export function formatPage(page: JsonApiResource, options?: FormatOptions): Form
     result.created_at = attrs.created_at ? String(attrs.created_at) : undefined;
     result.updated_at = attrs.updated_at ? String(attrs.updated_at) : undefined;
     result.edited_at = attrs.edited_at ? String(attrs.edited_at) : undefined;
+  }
+
+  if (opts.included) {
+    Object.assign(result, resolveRelationships(page, opts.included));
   }
 
   return result;

--- a/packages/api/src/formatters/page.ts
+++ b/packages/api/src/formatters/page.ts
@@ -5,7 +5,7 @@
 import type { JsonApiResource, FormatOptions } from './types.js';
 
 import { stripHtml } from '../utils/html.js';
-import { resolveRelationships } from './included.js';
+import { applyIncluded } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 export interface FormattedPage {
@@ -56,9 +56,7 @@ export function formatPage(page: JsonApiResource, options?: FormatOptions): Form
     result.edited_at = attrs.edited_at ? String(attrs.edited_at) : undefined;
   }
 
-  if (opts.included) {
-    Object.assign(result, resolveRelationships(page, opts.included));
-  }
+  applyIncluded(result, page, opts.included);
 
   return result;
 }

--- a/packages/api/src/formatters/person.test.ts
+++ b/packages/api/src/formatters/person.test.ts
@@ -79,3 +79,29 @@ describe('formatPerson', () => {
     expect(r.custom_fields).toBeUndefined();
   });
 });
+
+describe('formatPerson resolves included relationships', () => {
+  it('inlines the company relationship from the included array', () => {
+    const result = formatPerson(
+      {
+        id: '1',
+        type: 'people',
+        attributes: { first_name: 'Jane', last_name: 'Doe' },
+        relationships: { company: { data: { type: 'companies', id: '99' } } },
+      },
+      { included: [{ id: '99', type: 'companies', attributes: { name: 'Acme Inc.' } }] },
+    );
+
+    expect(result.company).toEqual({ id: '99', type: 'companies', name: 'Acme Inc.' });
+  });
+
+  it('adds no relationship object when nothing is sideloaded', () => {
+    const result = formatPerson({
+      id: '1',
+      type: 'people',
+      attributes: { first_name: 'Jane', last_name: 'Doe' },
+    });
+
+    expect(result.company).toBeUndefined();
+  });
+});

--- a/packages/api/src/formatters/person.ts
+++ b/packages/api/src/formatters/person.ts
@@ -4,7 +4,7 @@
 
 import type { JsonApiResource, FormatOptions, FormattedPerson } from './types.js';
 
-import { resolveRelationships } from './included.js';
+import { applyIncluded } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 /**
@@ -46,9 +46,7 @@ export function formatPerson(
     result.updated_at = attrs.updated_at as string | undefined;
   }
 
-  if (opts.included) {
-    Object.assign(result, resolveRelationships(person, opts.included));
-  }
+  applyIncluded(result, person, opts.included);
 
   return result;
 }

--- a/packages/api/src/formatters/person.ts
+++ b/packages/api/src/formatters/person.ts
@@ -4,6 +4,7 @@
 
 import type { JsonApiResource, FormatOptions, FormattedPerson } from './types.js';
 
+import { resolveRelationships } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 /**
@@ -43,6 +44,10 @@ export function formatPerson(
   if (opts.includeTimestamps) {
     result.created_at = attrs.created_at as string | undefined;
     result.updated_at = attrs.updated_at as string | undefined;
+  }
+
+  if (opts.included) {
+    Object.assign(result, resolveRelationships(person, opts.included));
   }
 
   return result;

--- a/packages/api/src/formatters/project.test.ts
+++ b/packages/api/src/formatters/project.test.ts
@@ -36,3 +36,30 @@ describe('formatProject', () => {
     expect(result.updated_at).toBeUndefined();
   });
 });
+
+describe('formatProject resolves included relationships', () => {
+  it('inlines the company relationship from the included array (issue #174)', () => {
+    const result = formatProject(
+      {
+        id: '1',
+        type: 'projects',
+        attributes: { name: 'Alpha' },
+        relationships: { company: { data: { type: 'companies', id: '99' } } },
+      },
+      { included: [{ id: '99', type: 'companies', attributes: { name: 'Acme Inc.' } }] },
+    );
+
+    expect(result.company).toEqual({ id: '99', type: 'companies', name: 'Acme Inc.' });
+  });
+
+  it('adds no relationship object when nothing is sideloaded', () => {
+    const result = formatProject({
+      id: '1',
+      type: 'projects',
+      attributes: { name: 'Alpha' },
+      relationships: { company: { data: { type: 'companies', id: '99' } } },
+    });
+
+    expect(result.company).toBeUndefined();
+  });
+});

--- a/packages/api/src/formatters/project.ts
+++ b/packages/api/src/formatters/project.ts
@@ -4,6 +4,7 @@
 
 import type { JsonApiResource, FormatOptions, FormattedProject } from './types.js';
 
+import { resolveRelationships } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 /**
@@ -32,6 +33,10 @@ export function formatProject(
   if (opts.includeTimestamps) {
     result.created_at = attrs.created_at as string | undefined;
     result.updated_at = attrs.updated_at as string | undefined;
+  }
+
+  if (opts.included) {
+    Object.assign(result, resolveRelationships(project, opts.included));
   }
 
   return result;

--- a/packages/api/src/formatters/project.ts
+++ b/packages/api/src/formatters/project.ts
@@ -4,7 +4,7 @@
 
 import type { JsonApiResource, FormatOptions, FormattedProject } from './types.js';
 
-import { resolveRelationships } from './included.js';
+import { applyIncluded } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 /**
@@ -35,9 +35,7 @@ export function formatProject(
     result.updated_at = attrs.updated_at as string | undefined;
   }
 
-  if (opts.included) {
-    Object.assign(result, resolveRelationships(project, opts.included));
-  }
+  applyIncluded(result, project, opts.included);
 
   return result;
 }

--- a/packages/api/src/formatters/service.test.ts
+++ b/packages/api/src/formatters/service.test.ts
@@ -69,3 +69,30 @@ describe('formatService', () => {
     expect(r.billing_type_id).toBeUndefined();
   });
 });
+
+describe('formatService resolves included relationships', () => {
+  it('inlines the deal relationship from the included array', () => {
+    const result = formatService(
+      {
+        id: '1',
+        type: 'services',
+        attributes: { name: 'Dev' },
+        relationships: { deal: { data: { type: 'deals', id: '4' } } },
+      },
+      { included: [{ id: '4', type: 'deals', attributes: { name: 'Big Deal' } }] },
+    );
+
+    expect(result.deal).toEqual({ id: '4', type: 'deals', name: 'Big Deal' });
+  });
+
+  it('adds no relationship object when nothing is sideloaded', () => {
+    const result = formatService({
+      id: '1',
+      type: 'services',
+      attributes: { name: 'Dev' },
+      relationships: { deal: { data: { type: 'deals', id: '4' } } },
+    });
+
+    expect(result.deal).toBeUndefined();
+  });
+});

--- a/packages/api/src/formatters/service.ts
+++ b/packages/api/src/formatters/service.ts
@@ -4,6 +4,7 @@
 
 import type { JsonApiResource, FormatOptions, FormattedService } from './types.js';
 
+import { resolveRelationships } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 /**
@@ -36,6 +37,10 @@ export function formatService(
   if (opts.includeTimestamps) {
     result.created_at = attrs.created_at as string | undefined;
     result.updated_at = attrs.updated_at as string | undefined;
+  }
+
+  if (opts.included) {
+    Object.assign(result, resolveRelationships(service, opts.included));
   }
 
   return result;

--- a/packages/api/src/formatters/service.ts
+++ b/packages/api/src/formatters/service.ts
@@ -4,7 +4,7 @@
 
 import type { JsonApiResource, FormatOptions, FormattedService } from './types.js';
 
-import { resolveRelationships } from './included.js';
+import { applyIncluded } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 /**
@@ -39,9 +39,7 @@ export function formatService(
     result.updated_at = attrs.updated_at as string | undefined;
   }
 
-  if (opts.included) {
-    Object.assign(result, resolveRelationships(service, opts.included));
-  }
+  applyIncluded(result, service, opts.included);
 
   return result;
 }

--- a/packages/api/src/formatters/time-entry.test.ts
+++ b/packages/api/src/formatters/time-entry.test.ts
@@ -77,3 +77,18 @@ describe('formatTimeEntry', () => {
     expect(result.started_at).toBeUndefined();
   });
 });
+
+describe('formatTimeEntry resolves included relationships', () => {
+  it('inlines the service relationship from the included array', () => {
+    const result = formatTimeEntry(mockEntry, {
+      included: [{ id: '200', type: 'services', attributes: { name: 'Development' } }],
+    });
+
+    expect(result.service).toEqual({ id: '200', type: 'services', name: 'Development' });
+  });
+
+  it('adds no relationship object when nothing is sideloaded', () => {
+    const result = formatTimeEntry(mockEntry);
+    expect(result.service).toBeUndefined();
+  });
+});

--- a/packages/api/src/formatters/time-entry.ts
+++ b/packages/api/src/formatters/time-entry.ts
@@ -5,6 +5,7 @@
 import type { JsonApiResource, FormatOptions, FormattedTimeEntry } from './types.js';
 
 import { stripHtml } from '../utils/html.js';
+import { resolveRelationships } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 /**
@@ -55,6 +56,10 @@ export function formatTimeEntry(
   if (opts.includeTimestamps) {
     result.created_at = attrs.created_at as string | undefined;
     result.updated_at = attrs.updated_at as string | undefined;
+  }
+
+  if (opts.included) {
+    Object.assign(result, resolveRelationships(entry, opts.included));
   }
 
   return result;

--- a/packages/api/src/formatters/time-entry.ts
+++ b/packages/api/src/formatters/time-entry.ts
@@ -5,7 +5,7 @@
 import type { JsonApiResource, FormatOptions, FormattedTimeEntry } from './types.js';
 
 import { stripHtml } from '../utils/html.js';
-import { resolveRelationships } from './included.js';
+import { applyIncluded } from './included.js';
 import { DEFAULT_FORMAT_OPTIONS } from './types.js';
 
 /**
@@ -58,9 +58,7 @@ export function formatTimeEntry(
     result.updated_at = attrs.updated_at as string | undefined;
   }
 
-  if (opts.included) {
-    Object.assign(result, resolveRelationships(entry, opts.included));
-  }
+  applyIncluded(result, entry, opts.included);
 
   return result;
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -6,8 +6,8 @@
  */
 
 // API client
-export { ProductiveApi } from './client.js';
-export type { ApiOptions } from './client.js';
+export { ProductiveApi, buildListQuery } from './client.js';
+export type { ApiOptions, ListParams } from './client.js';
 
 // Rate limiter
 export { RateLimiter, DEFAULT_RATE_LIMIT_CONFIG } from './rate-limiter.js';
@@ -110,6 +110,7 @@ export type {
 } from './formatters/custom-field.js';
 
 // Status/type constants (bidirectional lookup maps)
+export { DEFAULT_PAGE_SIZE } from './constants.js';
 export { createStatusMap, createNumericStatusMap } from './constants.js';
 export type { StatusMap, NumericStatusMap } from './constants.js';
 export {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,10 +53,10 @@
     "@studiometa/productive-sdk": "*"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^4.1.7",
+    "@vitest/coverage-v8": "^4.1.8",
     "memfs": "4.57.2",
-    "vite": "^8.0.14",
-    "vitest": "^4.1.7"
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/cli/src/commands/attachments.test.ts
+++ b/packages/cli/src/commands/attachments.test.ts
@@ -478,4 +478,33 @@ describe('attachments command', () => {
       expect(deleteAttachment).toHaveBeenCalledWith('1');
     });
   });
+
+  describe('--include forwarding', () => {
+    it('forwards --include to the list request', async () => {
+      const getAttachments = vi.fn().mockResolvedValue({ data: [], meta: {}, included: [] });
+      const ctx = createTestContext({
+        api: { getAttachments } as unknown as ProductiveApi,
+        options: { include: 'task' },
+      });
+
+      await attachmentsList(ctx);
+
+      expect(getAttachments).toHaveBeenCalledWith(expect.objectContaining({ include: ['task'] }));
+    });
+
+    it('forwards --include to the get request', async () => {
+      const getAttachment = vi.fn().mockResolvedValue({
+        data: { id: '1', type: 'attachments', attributes: { name: 'f.pdf' } },
+        included: [],
+      });
+      const ctx = createTestContext({
+        api: { getAttachment } as unknown as ProductiveApi,
+        options: { include: 'task' },
+      });
+
+      await attachmentsGet(['1'], ctx);
+
+      expect(getAttachment).toHaveBeenCalledWith('1', { include: ['task'] });
+    });
+  });
 });

--- a/packages/cli/src/commands/attachments.test.ts
+++ b/packages/cli/src/commands/attachments.test.ts
@@ -274,7 +274,7 @@ describe('attachments command', () => {
 
       await attachmentsGet(['1'], ctx);
 
-      expect(getAttachment).toHaveBeenCalledWith('1');
+      expect(getAttachment).toHaveBeenCalledWith('1', { include: undefined });
       expect(consoleLogSpy).toHaveBeenCalled();
     });
 
@@ -465,7 +465,7 @@ describe('attachments command', () => {
         options: { format: 'json' },
       });
       await attachmentsGet(['1'], ctx);
-      expect(getAttachment).toHaveBeenCalledWith('1');
+      expect(getAttachment).toHaveBeenCalledWith('1', { include: undefined });
     });
 
     it('should route delete subcommand', async () => {

--- a/packages/cli/src/commands/attachments/handlers.ts
+++ b/packages/cli/src/commands/attachments/handlers.ts
@@ -38,6 +38,7 @@ function parseListOptions(ctx: CommandContext): ListAttachmentsOptions {
   const { page, perPage } = ctx.getPagination();
   options.page = page;
   options.perPage = perPage;
+  options.include = ctx.getInclude();
 
   return options;
 }
@@ -53,7 +54,9 @@ export async function attachmentsList(ctx: CommandContext): Promise<void> {
     spinner.succeed();
 
     const format = (ctx.options.format || ctx.options.f || 'human') as OutputFormat;
-    const formattedData = formatListResponse(result.data, formatAttachment, result.meta);
+    const formattedData = formatListResponse(result.data, formatAttachment, result.meta, {
+      included: result.included,
+    });
 
     if (format === 'csv' || format === 'table') {
       const data = result.data.map((a) => ({
@@ -80,12 +83,12 @@ export async function attachmentsGet(args: string[], ctx: CommandContext): Promi
 
   await runCommand(async () => {
     const execCtx = fromCommandContext(ctx);
-    const result = await getAttachment({ id }, execCtx);
+    const result = await getAttachment({ id, include: ctx.getInclude() }, execCtx);
 
     spinner.succeed();
 
     const format = (ctx.options.format || ctx.options.f || 'human') as OutputFormat;
-    const formattedData = formatAttachment(result.data);
+    const formattedData = formatAttachment(result.data, { included: result.included });
 
     if (format === 'json') {
       ctx.formatter.output(formattedData);

--- a/packages/cli/src/commands/attachments/help.ts
+++ b/packages/cli/src/commands/attachments/help.ts
@@ -18,6 +18,7 @@ ${colors.bold('OPTIONS:')}
   --page <id>         Filter by page ID
   --deal <id>         Filter by deal ID
   --filter <filters>  Generic filters (comma-separated key=value pairs)
+  --include <list>    Sideload related resources (comma-separated, e.g. task)
   -p, --page <num>    Page number (default: 1)
   -s, --size <num>    Page size (default: 100)
   -f, --format <fmt>  Output format: json, human, csv, table

--- a/packages/cli/src/commands/companies.test.ts
+++ b/packages/cli/src/commands/companies.test.ts
@@ -95,7 +95,7 @@ describe('companies command', () => {
 
       await companiesGet(['1'], ctx);
 
-      expect(getCompany).toHaveBeenCalledWith('1');
+      expect(getCompany).toHaveBeenCalledWith('1', { include: undefined });
       expect(consoleLogSpy).toHaveBeenCalled();
     });
 

--- a/packages/cli/src/commands/companies.test.ts
+++ b/packages/cli/src/commands/companies.test.ts
@@ -290,4 +290,33 @@ describe('companies command', () => {
       expect(processExitSpy).toHaveBeenCalledWith(1);
     });
   });
+
+  describe('--include forwarding', () => {
+    it('forwards --include to the list request', async () => {
+      const getCompanies = vi.fn().mockResolvedValue({ data: [], meta: {}, included: [] });
+      const ctx = createTestContext({
+        api: { getCompanies } as unknown as ProductiveApi,
+        options: { include: 'contacts' },
+      });
+
+      await companiesList(ctx);
+
+      expect(getCompanies).toHaveBeenCalledWith(expect.objectContaining({ include: ['contacts'] }));
+    });
+
+    it('forwards --include to the get request', async () => {
+      const getCompany = vi.fn().mockResolvedValue({
+        data: { id: '1', type: 'companies', attributes: { name: 'Acme' } },
+        included: [],
+      });
+      const ctx = createTestContext({
+        api: { getCompany } as unknown as ProductiveApi,
+        options: { include: 'contacts' },
+      });
+
+      await companiesGet(['1'], ctx);
+
+      expect(getCompany).toHaveBeenCalledWith('1', { include: ['contacts'] });
+    });
+  });
 });

--- a/packages/cli/src/commands/companies/handlers.ts
+++ b/packages/cli/src/commands/companies/handlers.ts
@@ -40,6 +40,7 @@ export async function companiesList(ctx: CommandContext): Promise<void> {
         page,
         perPage,
         sort: ctx.getSort(),
+        include: ctx.getInclude(),
       },
       execCtx,
     );
@@ -47,7 +48,9 @@ export async function companiesList(ctx: CommandContext): Promise<void> {
     spinner.succeed();
 
     const format = (ctx.options.format || ctx.options.f || 'human') as OutputFormat;
-    const formattedData = formatListResponse(result.data, formatCompany, result.meta);
+    const formattedData = formatListResponse(result.data, formatCompany, result.meta, {
+      included: result.included,
+    });
 
     if (format === 'csv' || format === 'table') {
       const data = result.data.map((c) => ({
@@ -75,12 +78,12 @@ export async function companiesGet(args: string[], ctx: CommandContext): Promise
 
   await runCommand(async () => {
     const execCtx = fromCommandContext(ctx);
-    const result = await getCompany({ id }, execCtx);
+    const result = await getCompany({ id, include: ctx.getInclude() }, execCtx);
 
     spinner.succeed();
 
     const format = (ctx.options.format || ctx.options.f || 'human') as OutputFormat;
-    const formattedData = formatCompany(result.data);
+    const formattedData = formatCompany(result.data, { included: result.included });
 
     if (format === 'json') {
       ctx.formatter.output(formattedData);

--- a/packages/cli/src/commands/companies/help.ts
+++ b/packages/cli/src/commands/companies/help.ts
@@ -15,6 +15,7 @@ ${colors.bold('USAGE:')}
 ${colors.bold('OPTIONS:')}
   --archived          Include archived companies
   --filter <filters>  Generic filters (comma-separated key=value pairs)
+  --include <list>    Sideload related resources (comma-separated, e.g. contacts)
   -p, --page <num>    Page number (default: 1)
   -s, --size <num>    Page size (default: 100)
   --sort <field>      Sort by field (prefix with - for descending)

--- a/packages/cli/src/commands/deals/handlers.ts
+++ b/packages/cli/src/commands/deals/handlers.ts
@@ -126,6 +126,7 @@ export async function dealsAdd(ctx: CommandContext): Promise<void> {
         name: String(ctx.options.name),
         companyId: String(ctx.options.company),
         date: ctx.options.date ? String(ctx.options.date) : undefined,
+        endDate: ctx.options['end-date'] ? String(ctx.options['end-date']) : undefined,
         budget: ctx.options.budget === true,
         responsibleId: ctx.options.responsible ? String(ctx.options.responsible) : undefined,
       },

--- a/packages/cli/src/commands/deals/help.test.ts
+++ b/packages/cli/src/commands/deals/help.test.ts
@@ -46,6 +46,7 @@ describe('showDealsHelp', () => {
     expect(output).toContain('--name');
     expect(output).toContain('--company');
     expect(output).toContain('--budget');
+    expect(output).toContain('--end-date');
   });
 
   it('shows add help for "create" alias', () => {

--- a/packages/cli/src/commands/deals/help.ts
+++ b/packages/cli/src/commands/deals/help.ts
@@ -69,6 +69,7 @@ ${colors.bold('OPTIONS:')}
   --name <name>         Deal name (required)
   --company <id>        Company ID (required)
   --date <date>         Start date (YYYY-MM-DD, default: today)
+  --end-date <date>     End date (YYYY-MM-DD)
   --budget              Create as budget instead of deal
   --responsible <id>    Responsible person ID
   -f, --format <fmt>    Output format: json, human
@@ -76,7 +77,7 @@ ${colors.bold('OPTIONS:')}
 ${colors.bold('EXAMPLES:')}
   productive deals add --name "New Project" --company 12345
   productive deals add --name "Q1 Budget" --company 12345 --budget
-  productive deals add --name "Website Redesign" --company 12345 --responsible 789
+  productive deals add --name "Website Redesign" --company 12345 --end-date 2026-12-31
 `);
   } else if (subcommand === 'update') {
     console.log(`

--- a/packages/cli/src/commands/discussions.test.ts
+++ b/packages/cli/src/commands/discussions.test.ts
@@ -271,7 +271,7 @@ describe('discussions command', () => {
 
       await discussionsGet(['1'], ctx);
 
-      expect(getDiscussion).toHaveBeenCalledWith('1');
+      expect(getDiscussion).toHaveBeenCalledWith('1', { include: undefined });
       expect(consoleLogSpy).toHaveBeenCalled();
     });
 
@@ -316,7 +316,7 @@ describe('discussions command', () => {
 
       await discussionsGet(['1'], ctx);
 
-      expect(getDiscussion).toHaveBeenCalledWith('1');
+      expect(getDiscussion).toHaveBeenCalledWith('1', { include: undefined });
       expect(consoleLogSpy).toHaveBeenCalled();
     });
 

--- a/packages/cli/src/commands/discussions.test.ts
+++ b/packages/cli/src/commands/discussions.test.ts
@@ -816,4 +816,33 @@ describe('discussions command', () => {
       expect(processExitSpy).toHaveBeenCalledWith(1);
     });
   });
+
+  describe('--include forwarding', () => {
+    it('forwards --include to the list request', async () => {
+      const getDiscussions = vi.fn().mockResolvedValue({ data: [], meta: {}, included: [] });
+      const ctx = createTestContext({
+        api: { getDiscussions } as unknown as ProductiveApi,
+        options: { include: 'page' },
+      });
+
+      await discussionsList(ctx);
+
+      expect(getDiscussions).toHaveBeenCalledWith(expect.objectContaining({ include: ['page'] }));
+    });
+
+    it('forwards --include to the get request', async () => {
+      const getDiscussion = vi.fn().mockResolvedValue({
+        data: { id: '1', type: 'discussions', attributes: { title: 'D', status: 1 } },
+        included: [],
+      });
+      const ctx = createTestContext({
+        api: { getDiscussion } as unknown as ProductiveApi,
+        options: { include: 'page' },
+      });
+
+      await discussionsGet(['1'], ctx);
+
+      expect(getDiscussion).toHaveBeenCalledWith('1', { include: ['page'] });
+    });
+  });
 });

--- a/packages/cli/src/commands/discussions/handlers.ts
+++ b/packages/cli/src/commands/discussions/handlers.ts
@@ -45,6 +45,7 @@ function parseListOptions(ctx: CommandContext): ListDiscussionsOptions {
   options.page = page;
   options.perPage = perPage;
   options.sort = ctx.getSort();
+  options.include = ctx.getInclude();
 
   return options;
 }
@@ -78,7 +79,7 @@ export async function discussionsGet(args: string[], ctx: CommandContext): Promi
 
   await runCommand(async () => {
     const execCtx = fromCommandContext(ctx);
-    const result = await getDiscussion({ id }, execCtx);
+    const result = await getDiscussion({ id, include: ctx.getInclude() }, execCtx);
 
     spinner.succeed();
 

--- a/packages/cli/src/commands/discussions/help.ts
+++ b/packages/cli/src/commands/discussions/help.ts
@@ -16,6 +16,7 @@ ${colors.bold('OPTIONS:')}
   --page-id <id>      Filter by page ID
   --status <status>   Filter by status: active, resolved
   --filter <filters>  Generic filters (comma-separated key=value pairs)
+  --include <list>    Sideload related resources (comma-separated, e.g. page)
   -p, --page <num>    Page number (default: 1)
   -s, --size <num>    Page size (default: 100)
   --sort <field>      Sort by field (prefix with - for descending)

--- a/packages/cli/src/commands/pages.test.ts
+++ b/packages/cli/src/commands/pages.test.ts
@@ -617,4 +617,33 @@ describe('pages command', () => {
       expect(processExitSpy).toHaveBeenCalledWith(1);
     });
   });
+
+  describe('--include forwarding', () => {
+    it('forwards --include to the list request', async () => {
+      const getPages = vi.fn().mockResolvedValue({ data: [], meta: {}, included: [] });
+      const ctx = createTestContext({
+        api: { getPages } as unknown as ProductiveApi,
+        options: { include: 'creator' },
+      });
+
+      await pagesList(ctx);
+
+      expect(getPages).toHaveBeenCalledWith(expect.objectContaining({ include: ['creator'] }));
+    });
+
+    it('forwards --include to the get request', async () => {
+      const getPage = vi.fn().mockResolvedValue({
+        data: { id: '1', type: 'pages', attributes: { title: 'Doc' } },
+        included: [],
+      });
+      const ctx = createTestContext({
+        api: { getPage } as unknown as ProductiveApi,
+        options: { include: 'creator' },
+      });
+
+      await pagesGet(['1'], ctx);
+
+      expect(getPage).toHaveBeenCalledWith('1', { include: ['creator'] });
+    });
+  });
 });

--- a/packages/cli/src/commands/pages.test.ts
+++ b/packages/cli/src/commands/pages.test.ts
@@ -234,7 +234,7 @@ describe('pages command', () => {
 
       await pagesGet(['1'], ctx);
 
-      expect(getPage).toHaveBeenCalledWith('1');
+      expect(getPage).toHaveBeenCalledWith('1', { include: undefined });
       expect(consoleLogSpy).toHaveBeenCalled();
     });
 
@@ -254,7 +254,7 @@ describe('pages command', () => {
 
       await pagesGet(['1'], ctx);
 
-      expect(getPage).toHaveBeenCalledWith('1');
+      expect(getPage).toHaveBeenCalledWith('1', { include: undefined });
       expect(consoleLogSpy).toHaveBeenCalled();
     });
 
@@ -280,7 +280,7 @@ describe('pages command', () => {
 
       await pagesGet(['1'], ctx);
 
-      expect(getPage).toHaveBeenCalledWith('1');
+      expect(getPage).toHaveBeenCalledWith('1', { include: undefined });
       expect(consoleLogSpy).toHaveBeenCalled();
     });
 

--- a/packages/cli/src/commands/pages/handlers.ts
+++ b/packages/cli/src/commands/pages/handlers.ts
@@ -38,6 +38,7 @@ function parseListOptions(ctx: CommandContext): ListPagesOptions {
   options.page = page;
   options.perPage = perPage;
   options.sort = ctx.getSort();
+  options.include = ctx.getInclude();
 
   return options;
 }
@@ -71,7 +72,7 @@ export async function pagesGet(args: string[], ctx: CommandContext): Promise<voi
 
   await runCommand(async () => {
     const execCtx = fromCommandContext(ctx);
-    const result = await getPage({ id }, execCtx);
+    const result = await getPage({ id, include: ctx.getInclude() }, execCtx);
 
     spinner.succeed();
 

--- a/packages/cli/src/commands/pages/help.ts
+++ b/packages/cli/src/commands/pages/help.ts
@@ -16,6 +16,7 @@ ${colors.bold('OPTIONS:')}
   --project <id>      Filter by project ID
   --creator <id>      Filter by creator person ID
   --filter <filters>  Generic filters (comma-separated key=value pairs)
+  --include <list>    Sideload related resources (comma-separated, e.g. creator)
   -p, --page <num>    Page number (default: 1)
   -s, --size <num>    Page size (default: 100)
   --sort <field>      Sort by field (prefix with - for descending)

--- a/packages/cli/src/commands/people.test.ts
+++ b/packages/cli/src/commands/people.test.ts
@@ -324,4 +324,33 @@ describe('people command', () => {
       expect(processExitSpy).toHaveBeenCalledWith(1);
     });
   });
+
+  describe('--include forwarding', () => {
+    it('forwards --include to the list request', async () => {
+      const getPeople = vi.fn().mockResolvedValue({ data: [], meta: {}, included: [] });
+      const ctx = createTestContext({
+        api: { getPeople } as unknown as ProductiveApi,
+        options: { include: 'company' },
+      });
+
+      await peopleList(ctx);
+
+      expect(getPeople).toHaveBeenCalledWith(expect.objectContaining({ include: ['company'] }));
+    });
+
+    it('forwards --include to the get request', async () => {
+      const getPerson = vi.fn().mockResolvedValue({
+        data: { id: '1', type: 'people', attributes: { first_name: 'J', last_name: 'D' } },
+        included: [],
+      });
+      const ctx = createTestContext({
+        api: { getPerson } as unknown as ProductiveApi,
+        options: { include: 'company' },
+      });
+
+      await peopleGet(['1'], ctx);
+
+      expect(getPerson).toHaveBeenCalledWith('1', { include: ['company'] });
+    });
+  });
 });

--- a/packages/cli/src/commands/people.test.ts
+++ b/packages/cli/src/commands/people.test.ts
@@ -227,7 +227,7 @@ describe('people command', () => {
 
       await peopleGet(['1'], ctx);
 
-      expect(getPerson).toHaveBeenCalledWith('1');
+      expect(getPerson).toHaveBeenCalledWith('1', { include: undefined });
       expect(consoleLogSpy).toHaveBeenCalled();
     });
 

--- a/packages/cli/src/commands/people/handlers.ts
+++ b/packages/cli/src/commands/people/handlers.ts
@@ -36,6 +36,7 @@ function parseListOptions(ctx: CommandContext): ListPeopleOptions {
   options.page = page;
   options.perPage = perPage;
   options.sort = ctx.getSort();
+  options.include = ctx.getInclude();
 
   return options;
 }
@@ -51,7 +52,9 @@ export async function peopleList(ctx: CommandContext): Promise<void> {
     spinner.succeed();
 
     const format = (ctx.options.format || ctx.options.f || 'human') as OutputFormat;
-    const formattedData = formatListResponse(result.data, formatPerson, result.meta);
+    const formattedData = formatListResponse(result.data, formatPerson, result.meta, {
+      included: result.included,
+    });
 
     if (format === 'csv' || format === 'table') {
       const data = result.data.map((p) => ({
@@ -78,12 +81,12 @@ export async function peopleGet(args: string[], ctx: CommandContext): Promise<vo
 
   await runCommand(async () => {
     const execCtx = fromCommandContext(ctx);
-    const result = await getPerson({ id }, execCtx);
+    const result = await getPerson({ id, include: ctx.getInclude() }, execCtx);
 
     spinner.succeed();
 
     const format = (ctx.options.format || ctx.options.f || 'human') as OutputFormat;
-    const formattedData = formatPerson(result.data);
+    const formattedData = formatPerson(result.data, { included: result.included });
 
     if (format === 'json') {
       ctx.formatter.output(formattedData);

--- a/packages/cli/src/commands/people/help.ts
+++ b/packages/cli/src/commands/people/help.ts
@@ -20,6 +20,7 @@ ${colors.bold('OPTIONS:')}
   --type <type>       Filter by person type: user, contact, placeholder
   --status <status>   Filter by status: active, deactivated
   --filter <filters>  Generic filters (comma-separated key=value pairs)
+  --include <list>    Sideload related resources (comma-separated, e.g. company)
   -p, --page <num>    Page number (default: 1)
   -s, --size <num>    Page size (default: 100)
   --sort <field>      Sort by field (prefix with - for descending)

--- a/packages/cli/src/commands/projects.test.ts
+++ b/packages/cli/src/commands/projects.test.ts
@@ -603,4 +603,33 @@ describe('projects command', () => {
       expect(processExitSpy).toHaveBeenCalledWith(1);
     });
   });
+
+  describe('--include forwarding', () => {
+    it('forwards --include to the list request', async () => {
+      const getProjects = vi.fn().mockResolvedValue({ data: [], meta: {}, included: [] });
+      const ctx = createTestContext({
+        api: { getProjects } as unknown as ProductiveApi,
+        options: { include: 'company' },
+      });
+
+      await projectsList(ctx);
+
+      expect(getProjects).toHaveBeenCalledWith(expect.objectContaining({ include: ['company'] }));
+    });
+
+    it('forwards --include to the get request', async () => {
+      const getProject = vi.fn().mockResolvedValue({
+        data: { id: '1', type: 'projects', attributes: { name: 'P' } },
+        included: [],
+      });
+      const ctx = createTestContext({
+        api: { getProject } as unknown as ProductiveApi,
+        options: { include: 'company' },
+      });
+
+      await projectsGet(['1'], ctx);
+
+      expect(getProject).toHaveBeenCalledWith('1', { include: ['company'] });
+    });
+  });
 });

--- a/packages/cli/src/commands/projects.test.ts
+++ b/packages/cli/src/commands/projects.test.ts
@@ -431,7 +431,7 @@ describe('projects command', () => {
 
       await projectsGet(['1'], ctx);
 
-      expect(getProject).toHaveBeenCalledWith('1');
+      expect(getProject).toHaveBeenCalledWith('1', { include: undefined });
       expect(consoleLogSpy).toHaveBeenCalled();
     });
 

--- a/packages/cli/src/commands/projects/handlers.ts
+++ b/packages/cli/src/commands/projects/handlers.ts
@@ -41,6 +41,7 @@ function parseListOptions(ctx: CommandContext): ListProjectsOptions {
   options.page = page;
   options.perPage = perPage;
   options.sort = ctx.getSort();
+  options.include = ctx.getInclude();
 
   return options;
 }
@@ -60,7 +61,9 @@ export async function projectsList(ctx: CommandContext): Promise<void> {
     spinner.succeed();
 
     const format = (ctx.options.format || ctx.options.f || 'human') as OutputFormat;
-    const formattedData = formatListResponse(result.data, formatProject, result.meta);
+    const formattedData = formatListResponse(result.data, formatProject, result.meta, {
+      included: result.included,
+    });
 
     if (format === 'csv' || format === 'table') {
       const data = result.data.map((p) => ({
@@ -96,13 +99,13 @@ export async function projectsGet(args: string[], ctx: CommandContext): Promise<
 
   await runCommand(async () => {
     const execCtx = fromCommandContext(ctx);
-    const result = await getProject({ id }, execCtx);
+    const result = await getProject({ id, include: ctx.getInclude() }, execCtx);
     const project = result.data;
 
     spinner.succeed();
 
     const format = (ctx.options.format || ctx.options.f || 'human') as OutputFormat;
-    const formattedData = formatProject(project);
+    const formattedData = formatProject(project, { included: result.included });
 
     if (format === 'json') {
       ctx.formatter.output(formattedData);

--- a/packages/cli/src/commands/projects/help.ts
+++ b/packages/cli/src/commands/projects/help.ts
@@ -19,6 +19,7 @@ ${colors.bold('OPTIONS:')}
   --type <type>       Filter by project type: internal, client
   --status <status>   Filter by status: active, archived
   --filter <filters>  Generic filters (comma-separated key=value pairs)
+  --include <list>    Sideload related resources (comma-separated, e.g. company)
   -p, --page <num>    Page number (default: 1)
   -s, --size <num>    Page size (default: 100)
   --sort <field>      Sort by field (prefix with - for descending)

--- a/packages/cli/src/commands/services.test.ts
+++ b/packages/cli/src/commands/services.test.ts
@@ -259,4 +259,33 @@ describe('services command', () => {
       expect(processExitSpy).toHaveBeenCalledWith(1);
     });
   });
+
+  describe('--include forwarding', () => {
+    it('forwards --include to the list request', async () => {
+      const getServices = vi.fn().mockResolvedValue({ data: [], meta: {}, included: [] });
+      const ctx = createTestContext({
+        api: { getServices } as unknown as ProductiveApi,
+        options: { include: 'deal' },
+      });
+
+      await servicesList(ctx);
+
+      expect(getServices).toHaveBeenCalledWith(expect.objectContaining({ include: ['deal'] }));
+    });
+
+    it('forwards --include to the get request', async () => {
+      const getService = vi.fn().mockResolvedValue({
+        data: { id: '1', type: 'services', attributes: { name: 'Dev' } },
+        included: [],
+      });
+      const ctx = createTestContext({
+        api: { getService } as unknown as ProductiveApi,
+        options: { include: 'deal', format: 'json' },
+      });
+
+      await servicesGet(['1'], ctx);
+
+      expect(getService).toHaveBeenCalledWith('1', { include: ['deal'] });
+    });
+  });
 });

--- a/packages/cli/src/commands/services/handlers.ts
+++ b/packages/cli/src/commands/services/handlers.ts
@@ -37,6 +37,7 @@ function parseListOptions(ctx: CommandContext): ListServicesOptions {
   const { page, perPage } = ctx.getPagination();
   options.page = page;
   options.perPage = perPage;
+  options.include = ctx.getInclude();
 
   return options;
 }
@@ -52,7 +53,9 @@ export async function servicesList(ctx: CommandContext): Promise<void> {
     spinner.succeed();
 
     const format = (ctx.options.format || ctx.options.f || 'human') as OutputFormat;
-    const formattedData = formatListResponse(result.data, formatService, result.meta);
+    const formattedData = formatListResponse(result.data, formatService, result.meta, {
+      included: result.included,
+    });
 
     if (format === 'csv' || format === 'table') {
       const data = result.data.map((s) => ({
@@ -76,12 +79,12 @@ export async function servicesGet(args: string[], ctx: CommandContext): Promise<
 
   await runCommand(async () => {
     const execCtx = fromCommandContext(ctx);
-    const result = await getService({ id }, execCtx);
+    const result = await getService({ id, include: ctx.getInclude() }, execCtx);
 
     spinner.succeed();
 
     const format = (ctx.options.format || ctx.options.f || 'human') as OutputFormat;
-    const formattedData = formatService(result.data);
+    const formattedData = formatService(result.data, { included: result.included });
 
     if (format === 'json') {
       ctx.formatter.output(formattedData);

--- a/packages/cli/src/commands/services/help.ts
+++ b/packages/cli/src/commands/services/help.ts
@@ -22,6 +22,7 @@ ${colors.bold('OPTIONS:')}
   --time-tracking      Filter services with time tracking enabled
   --no-time-tracking   Filter services without time tracking
   --filter <filters>   Generic filters (comma-separated key=value pairs)
+  --include <list>     Sideload related resources (comma-separated, e.g. deal)
   -p, --page <num>     Page number (default: 1)
   -s, --size <num>     Page size (default: 100)
   -f, --format <fmt>   Output format: json, human, csv, table

--- a/packages/cli/src/context.test.ts
+++ b/packages/cli/src/context.test.ts
@@ -146,6 +146,30 @@ describe('createContext', () => {
       expect(ctx.getSort()).toBe('-created_at');
     });
   });
+
+  describe('getInclude', () => {
+    it('should return undefined when not provided', () => {
+      expect(createContext({}).getInclude()).toBeUndefined();
+    });
+
+    it('should parse a comma-separated value into a trimmed array', () => {
+      const ctx = createContext({ include: 'company, project.company ,memberships' });
+      expect(ctx.getInclude()).toEqual(['company', 'project.company', 'memberships']);
+    });
+
+    it('should return a single-element array for one value', () => {
+      expect(createContext({ include: 'company' }).getInclude()).toEqual(['company']);
+    });
+
+    it('should return undefined for an empty or whitespace value', () => {
+      expect(createContext({ include: '' }).getInclude()).toBeUndefined();
+      expect(createContext({ include: ' , ' }).getInclude()).toBeUndefined();
+    });
+
+    it('should ignore a non-string value', () => {
+      expect(createContext({ include: true }).getInclude()).toBeUndefined();
+    });
+  });
 });
 
 describe('createTestContext', () => {

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -71,6 +71,20 @@ export interface CommandOptions {
 }
 
 /**
+ * Parse a comma-separated `--include` option value (e.g. `company,project`)
+ * into an array of include keys. Returns undefined when no usable value
+ * was provided.
+ */
+function parseIncludeOption(raw: string | boolean | number | undefined): string[] | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const values = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  return values.length > 0 ? values : undefined;
+}
+
+/**
  * Context containing all dependencies needed by commands.
  * This is the main interface for dependency injection.
  */
@@ -98,6 +112,9 @@ export interface CommandContext {
 
   /** Get sort parameter */
   getSort(): string;
+
+  /** Get the include parameter (comma-separated `--include` flag parsed into an array) */
+  getInclude(): string[] | undefined;
 
   /**
    * Resolve human-friendly identifiers in filters (emails, project numbers, etc.)
@@ -166,6 +183,10 @@ export function createContext(options: CommandOptions = {}): CommandContext {
 
     getSort(): string {
       return String(options.sort || '');
+    },
+
+    getInclude(): string[] | undefined {
+      return parseIncludeOption(options.include);
     },
 
     resolveFilters(
@@ -267,6 +288,7 @@ export function createTestContext(overrides: Partial<CommandContext> = {}): Comm
         perPage: parseInt(String(opts.size || opts.s || '100')),
       })),
     getSort: overrides.getSort ?? (() => String(opts.sort || '')),
+    getInclude: overrides.getInclude ?? (() => parseIncludeOption(opts.include)),
     resolveFilters: overrides.resolveFilters ?? noopResolveFilters,
     tryResolveValue: overrides.tryResolveValue ?? noopTryResolveValue,
   };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,9 +50,9 @@
     "@studiometa/productive-api": "*"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^4.1.7",
-    "vite": "^8.0.14",
-    "vitest": "^4.1.7"
+    "@vitest/coverage-v8": "^4.1.8",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/core/src/executors/activities/list.test.ts
+++ b/packages/core/src/executors/activities/list.test.ts
@@ -37,7 +37,7 @@ describe('listActivities', () => {
 
     expect(getActivities).toHaveBeenCalledWith({
       page: 1,
-      perPage: 25,
+      perPage: 100,
       filter: undefined,
       include: undefined,
     });

--- a/packages/core/src/executors/activities/list.ts
+++ b/packages/core/src/executors/activities/list.ts
@@ -8,6 +8,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListActivitiesOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export async function listActivities(
   options: ListActivitiesOptions,
   ctx: ExecutorContext,
@@ -19,10 +21,8 @@ export async function listActivities(
   }
 
   const response = await ctx.api.getActivities({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: Object.keys(filter).length > 0 ? filter : undefined,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/activities/list.ts
+++ b/packages/core/src/executors/activities/list.ts
@@ -20,7 +20,7 @@ export async function listActivities(
 
   const response = await ctx.api.getActivities({
     page: options.page ?? 1,
-    perPage: options.perPage ?? 25,
+    perPage: options.perPage ?? 100,
     filter: Object.keys(filter).length > 0 ? filter : undefined,
     include: options.include,
   });

--- a/packages/core/src/executors/attachments/get.test.ts
+++ b/packages/core/src/executors/attachments/get.test.ts
@@ -15,7 +15,21 @@ describe('getAttachment', () => {
 
     const result = await getAttachment({ id: '1' }, ctx);
 
-    expect(getAttachmentApi).toHaveBeenCalledWith('1');
+    expect(getAttachmentApi).toHaveBeenCalledWith('1', { include: undefined });
     expect(result.data).toEqual(mockAttachment);
+  });
+
+  it('forwards include and returns included (Finding 1)', async () => {
+    const included = [{ id: '7', type: 'tasks', attributes: { title: 'Task' } }];
+    const getAttachmentApi = vi.fn().mockResolvedValue({
+      data: { id: '1', type: 'attachments', attributes: {} },
+      included,
+    });
+    const ctx = createTestExecutorContext({ api: { getAttachment: getAttachmentApi } });
+
+    const result = await getAttachment({ id: '1', include: ['task'] }, ctx);
+
+    expect(getAttachmentApi).toHaveBeenCalledWith('1', { include: ['task'] });
+    expect(result.included).toEqual(included);
   });
 });

--- a/packages/core/src/executors/attachments/get.ts
+++ b/packages/core/src/executors/attachments/get.ts
@@ -8,6 +8,6 @@ export async function getAttachment(
   options: GetAttachmentOptions,
   ctx: ExecutorContext,
 ): Promise<ExecutorResult<ProductiveAttachment>> {
-  const response = await ctx.api.getAttachment(options.id);
-  return { data: response.data };
+  const response = await ctx.api.getAttachment(options.id, { include: options.include });
+  return { data: response.data, included: response.included };
 }

--- a/packages/core/src/executors/attachments/list.test.ts
+++ b/packages/core/src/executors/attachments/list.test.ts
@@ -76,4 +76,15 @@ describe('listAttachments', () => {
     expect(result.data).toEqual(mockResponse.data);
     expect(result.meta).toEqual(mockResponse.meta);
   });
+
+  it('forwards include and returns included (Finding 1)', async () => {
+    const included = [{ id: '7', type: 'tasks', attributes: { title: 'Task' } }];
+    const getAttachments = vi.fn().mockResolvedValue({ data: [], meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getAttachments } });
+
+    const result = await listAttachments({ include: ['task'] }, ctx);
+
+    expect(getAttachments).toHaveBeenCalledWith(expect.objectContaining({ include: ['task'] }));
+    expect(result.included).toEqual(included);
+  });
 });

--- a/packages/core/src/executors/attachments/list.ts
+++ b/packages/core/src/executors/attachments/list.ts
@@ -26,10 +26,12 @@ export async function listAttachments(
     page: options.page ?? 1,
     perPage: options.perPage ?? 100,
     filter,
+    include: options.include,
   });
 
   return {
     data: response.data,
     meta: response.meta,
+    included: response.included,
   };
 }

--- a/packages/core/src/executors/attachments/list.ts
+++ b/packages/core/src/executors/attachments/list.ts
@@ -4,6 +4,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListAttachmentsOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildAttachmentFilters(options: ListAttachmentsOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -23,10 +25,8 @@ export async function listAttachments(
   const filter = buildAttachmentFilters(options);
 
   const response = await ctx.api.getAttachments({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/attachments/types.ts
+++ b/packages/core/src/executors/attachments/types.ts
@@ -10,6 +10,8 @@ export interface ListAttachmentsOptions extends PaginationOptions {
 
 export interface GetAttachmentOptions {
   id: string;
+  /** Related resources to include */
+  include?: string[];
 }
 
 export interface DeleteAttachmentOptions {

--- a/packages/core/src/executors/bookings/list.test.ts
+++ b/packages/core/src/executors/bookings/list.test.ts
@@ -113,4 +113,14 @@ describe('listBookings', () => {
     expect(callArgs.filter.after).toBe('2026-01-01');
     expect(callArgs.filter.with_draft).toBe('true');
   });
+
+  it('returns included sideloaded resources (Finding 2)', async () => {
+    const included = [{ id: '9', type: 'people', attributes: { first_name: 'Jane' } }];
+    const getBookings = vi.fn().mockResolvedValue({ data: [], meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getBookings } });
+
+    const result = await listBookings({ include: ['person'] }, ctx);
+
+    expect(result.included).toEqual(included);
+  });
 });

--- a/packages/core/src/executors/bookings/list.ts
+++ b/packages/core/src/executors/bookings/list.ts
@@ -44,6 +44,7 @@ export async function listBookings(
   return {
     data: response.data,
     meta: response.meta,
+    included: response.included,
     resolved: Object.keys(metadata).length > 0 ? metadata : undefined,
   };
 }

--- a/packages/core/src/executors/bookings/list.ts
+++ b/packages/core/src/executors/bookings/list.ts
@@ -4,6 +4,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListBookingsOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildBookingFilters(options: ListBookingsOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -34,11 +36,8 @@ export async function listBookings(
   const { resolved: resolvedFilter, metadata } = await ctx.resolver.resolveFilters(filter);
 
   const response = await ctx.api.getBookings({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: resolvedFilter,
-    sort: options.sort,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/comments/list.test.ts
+++ b/packages/core/src/executors/comments/list.test.ts
@@ -71,4 +71,14 @@ describe('listComments', () => {
     expect(result.data).toEqual(mockResponse.data);
     expect(result.meta).toEqual(mockResponse.meta);
   });
+
+  it('returns included sideloaded resources (Finding 2)', async () => {
+    const included = [{ id: '7', type: 'people', attributes: { first_name: 'Jane' } }];
+    const getComments = vi.fn().mockResolvedValue({ data: [], meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getComments } });
+
+    const result = await listComments({ include: ['creator'] }, ctx);
+
+    expect(result.included).toEqual(included);
+  });
 });

--- a/packages/core/src/executors/comments/list.ts
+++ b/packages/core/src/executors/comments/list.ts
@@ -4,6 +4,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListCommentsOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildCommentFilters(options: ListCommentsOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -23,10 +25,8 @@ export async function listComments(
   const filter = buildCommentFilters(options);
 
   const response = await ctx.api.getComments({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/comments/list.ts
+++ b/packages/core/src/executors/comments/list.ts
@@ -32,5 +32,6 @@ export async function listComments(
   return {
     data: response.data,
     meta: response.meta,
+    included: response.included,
   };
 }

--- a/packages/core/src/executors/companies/get.test.ts
+++ b/packages/core/src/executors/companies/get.test.ts
@@ -18,8 +18,19 @@ describe('getCompany', () => {
 
     const result = await getCompany({ id: '1' }, ctx);
 
-    expect(getCompanyApi).toHaveBeenCalledWith('1');
+    expect(getCompanyApi).toHaveBeenCalledWith('1', { include: undefined });
     expect(result.data).toEqual(mockCompany);
+  });
+
+  it('forwards include and returns included (Finding 1)', async () => {
+    const included = [{ id: '5', type: 'people', attributes: { first_name: 'Jane' } }];
+    const getCompanyApi = vi.fn().mockResolvedValue({ data: mockCompany, included });
+    const ctx = createTestExecutorContext({ api: { getCompany: getCompanyApi } });
+
+    const result = await getCompany({ id: '1', include: ['contacts'] }, ctx);
+
+    expect(getCompanyApi).toHaveBeenCalledWith('1', { include: ['contacts'] });
+    expect(result.included).toEqual(included);
   });
 
   it('resolves non-numeric ID before fetching', async () => {
@@ -33,6 +44,6 @@ describe('getCompany', () => {
     await getCompany({ id: 'Acme Corp' }, ctx);
 
     expect(resolveValue).toHaveBeenCalledWith('Acme Corp', 'company');
-    expect(getCompanyApi).toHaveBeenCalledWith('1');
+    expect(getCompanyApi).toHaveBeenCalledWith('1', { include: undefined });
   });
 });

--- a/packages/core/src/executors/companies/get.ts
+++ b/packages/core/src/executors/companies/get.ts
@@ -13,6 +13,6 @@ export async function getCompany(
   ctx: ExecutorContext,
 ): Promise<ExecutorResult<ProductiveCompany>> {
   const resolvedId = await ctx.resolver.resolveValue(options.id, 'company');
-  const response = await ctx.api.getCompany(resolvedId);
-  return { data: response.data };
+  const response = await ctx.api.getCompany(resolvedId, { include: options.include });
+  return { data: response.data, included: response.included };
 }

--- a/packages/core/src/executors/companies/list.test.ts
+++ b/packages/core/src/executors/companies/list.test.ts
@@ -66,4 +66,15 @@ describe('listCompanies', () => {
     expect(result.data).toEqual(mockResponse.data);
     expect(result.meta).toEqual(mockResponse.meta);
   });
+
+  it('forwards include and returns included (Finding 1)', async () => {
+    const included = [{ id: '5', type: 'people', attributes: { first_name: 'Jane' } }];
+    const getCompanies = vi.fn().mockResolvedValue({ data: [], meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getCompanies } });
+
+    const result = await listCompanies({ include: ['contacts'] }, ctx);
+
+    expect(getCompanies).toHaveBeenCalledWith(expect.objectContaining({ include: ['contacts'] }));
+    expect(result.included).toEqual(included);
+  });
 });

--- a/packages/core/src/executors/companies/list.ts
+++ b/packages/core/src/executors/companies/list.ts
@@ -35,10 +35,12 @@ export async function listCompanies(
     perPage: options.perPage ?? 100,
     filter,
     sort: options.sort,
+    include: options.include,
   });
 
   return {
     data: response.data,
     meta: response.meta,
+    included: response.included,
   };
 }

--- a/packages/core/src/executors/companies/list.ts
+++ b/packages/core/src/executors/companies/list.ts
@@ -10,6 +10,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListCompaniesOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildCompanyFilters(options: ListCompaniesOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -31,11 +33,8 @@ export async function listCompanies(
   const filter = buildCompanyFilters(options);
 
   const response = await ctx.api.getCompanies({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter,
-    sort: options.sort,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/companies/types.ts
+++ b/packages/core/src/executors/companies/types.ts
@@ -13,6 +13,8 @@ export interface ListCompaniesOptions extends PaginationOptions {
 export interface GetCompanyOptions {
   /** Company ID or human-friendly identifier (name) */
   id: string;
+  /** Related resources to include (e.g., contacts) */
+  include?: string[];
 }
 
 export interface CreateCompanyOptions {

--- a/packages/core/src/executors/custom-fields/list.test.ts
+++ b/packages/core/src/executors/custom-fields/list.test.ts
@@ -45,7 +45,7 @@ describe('listCustomFields', () => {
 
     expect(getCustomFields).toHaveBeenCalledWith({
       page: 1,
-      perPage: 25,
+      perPage: 100,
       filter: undefined,
       include: undefined,
     });

--- a/packages/core/src/executors/custom-fields/list.ts
+++ b/packages/core/src/executors/custom-fields/list.ts
@@ -8,6 +8,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListCustomFieldsOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export async function listCustomFields(
   options: ListCustomFieldsOptions,
   ctx: ExecutorContext,
@@ -27,10 +29,8 @@ export async function listCustomFields(
   }
 
   const response = await ctx.api.getCustomFields({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: Object.keys(filter).length > 0 ? filter : undefined,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/custom-fields/list.ts
+++ b/packages/core/src/executors/custom-fields/list.ts
@@ -28,7 +28,7 @@ export async function listCustomFields(
 
   const response = await ctx.api.getCustomFields({
     page: options.page ?? 1,
-    perPage: options.perPage ?? 25,
+    perPage: options.perPage ?? 100,
     filter: Object.keys(filter).length > 0 ? filter : undefined,
     include: options.include,
   });

--- a/packages/core/src/executors/deals/create.test.ts
+++ b/packages/core/src/executors/deals/create.test.ts
@@ -65,6 +65,15 @@ describe('createDeal', () => {
     });
   });
 
+  it('passes endDate as end_date (Finding 7)', async () => {
+    const createDealApi = vi.fn().mockResolvedValue({ data: mockDeal });
+    const ctx = createTestExecutorContext({ api: { createDeal: createDealApi } });
+
+    await createDeal({ name: 'Deal', companyId: '100', endDate: '2026-12-31' }, ctx);
+
+    expect(createDealApi).toHaveBeenCalledWith(expect.objectContaining({ end_date: '2026-12-31' }));
+  });
+
   it('passes through numeric company ID without resolving', async () => {
     const createDealApi = vi.fn().mockResolvedValue({ data: mockDeal });
     const resolveValue = vi.fn().mockResolvedValue('100');

--- a/packages/core/src/executors/deals/create.ts
+++ b/packages/core/src/executors/deals/create.ts
@@ -17,6 +17,7 @@ export async function createDeal(
     name: options.name,
     company_id: companyId,
     date: options.date,
+    end_date: options.endDate,
     budget: options.budget,
     responsible_id: responsibleId,
   });

--- a/packages/core/src/executors/deals/list.ts
+++ b/packages/core/src/executors/deals/list.ts
@@ -6,6 +6,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListDealsOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildDealFilters(options: ListDealsOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -39,10 +41,8 @@ export async function listDeals(
   const { resolved: resolvedFilter, metadata } = await ctx.resolver.resolveFilters(filter);
 
   const response = await ctx.api.getDeals({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: resolvedFilter,
-    sort: options.sort,
     include: options.include ?? ['company', 'deal_status', 'responsible'],
   });
 

--- a/packages/core/src/executors/deals/types.ts
+++ b/packages/core/src/executors/deals/types.ts
@@ -23,6 +23,7 @@ export interface CreateDealOptions {
   name: string;
   companyId: string;
   date?: string;
+  endDate?: string;
   budget?: boolean;
   responsibleId?: string;
 }

--- a/packages/core/src/executors/discussions/get.test.ts
+++ b/packages/core/src/executors/discussions/get.test.ts
@@ -14,8 +14,22 @@ describe('getDiscussion', () => {
 
     const result = await getDiscussion({ id: '1' }, ctx);
 
-    expect(getDiscussionApi).toHaveBeenCalledWith('1');
+    expect(getDiscussionApi).toHaveBeenCalledWith('1', { include: undefined });
     expect(result.data).toEqual(mockResponse.data);
     expect(result.included).toEqual([]);
+  });
+
+  it('forwards include (Finding 3)', async () => {
+    const included = [{ id: '7', type: 'pages', attributes: { title: 'Page' } }];
+    const getDiscussionApi = vi.fn().mockResolvedValue({
+      data: { id: '1', type: 'discussions', attributes: {} },
+      included,
+    });
+    const ctx = createTestExecutorContext({ api: { getDiscussion: getDiscussionApi } });
+
+    const result = await getDiscussion({ id: '1', include: ['page'] }, ctx);
+
+    expect(getDiscussionApi).toHaveBeenCalledWith('1', { include: ['page'] });
+    expect(result.included).toEqual(included);
   });
 });

--- a/packages/core/src/executors/discussions/get.ts
+++ b/packages/core/src/executors/discussions/get.ts
@@ -8,6 +8,6 @@ export async function getDiscussion(
   options: GetDiscussionOptions,
   ctx: ExecutorContext,
 ): Promise<ExecutorResult<ProductiveDiscussion>> {
-  const response = await ctx.api.getDiscussion(options.id);
+  const response = await ctx.api.getDiscussion(options.id, { include: options.include });
   return { data: response.data, included: response.included };
 }

--- a/packages/core/src/executors/discussions/list.test.ts
+++ b/packages/core/src/executors/discussions/list.test.ts
@@ -84,4 +84,15 @@ describe('listDiscussions', () => {
     const result = await listDiscussions({ pageId: '123' }, ctx);
     expect(result.resolved).toBeUndefined();
   });
+
+  it('forwards include and returns included (Finding 3)', async () => {
+    const included = [{ id: '7', type: 'pages', attributes: { title: 'Page' } }];
+    const getDiscussions = vi.fn().mockResolvedValue({ data: [], meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getDiscussions } });
+
+    const result = await listDiscussions({ include: ['page'] }, ctx);
+
+    expect(getDiscussions).toHaveBeenCalledWith(expect.objectContaining({ include: ['page'] }));
+    expect(result.included).toEqual(included);
+  });
 });

--- a/packages/core/src/executors/discussions/list.ts
+++ b/packages/core/src/executors/discussions/list.ts
@@ -6,6 +6,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListDiscussionsOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildDiscussionFilters(options: ListDiscussionsOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -29,11 +31,8 @@ export async function listDiscussions(
   const { resolved: resolvedFilter, metadata } = await ctx.resolver.resolveFilters(filter);
 
   const response = await ctx.api.getDiscussions({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: resolvedFilter,
-    sort: options.sort,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/discussions/list.ts
+++ b/packages/core/src/executors/discussions/list.ts
@@ -33,6 +33,7 @@ export async function listDiscussions(
     perPage: options.perPage ?? 100,
     filter: resolvedFilter,
     sort: options.sort,
+    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/discussions/types.ts
+++ b/packages/core/src/executors/discussions/types.ts
@@ -8,6 +8,8 @@ export interface ListDiscussionsOptions extends PaginationOptions {
 
 export interface GetDiscussionOptions {
   id: string;
+  /** Related resources to include (e.g., page) */
+  include?: string[];
 }
 
 export interface CreateDiscussionOptions {

--- a/packages/core/src/executors/pages/get.test.ts
+++ b/packages/core/src/executors/pages/get.test.ts
@@ -14,8 +14,22 @@ describe('getPage', () => {
 
     const result = await getPage({ id: '1' }, ctx);
 
-    expect(getPageApi).toHaveBeenCalledWith('1');
+    expect(getPageApi).toHaveBeenCalledWith('1', { include: undefined });
     expect(result.data).toEqual(mockResponse.data);
     expect(result.included).toEqual([]);
+  });
+
+  it('forwards include (Finding 3)', async () => {
+    const included = [{ id: '7', type: 'people', attributes: { first_name: 'Jane' } }];
+    const getPageApi = vi.fn().mockResolvedValue({
+      data: { id: '1', type: 'pages', attributes: {} },
+      included,
+    });
+    const ctx = createTestExecutorContext({ api: { getPage: getPageApi } });
+
+    const result = await getPage({ id: '1', include: ['creator'] }, ctx);
+
+    expect(getPageApi).toHaveBeenCalledWith('1', { include: ['creator'] });
+    expect(result.included).toEqual(included);
   });
 });

--- a/packages/core/src/executors/pages/get.ts
+++ b/packages/core/src/executors/pages/get.ts
@@ -8,6 +8,6 @@ export async function getPage(
   options: GetPageOptions,
   ctx: ExecutorContext,
 ): Promise<ExecutorResult<ProductivePage>> {
-  const response = await ctx.api.getPage(options.id);
+  const response = await ctx.api.getPage(options.id, { include: options.include });
   return { data: response.data, included: response.included };
 }

--- a/packages/core/src/executors/pages/list.test.ts
+++ b/packages/core/src/executors/pages/list.test.ts
@@ -85,4 +85,15 @@ describe('listPages', () => {
 
     expect(getPages).toHaveBeenCalledWith(expect.objectContaining({ page: 1, perPage: 100 }));
   });
+
+  it('forwards include and returns included (Finding 3)', async () => {
+    const included = [{ id: '7', type: 'people', attributes: { first_name: 'Jane' } }];
+    const getPages = vi.fn().mockResolvedValue({ data: [], meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getPages } });
+
+    const result = await listPages({ include: ['creator'] }, ctx);
+
+    expect(getPages).toHaveBeenCalledWith(expect.objectContaining({ include: ['creator'] }));
+    expect(result.included).toEqual(included);
+  });
 });

--- a/packages/core/src/executors/pages/list.ts
+++ b/packages/core/src/executors/pages/list.ts
@@ -4,6 +4,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListPagesOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildPageFilters(options: ListPagesOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -23,11 +25,8 @@ export async function listPages(
   const { resolved: resolvedFilter, metadata } = await ctx.resolver.resolveFilters(filter);
 
   const response = await ctx.api.getPages({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: resolvedFilter,
-    sort: options.sort,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/pages/list.ts
+++ b/packages/core/src/executors/pages/list.ts
@@ -27,6 +27,7 @@ export async function listPages(
     perPage: options.perPage ?? 100,
     filter: resolvedFilter,
     sort: options.sort,
+    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/pages/types.ts
+++ b/packages/core/src/executors/pages/types.ts
@@ -8,6 +8,8 @@ export interface ListPagesOptions extends PaginationOptions {
 
 export interface GetPageOptions {
   id: string;
+  /** Related resources to include (e.g., creator) */
+  include?: string[];
 }
 
 export interface CreatePageOptions {

--- a/packages/core/src/executors/people/get.test.ts
+++ b/packages/core/src/executors/people/get.test.ts
@@ -18,8 +18,19 @@ describe('getPerson', () => {
 
     const result = await getPerson({ id: '1' }, ctx);
 
-    expect(getPersonApi).toHaveBeenCalledWith('1');
+    expect(getPersonApi).toHaveBeenCalledWith('1', { include: undefined });
     expect(result.data).toEqual(mockPerson);
+  });
+
+  it('forwards include and returns included (Finding 1)', async () => {
+    const included = [{ id: '9', type: 'companies', attributes: { name: 'Acme' } }];
+    const getPersonApi = vi.fn().mockResolvedValue({ data: mockPerson, included });
+    const ctx = createTestExecutorContext({ api: { getPerson: getPersonApi } });
+
+    const result = await getPerson({ id: '1', include: ['company'] }, ctx);
+
+    expect(getPersonApi).toHaveBeenCalledWith('1', { include: ['company'] });
+    expect(result.included).toEqual(included);
   });
 
   it('resolves non-numeric ID before fetching', async () => {
@@ -33,6 +44,6 @@ describe('getPerson', () => {
     await getPerson({ id: 'john@test.com' }, ctx);
 
     expect(resolveValue).toHaveBeenCalledWith('john@test.com', 'person');
-    expect(getPersonApi).toHaveBeenCalledWith('1');
+    expect(getPersonApi).toHaveBeenCalledWith('1', { include: undefined });
   });
 });

--- a/packages/core/src/executors/people/get.ts
+++ b/packages/core/src/executors/people/get.ts
@@ -13,6 +13,6 @@ export async function getPerson(
   ctx: ExecutorContext,
 ): Promise<ExecutorResult<ProductivePerson>> {
   const resolvedId = await ctx.resolver.resolveValue(options.id, 'person');
-  const response = await ctx.api.getPerson(resolvedId);
-  return { data: response.data };
+  const response = await ctx.api.getPerson(resolvedId, { include: options.include });
+  return { data: response.data, included: response.included };
 }

--- a/packages/core/src/executors/people/list.test.ts
+++ b/packages/core/src/executors/people/list.test.ts
@@ -104,4 +104,15 @@ describe('listPeople', () => {
 
     expect(getPeople).toHaveBeenCalledWith(expect.objectContaining({ page: 1, perPage: 100 }));
   });
+
+  it('forwards include and returns included (Finding 1)', async () => {
+    const included = [{ id: '9', type: 'companies', attributes: { name: 'Acme' } }];
+    const getPeople = vi.fn().mockResolvedValue({ data: [], meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getPeople } });
+
+    const result = await listPeople({ include: ['company'] }, ctx);
+
+    expect(getPeople).toHaveBeenCalledWith(expect.objectContaining({ include: ['company'] }));
+    expect(result.included).toEqual(included);
+  });
 });

--- a/packages/core/src/executors/people/list.ts
+++ b/packages/core/src/executors/people/list.ts
@@ -10,6 +10,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListPeopleOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildPeopleFilters(options: ListPeopleOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -41,11 +43,8 @@ export async function listPeople(
   const { resolved: resolvedFilter, metadata } = await ctx.resolver.resolveFilters(filter);
 
   const response = await ctx.api.getPeople({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: resolvedFilter,
-    sort: options.sort,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/people/list.ts
+++ b/packages/core/src/executors/people/list.ts
@@ -45,11 +45,13 @@ export async function listPeople(
     perPage: options.perPage ?? 100,
     filter: resolvedFilter,
     sort: options.sort,
+    include: options.include,
   });
 
   return {
     data: response.data,
     meta: response.meta,
+    included: response.included,
     resolved: Object.keys(metadata).length > 0 ? metadata : undefined,
   };
 }

--- a/packages/core/src/executors/people/types.ts
+++ b/packages/core/src/executors/people/types.ts
@@ -19,4 +19,6 @@ export interface ListPeopleOptions extends PaginationOptions {
 export interface GetPersonOptions {
   /** Person ID or human-friendly identifier (email) */
   id: string;
+  /** Related resources to include (e.g., company) */
+  include?: string[];
 }

--- a/packages/core/src/executors/projects/get.test.ts
+++ b/packages/core/src/executors/projects/get.test.ts
@@ -26,7 +26,22 @@ describe('getProject', () => {
     const result = await getProject({ id: 'PRJ-001' }, ctx);
 
     expect(resolveValue).toHaveBeenCalledWith('PRJ-001', 'project');
-    expect(getProjectApi).toHaveBeenCalledWith('42');
+    expect(getProjectApi).toHaveBeenCalledWith('42', { include: undefined });
     expect(result.data).toEqual(mockProject);
+  });
+
+  it('forwards include and returns included (Finding 1)', async () => {
+    const included = [{ id: '99', type: 'companies', attributes: { name: 'Acme' } }];
+    const resolveValue = vi.fn().mockResolvedValue('42');
+    const getProjectApi = vi.fn().mockResolvedValue({ data: mockProject, included });
+    const ctx = createTestExecutorContext({
+      api: { getProject: getProjectApi },
+      resolver: { resolveValue },
+    });
+
+    const result = await getProject({ id: 'PRJ-001', include: ['company'] }, ctx);
+
+    expect(getProjectApi).toHaveBeenCalledWith('42', { include: ['company'] });
+    expect(result.included).toEqual(included);
   });
 });

--- a/packages/core/src/executors/projects/get.ts
+++ b/packages/core/src/executors/projects/get.ts
@@ -17,9 +17,10 @@ export async function getProject(
   ctx: ExecutorContext,
 ): Promise<ExecutorResult<ProductiveProject>> {
   const resolvedId = await ctx.resolver.resolveValue(options.id, 'project');
-  const response = await ctx.api.getProject(resolvedId);
+  const response = await ctx.api.getProject(resolvedId, { include: options.include });
 
   return {
     data: response.data,
+    included: response.included,
   };
 }

--- a/packages/core/src/executors/projects/list.test.ts
+++ b/packages/core/src/executors/projects/list.test.ts
@@ -70,8 +70,20 @@ describe('listProjects', () => {
       perPage: 100,
       filter: {},
       sort: undefined,
+      include: undefined,
     });
     expect(result.data).toEqual(mockProjects);
+  });
+
+  it('forwards include and returns included (Finding 1)', async () => {
+    const included = [{ id: '99', type: 'companies', attributes: { name: 'Acme' } }];
+    const getProjects = vi.fn().mockResolvedValue({ data: mockProjects, meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getProjects } });
+
+    const result = await listProjects({ include: ['company'] }, ctx);
+
+    expect(getProjects).toHaveBeenCalledWith(expect.objectContaining({ include: ['company'] }));
+    expect(result.included).toEqual(included);
   });
 
   it('resolves filters with type mapping', async () => {

--- a/packages/core/src/executors/projects/list.ts
+++ b/packages/core/src/executors/projects/list.ts
@@ -51,11 +51,13 @@ export async function listProjects(
     perPage: options.perPage ?? 100,
     filter: resolvedFilter,
     sort: options.sort,
+    include: options.include,
   });
 
   return {
     data: response.data,
     meta: response.meta,
+    included: response.included,
     resolved: Object.keys(metadata).length > 0 ? metadata : undefined,
   };
 }

--- a/packages/core/src/executors/projects/list.ts
+++ b/packages/core/src/executors/projects/list.ts
@@ -10,6 +10,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListProjectsOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 /**
  * Build the filter object from typed options.
  */
@@ -47,11 +49,8 @@ export async function listProjects(
   const { resolved: resolvedFilter, metadata } = await ctx.resolver.resolveFilters(filter);
 
   const response = await ctx.api.getProjects({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: resolvedFilter,
-    sort: options.sort,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/projects/types.ts
+++ b/packages/core/src/executors/projects/types.ts
@@ -28,6 +28,8 @@ export interface ListProjectsOptions extends PaginationOptions {
 export interface GetProjectOptions {
   /** Project ID or human-friendly identifier (e.g., PRJ-123) */
   id: string;
+  /** Related resources to include (e.g., company) */
+  include?: string[];
 }
 
 /**

--- a/packages/core/src/executors/services/list.test.ts
+++ b/packages/core/src/executors/services/list.test.ts
@@ -107,4 +107,15 @@ describe('listServices', () => {
 
     expect(getServices).toHaveBeenCalledWith(expect.objectContaining({ page: 1, perPage: 100 }));
   });
+
+  it('forwards include and returns included (Finding 1)', async () => {
+    const included = [{ id: '4', type: 'deals', attributes: { name: 'Deal' } }];
+    const getServices = vi.fn().mockResolvedValue({ data: [], meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getServices } });
+
+    const result = await listServices({ include: ['deal'] }, ctx);
+
+    expect(getServices).toHaveBeenCalledWith(expect.objectContaining({ include: ['deal'] }));
+    expect(result.included).toEqual(included);
+  });
 });

--- a/packages/core/src/executors/services/list.ts
+++ b/packages/core/src/executors/services/list.ts
@@ -10,6 +10,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListServicesOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildServicesFilters(options: ListServicesOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -42,10 +44,8 @@ export async function listServices(
   const { resolved: resolvedFilter, metadata } = await ctx.resolver.resolveFilters(filter);
 
   const response = await ctx.api.getServices({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: resolvedFilter,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/services/list.ts
+++ b/packages/core/src/executors/services/list.ts
@@ -45,11 +45,13 @@ export async function listServices(
     page: options.page ?? 1,
     perPage: options.perPage ?? 100,
     filter: resolvedFilter,
+    include: options.include,
   });
 
   return {
     data: response.data,
     meta: response.meta,
+    included: response.included,
     resolved: Object.keys(metadata).length > 0 ? metadata : undefined,
   };
 }

--- a/packages/core/src/executors/tasks/list.ts
+++ b/packages/core/src/executors/tasks/list.ts
@@ -6,6 +6,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListTasksOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildTaskFilters(options: ListTasksOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -42,10 +44,8 @@ export async function listTasks(
   const { resolved: resolvedFilter, metadata } = await ctx.resolver.resolveFilters(filter);
 
   const response = await ctx.api.getTasks({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: resolvedFilter,
-    sort: options.sort,
     include: options.include ?? ['project', 'assignee', 'workflow_status'],
   });
 

--- a/packages/core/src/executors/time/list.test.ts
+++ b/packages/core/src/executors/time/list.test.ts
@@ -189,4 +189,15 @@ describe('listTimeEntries', () => {
     const result = await listTimeEntries({ personId: '123' }, ctx);
     expect(result.resolved).toBeUndefined();
   });
+
+  it('forwards include and returns included (Finding 1)', async () => {
+    const included = [{ id: '8', type: 'people', attributes: { first_name: 'Jane' } }];
+    const getTimeEntries = vi.fn().mockResolvedValue({ data: [], meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getTimeEntries } });
+
+    const result = await listTimeEntries({ include: ['person'] }, ctx);
+
+    expect(getTimeEntries).toHaveBeenCalledWith(expect.objectContaining({ include: ['person'] }));
+    expect(result.included).toEqual(included);
+  });
 });

--- a/packages/core/src/executors/time/list.ts
+++ b/packages/core/src/executors/time/list.ts
@@ -13,6 +13,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListTimeEntriesOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 /**
  * Build the filter object from typed options.
  * This is a pure function with no side effects.
@@ -75,11 +77,8 @@ export async function listTimeEntries(
 
   // Call API
   const response = await ctx.api.getTimeEntries({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter: resolvedFilter,
-    sort: options.sort,
-    include: options.include,
   });
 
   return {

--- a/packages/core/src/executors/time/list.ts
+++ b/packages/core/src/executors/time/list.ts
@@ -79,11 +79,13 @@ export async function listTimeEntries(
     perPage: options.perPage ?? 100,
     filter: resolvedFilter,
     sort: options.sort,
+    include: options.include,
   });
 
   return {
     data: response.data,
     meta: response.meta,
+    included: response.included,
     resolved: Object.keys(metadata).length > 0 ? metadata : undefined,
   };
 }

--- a/packages/core/src/executors/timers/list.test.ts
+++ b/packages/core/src/executors/timers/list.test.ts
@@ -76,4 +76,14 @@ describe('listTimers', () => {
       perPage: 100,
     });
   });
+
+  it('returns included sideloaded resources (Finding 2)', async () => {
+    const included = [{ id: '9', type: 'people', attributes: { first_name: 'Jane' } }];
+    const getTimers = vi.fn().mockResolvedValue({ data: [], meta: {}, included });
+    const ctx = createTestExecutorContext({ api: { getTimers } });
+
+    const result = await listTimers({ include: ['person'] }, ctx);
+
+    expect(result.included).toEqual(included);
+  });
 });

--- a/packages/core/src/executors/timers/list.ts
+++ b/packages/core/src/executors/timers/list.ts
@@ -4,6 +4,8 @@ import type { ExecutorContext } from '../../context/types.js';
 import type { ExecutorResult } from '../types.js';
 import type { ListTimersOptions } from './types.js';
 
+import { buildListParams } from '../types.js';
+
 export function buildTimerFilters(options: ListTimersOptions): Record<string, string> {
   const filter: Record<string, string> = {};
 
@@ -20,11 +22,8 @@ export async function listTimers(
   const filter = buildTimerFilters(options);
 
   const response = await ctx.api.getTimers({
-    page: options.page ?? 1,
-    perPage: options.perPage ?? 100,
+    ...buildListParams(options),
     filter,
-    include: options.include,
-    sort: options.sort,
   });
 
   return {

--- a/packages/core/src/executors/timers/list.ts
+++ b/packages/core/src/executors/timers/list.ts
@@ -30,5 +30,6 @@ export async function listTimers(
   return {
     data: response.data,
     meta: response.meta,
+    included: response.included,
   };
 }

--- a/packages/core/src/executors/types.test.ts
+++ b/packages/core/src/executors/types.test.ts
@@ -1,0 +1,35 @@
+import { DEFAULT_PAGE_SIZE } from '@studiometa/productive-api';
+import { describe, expect, it } from 'vitest';
+
+import { buildListParams } from './types.js';
+
+describe('buildListParams', () => {
+  it('applies the page/perPage defaults when they are omitted', () => {
+    expect(buildListParams({})).toEqual({
+      page: 1,
+      perPage: DEFAULT_PAGE_SIZE,
+      sort: undefined,
+      include: undefined,
+    });
+  });
+
+  it('forwards positive pagination, sort and include values unchanged', () => {
+    expect(buildListParams({ page: 3, perPage: 50, sort: 'name', include: ['company'] })).toEqual({
+      page: 3,
+      perPage: 50,
+      sort: 'name',
+      include: ['company'],
+    });
+  });
+
+  it('coerces a non-positive page/perPage to the defaults', () => {
+    expect(buildListParams({ page: 0, perPage: 0 })).toMatchObject({
+      page: 1,
+      perPage: DEFAULT_PAGE_SIZE,
+    });
+    expect(buildListParams({ page: -1, perPage: -5 })).toMatchObject({
+      page: 1,
+      perPage: DEFAULT_PAGE_SIZE,
+    });
+  });
+});

--- a/packages/core/src/executors/types.ts
+++ b/packages/core/src/executors/types.ts
@@ -10,6 +10,8 @@
 
 import type { IncludedResource, JsonApiMeta } from '@studiometa/productive-api';
 
+import { DEFAULT_PAGE_SIZE } from '@studiometa/productive-api';
+
 import type { ExecutorContext, ResolvedInfo } from '../context/types.js';
 
 /**
@@ -40,6 +42,26 @@ export interface PaginationOptions {
   sort?: string;
   /** JSON:API include parameter for sideloading related resources */
   include?: string[];
+}
+
+/**
+ * Map the common pagination/sort/include options to the shape the API client
+ * expects, applying defaults. Spreading this into every list executor's API
+ * call guarantees these params are forwarded uniformly — no executor can
+ * silently drop `sort` or `include` the way several historically did.
+ */
+export function buildListParams(options: PaginationOptions): {
+  page: number;
+  perPage: number;
+  sort?: string;
+  include?: string[];
+} {
+  return {
+    page: options.page ?? 1,
+    perPage: options.perPage ?? DEFAULT_PAGE_SIZE,
+    sort: options.sort,
+    include: options.include,
+  };
 }
 
 /**

--- a/packages/core/src/executors/types.ts
+++ b/packages/core/src/executors/types.ts
@@ -57,8 +57,11 @@ export function buildListParams(options: PaginationOptions): {
   include?: string[];
 } {
   return {
-    page: options.page ?? 1,
-    perPage: options.perPage ?? DEFAULT_PAGE_SIZE,
+    // Treat a non-positive (or missing) page/perPage as "unset" so the default
+    // applies — `??` alone would forward an out-of-range 0 (e.g. from `--size 0`)
+    // straight to the API instead of falling back.
+    page: options.page && options.page > 0 ? options.page : 1,
+    perPage: options.perPage && options.perPage > 0 ? options.perPage : DEFAULT_PAGE_SIZE,
     sort: options.sort,
     include: options.include,
   };

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -81,16 +81,16 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@studiometa/productive-api": "*",
     "@studiometa/productive-core": "*",
-    "h3": "^2.0.1-rc.14",
+    "h3": "^2.0.1-rc.22",
     "zod": "4.3.6"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^4.1.7",
-    "vite": "^8.0.14",
-    "vitest": "^4.1.7"
+    "@vitest/coverage-v8": "^4.1.8",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/mcp/src/formatters.test.ts
+++ b/packages/mcp/src/formatters.test.ts
@@ -8,6 +8,10 @@ import {
   formatTask,
   formatPerson,
   formatService,
+  formatCompany,
+  formatPage,
+  formatDiscussion,
+  formatAttachment,
   formatListResponse,
 } from './formatters.js';
 
@@ -256,5 +260,113 @@ describe('formatters', () => {
       expect(result.data).toHaveLength(1);
       expect(result.data[0]).toHaveProperty('title', 'Task 1');
     });
+  });
+});
+
+describe('formatters thread included relationships through to the API resolver', () => {
+  it('formatProject inlines the company relationship (issue #174)', () => {
+    const project: JsonApiResource = {
+      id: '1',
+      type: 'projects',
+      attributes: { name: 'Alpha' },
+      relationships: { company: { data: { id: '99', type: 'companies' } } },
+    };
+    const result = formatProject(project, {
+      included: [{ id: '99', type: 'companies', attributes: { name: 'Acme Inc.' } }],
+    });
+    expect(result.company).toMatchObject({ id: '99', type: 'companies', name: 'Acme Inc.' });
+  });
+
+  it('formatPerson inlines the company relationship', () => {
+    const person: JsonApiResource = {
+      id: '1',
+      type: 'people',
+      attributes: { first_name: 'Jane', last_name: 'Doe' },
+      relationships: { company: { data: { id: '99', type: 'companies' } } },
+    };
+    const result = formatPerson(person, {
+      included: [{ id: '99', type: 'companies', attributes: { name: 'Acme Inc.' } }],
+    });
+    expect(result.company).toMatchObject({ id: '99', name: 'Acme Inc.' });
+  });
+
+  it('formatService inlines the deal relationship', () => {
+    const service: JsonApiResource = {
+      id: '1',
+      type: 'services',
+      attributes: { name: 'Dev' },
+      relationships: { deal: { data: { id: '4', type: 'deals' } } },
+    };
+    const result = formatService(service, {
+      included: [{ id: '4', type: 'deals', attributes: { name: 'Big Deal' } }],
+    });
+    expect(result.deal).toMatchObject({ id: '4', name: 'Big Deal' });
+  });
+
+  it('formatTimeEntry inlines the service relationship', () => {
+    const entry: JsonApiResource = {
+      id: '1',
+      type: 'time_entries',
+      attributes: { date: '2026-01-01', time: 60 },
+      relationships: { service: { data: { id: '5', type: 'services' } } },
+    };
+    const result = formatTimeEntry(entry, {
+      included: [{ id: '5', type: 'services', attributes: { name: 'Dev' } }],
+    });
+    expect(result.service).toMatchObject({ id: '5', name: 'Dev' });
+  });
+
+  it('formatCompany inlines the contacts relationship', () => {
+    const company: JsonApiResource = {
+      id: '1',
+      type: 'companies',
+      attributes: { name: 'Acme' },
+      relationships: { contacts: { data: [{ id: '7', type: 'contact_entries' }] } } as never,
+    };
+    const result = formatCompany(company, {
+      included: [{ id: '7', type: 'contact_entries', attributes: { email: 'a@b.com' } }],
+    });
+    expect(result.contacts).toEqual([{ id: '7', type: 'contact_entries', email: 'a@b.com' }]);
+  });
+
+  it('formatPage inlines the creator relationship', () => {
+    const page: JsonApiResource = {
+      id: '1',
+      type: 'pages',
+      attributes: { title: 'Doc' },
+      relationships: { creator: { data: { id: '20', type: 'people' } } },
+    };
+    const result = formatPage(page, {
+      included: [
+        { id: '20', type: 'people', attributes: { first_name: 'Jane', last_name: 'Doe' } },
+      ],
+    });
+    expect(result.creator).toMatchObject({ id: '20', first_name: 'Jane' });
+  });
+
+  it('formatDiscussion inlines the page relationship', () => {
+    const discussion: JsonApiResource = {
+      id: '1',
+      type: 'discussions',
+      attributes: { title: 'D', status: 1 },
+      relationships: { page: { data: { id: '10', type: 'pages' } } },
+    };
+    const result = formatDiscussion(discussion, {
+      included: [{ id: '10', type: 'pages', attributes: { title: 'Parent Page' } }],
+    });
+    expect(result.page).toMatchObject({ id: '10', title: 'Parent Page' });
+  });
+
+  it('formatAttachment inlines the attachable relationship', () => {
+    const attachment: JsonApiResource = {
+      id: '1',
+      type: 'attachments',
+      attributes: { name: 'f.pdf', size: 1, content_type: 'application/pdf', url: 'http://x' },
+      relationships: { attachable: { data: { id: '77', type: 'tasks' } } },
+    };
+    const result = formatAttachment(attachment, {
+      included: [{ id: '77', type: 'tasks', attributes: { title: 'My Task' } }],
+    });
+    expect(result.attachable).toMatchObject({ id: '77', title: 'My Task' });
   });
 });

--- a/packages/mcp/src/formatters.test.ts
+++ b/packages/mcp/src/formatters.test.ts
@@ -13,6 +13,7 @@ import {
   formatDiscussion,
   formatAttachment,
   formatListResponse,
+  withIncluded,
 } from './formatters.js';
 
 describe('formatters', () => {
@@ -368,5 +369,29 @@ describe('formatters thread included relationships through to the API resolver',
       included: [{ id: '77', type: 'tasks', attributes: { title: 'My Task' } }],
     });
     expect(result.attachable).toMatchObject({ id: '77', title: 'My Task' });
+  });
+});
+
+describe('withIncluded', () => {
+  it('merges the MCP format defaults with the sideloaded included array', () => {
+    const included: JsonApiResource[] = [
+      { id: '99', type: 'companies', attributes: { name: 'Acme Inc.' } },
+    ];
+
+    expect(withIncluded({ included })).toEqual({
+      includeRelationshipIds: false,
+      includeTimestamps: false,
+      stripHtml: true,
+      included,
+    });
+  });
+
+  it('defaults included to undefined when no options are passed', () => {
+    expect(withIncluded()).toEqual({
+      includeRelationshipIds: false,
+      includeTimestamps: false,
+      stripHtml: true,
+      included: undefined,
+    });
   });
 });

--- a/packages/mcp/src/formatters.ts
+++ b/packages/mcp/src/formatters.ts
@@ -72,7 +72,7 @@ export function formatTimeEntry(
   entry: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatTimeEntry(entry, MCP_FORMAT_OPTIONS);
+  const result = cliFormatTimeEntry(entry, { ...MCP_FORMAT_OPTIONS, included: options?.included });
   if (options?.compact) {
     return compactify(result, ['note', 'billable_time', 'approved']);
   }
@@ -86,7 +86,7 @@ export function formatProject(
   project: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatProject(project, MCP_FORMAT_OPTIONS);
+  const result = cliFormatProject(project, { ...MCP_FORMAT_OPTIONS, included: options?.included });
   if (options?.compact) {
     return compactify(result, ['budget']);
   }
@@ -122,7 +122,7 @@ export function formatPerson(
   person: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatPerson(person, MCP_FORMAT_OPTIONS);
+  const result = cliFormatPerson(person, { ...MCP_FORMAT_OPTIONS, included: options?.included });
   if (options?.compact) {
     return compactify(result, ['title', 'first_name', 'last_name']); // Keep 'name' which combines them
   }
@@ -136,7 +136,7 @@ export function formatService(
   service: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatService(service, MCP_FORMAT_OPTIONS);
+  const result = cliFormatService(service, { ...MCP_FORMAT_OPTIONS, included: options?.included });
   if (options?.compact) {
     return compactify(result, ['budgeted_time', 'worked_time']);
   }
@@ -150,7 +150,7 @@ export function formatCompany(
   company: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatCompany(company, MCP_FORMAT_OPTIONS);
+  const result = cliFormatCompany(company, { ...MCP_FORMAT_OPTIONS, included: options?.included });
   if (options?.compact) {
     return compactify(result, ['billing_name', 'domain', 'due_days']);
   }
@@ -214,7 +214,10 @@ export function formatAttachment(
   attachment: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatAttachment(attachment, MCP_FORMAT_OPTIONS);
+  const result = cliFormatAttachment(attachment, {
+    ...MCP_FORMAT_OPTIONS,
+    included: options?.included,
+  });
   if (options?.compact) {
     return compactify(result, ['url']);
   }
@@ -228,7 +231,7 @@ export function formatPage(
   page: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatPage(page, MCP_FORMAT_OPTIONS);
+  const result = cliFormatPage(page, { ...MCP_FORMAT_OPTIONS, included: options?.included });
   if (options?.compact) {
     return compactify(result, ['body', 'version_number']);
   }
@@ -242,7 +245,10 @@ export function formatDiscussion(
   discussion: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatDiscussion(discussion, MCP_FORMAT_OPTIONS);
+  const result = cliFormatDiscussion(discussion, {
+    ...MCP_FORMAT_OPTIONS,
+    included: options?.included,
+  });
   if (options?.compact) {
     return compactify(result, ['body']);
   }

--- a/packages/mcp/src/formatters.ts
+++ b/packages/mcp/src/formatters.ts
@@ -66,13 +66,22 @@ function compactify<T extends Record<string, unknown>>(obj: T, fieldsToRemove: s
 }
 
 /**
+ * Build the CLI formatter options for an MCP wrapper: the MCP defaults plus any
+ * sideloaded `included` array carried over, so each formatter forwards
+ * relationships with a single shared call instead of repeating the spread.
+ */
+export function withIncluded(options?: McpFormatOptions): FormatOptions {
+  return { ...MCP_FORMAT_OPTIONS, included: options?.included };
+}
+
+/**
  * Format time entry for agent consumption
  */
 export function formatTimeEntry(
   entry: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatTimeEntry(entry, { ...MCP_FORMAT_OPTIONS, included: options?.included });
+  const result = cliFormatTimeEntry(entry, withIncluded(options));
   if (options?.compact) {
     return compactify(result, ['note', 'billable_time', 'approved']);
   }
@@ -86,7 +95,7 @@ export function formatProject(
   project: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatProject(project, { ...MCP_FORMAT_OPTIONS, included: options?.included });
+  const result = cliFormatProject(project, withIncluded(options));
   if (options?.compact) {
     return compactify(result, ['budget']);
   }
@@ -101,7 +110,7 @@ export function formatTask(
   task: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatTask(task, { ...MCP_FORMAT_OPTIONS, included: options?.included });
+  const result = cliFormatTask(task, withIncluded(options));
   if (options?.compact) {
     return compactify(result, [
       'description',
@@ -122,7 +131,7 @@ export function formatPerson(
   person: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatPerson(person, { ...MCP_FORMAT_OPTIONS, included: options?.included });
+  const result = cliFormatPerson(person, withIncluded(options));
   if (options?.compact) {
     return compactify(result, ['title', 'first_name', 'last_name']); // Keep 'name' which combines them
   }
@@ -136,7 +145,7 @@ export function formatService(
   service: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatService(service, { ...MCP_FORMAT_OPTIONS, included: options?.included });
+  const result = cliFormatService(service, withIncluded(options));
   if (options?.compact) {
     return compactify(result, ['budgeted_time', 'worked_time']);
   }
@@ -150,7 +159,7 @@ export function formatCompany(
   company: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatCompany(company, { ...MCP_FORMAT_OPTIONS, included: options?.included });
+  const result = cliFormatCompany(company, withIncluded(options));
   if (options?.compact) {
     return compactify(result, ['billing_name', 'domain', 'due_days']);
   }
@@ -164,7 +173,7 @@ export function formatComment(
   comment: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatComment(comment, { ...MCP_FORMAT_OPTIONS, included: options?.included });
+  const result = cliFormatComment(comment, withIncluded(options));
   return result;
 }
 
@@ -186,7 +195,7 @@ export function formatDeal(
   deal: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatDeal(deal, { ...MCP_FORMAT_OPTIONS, included: options?.included });
+  const result = cliFormatDeal(deal, withIncluded(options));
   if (options?.compact) {
     return compactify(result, ['won_at', 'lost_at']);
   }
@@ -200,7 +209,7 @@ export function formatBooking(
   booking: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatBooking(booking, { ...MCP_FORMAT_OPTIONS, included: options?.included });
+  const result = cliFormatBooking(booking, withIncluded(options));
   if (options?.compact) {
     return compactify(result, ['approved_at', 'rejected_at', 'rejected_reason']);
   }
@@ -214,10 +223,7 @@ export function formatAttachment(
   attachment: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatAttachment(attachment, {
-    ...MCP_FORMAT_OPTIONS,
-    included: options?.included,
-  });
+  const result = cliFormatAttachment(attachment, withIncluded(options));
   if (options?.compact) {
     return compactify(result, ['url']);
   }
@@ -231,7 +237,7 @@ export function formatPage(
   page: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatPage(page, { ...MCP_FORMAT_OPTIONS, included: options?.included });
+  const result = cliFormatPage(page, withIncluded(options));
   if (options?.compact) {
     return compactify(result, ['body', 'version_number']);
   }
@@ -245,10 +251,7 @@ export function formatDiscussion(
   discussion: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  const result = cliFormatDiscussion(discussion, {
-    ...MCP_FORMAT_OPTIONS,
-    included: options?.included,
-  });
+  const result = cliFormatDiscussion(discussion, withIncluded(options));
   if (options?.compact) {
     return compactify(result, ['body']);
   }
@@ -259,10 +262,7 @@ export function formatActivity(
   activity: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  return cliFormatActivity(activity, {
-    ...MCP_FORMAT_OPTIONS,
-    included: options?.included,
-  });
+  return cliFormatActivity(activity, withIncluded(options));
 }
 
 /**
@@ -272,10 +272,7 @@ export function formatCustomField(
   field: JsonApiResource,
   options?: McpFormatOptions,
 ): Record<string, unknown> {
-  return cliFormatCustomField(field, {
-    ...MCP_FORMAT_OPTIONS,
-    included: options?.included,
-  });
+  return cliFormatCustomField(field, withIncluded(options));
 }
 
 /**
@@ -297,10 +294,7 @@ export function formatListResponse<T>(
     return formatter(item, options);
   };
 
-  const result = cliFormatListResponse(data, wrappedFormatter, meta, {
-    ...MCP_FORMAT_OPTIONS,
-    included: options?.included,
-  });
+  const result = cliFormatListResponse(data, wrappedFormatter, meta, withIncluded(options));
 
   return result as { data: T[]; meta?: FormattedPagination };
 }

--- a/packages/mcp/src/handlers.test.ts
+++ b/packages/mcp/src/handlers.test.ts
@@ -2282,6 +2282,72 @@ describe('include parameter', () => {
     });
   });
 
+  describe('people', () => {
+    it('forwards include to getPerson for get', async () => {
+      mockApi.getPerson.mockResolvedValue({
+        data: { id: '1', type: 'people', attributes: { first_name: 'J', last_name: 'D' } },
+      });
+
+      await executeToolWithCredentials(
+        'productive',
+        { resource: 'people', action: 'get', id: '1', include: ['company'] },
+        credentials,
+      );
+
+      expect(mockApi.getPerson).toHaveBeenCalledWith('1', { include: ['company'] });
+    });
+
+    it('forwards include to getPerson for me', async () => {
+      mockApi.getPerson.mockResolvedValue({
+        data: { id: '500521', type: 'people', attributes: { first_name: 'T', last_name: 'U' } },
+      });
+
+      await executeToolWithCredentials(
+        'productive',
+        { resource: 'people', action: 'me', include: ['company'] },
+        credentials,
+      );
+
+      expect(mockApi.getPerson).toHaveBeenCalledWith('500521', { include: ['company'] });
+    });
+
+    it('forwards include to getPeople for list', async () => {
+      mockApi.getPeople.mockResolvedValue({
+        data: [{ id: '1', type: 'people', attributes: { first_name: 'J', last_name: 'D' } }],
+        meta: { current_page: 1, total_pages: 1 },
+      });
+
+      await executeToolWithCredentials(
+        'productive',
+        { resource: 'people', action: 'list', include: ['company'] },
+        credentials,
+      );
+
+      expect(mockApi.getPeople).toHaveBeenCalledWith(
+        expect.objectContaining({ include: ['company'] }),
+      );
+    });
+  });
+
+  describe('services', () => {
+    it('forwards include to getServices for list', async () => {
+      mockApi.getServices.mockResolvedValue({
+        data: [{ id: '1', type: 'services', attributes: { name: 'Dev' } }],
+        meta: { current_page: 1, total_pages: 1 },
+      });
+
+      await executeToolWithCredentials(
+        'productive',
+        { resource: 'services', action: 'list', include: ['deal'] },
+        credentials,
+      );
+
+      expect(mockApi.getServices).toHaveBeenCalledWith(
+        expect.objectContaining({ include: ['deal'] }),
+      );
+    });
+  });
+
   describe('bookings', () => {
     it('should use default includes when no user includes', async () => {
       const mockResponse = {

--- a/packages/mcp/src/handlers.test.ts
+++ b/packages/mcp/src/handlers.test.ts
@@ -168,7 +168,7 @@ describe('handlers', () => {
         );
 
         expect(result.isError).toBeUndefined();
-        expect(mockApi.getProject).toHaveBeenCalledWith('123');
+        expect(mockApi.getProject).toHaveBeenCalledWith('123', { include: undefined });
       });
 
       it('should return error for get without id', async () => {
@@ -623,7 +623,7 @@ describe('handlers', () => {
         );
 
         expect(result.isError).toBeUndefined();
-        expect(mockApi.getPerson).toHaveBeenCalledWith('123');
+        expect(mockApi.getPerson).toHaveBeenCalledWith('123', { include: undefined });
       });
 
       it('should handle me action with userId', async () => {
@@ -643,7 +643,7 @@ describe('handlers', () => {
         );
 
         expect(result.isError).toBeUndefined();
-        expect(mockApi.getPerson).toHaveBeenCalledWith('500521');
+        expect(mockApi.getPerson).toHaveBeenCalledWith('500521', { include: undefined });
       });
 
       it('should handle me action without userId', async () => {
@@ -1316,7 +1316,7 @@ describe('handlers', () => {
         );
 
         expect(result.isError).toBeUndefined();
-        expect(mockApi.getCompany).toHaveBeenCalledWith('123');
+        expect(mockApi.getCompany).toHaveBeenCalledWith('123', { include: undefined });
       });
 
       it('should return error for get without id', async () => {
@@ -2507,7 +2507,7 @@ describe('include parameter', () => {
       );
 
       expect(result.isError).toBeFalsy();
-      expect(mockApi.getAttachment).toHaveBeenCalledWith('1');
+      expect(mockApi.getAttachment).toHaveBeenCalledWith('1', { include: undefined });
     });
 
     it('should handle delete action', async () => {
@@ -2881,7 +2881,7 @@ describe('smart ID resolution', () => {
 
       expect(result.isError).toBeUndefined();
       expect(mockApi.getPeople).toHaveBeenCalled();
-      expect(mockApi.getPerson).toHaveBeenCalledWith('500521');
+      expect(mockApi.getPerson).toHaveBeenCalledWith('500521', { include: undefined });
     });
 
     it('should handle resolve action for people resource', async () => {
@@ -2955,7 +2955,7 @@ describe('smart ID resolution', () => {
 
       expect(result.isError).toBeUndefined();
       expect(mockApi.getProjects).toHaveBeenCalled();
-      expect(mockApi.getProject).toHaveBeenCalledWith('777');
+      expect(mockApi.getProject).toHaveBeenCalledWith('777', { include: undefined });
     });
 
     it('should resolve filter with company name in list action', async () => {

--- a/packages/mcp/src/handlers.test.ts
+++ b/packages/mcp/src/handlers.test.ts
@@ -3301,7 +3301,7 @@ describe('smart ID resolution', () => {
       );
 
       expect(result.isError).toBeUndefined();
-      expect(mockApi.getPage).toHaveBeenCalledWith('1');
+      expect(mockApi.getPage).toHaveBeenCalledWith('1', { include: undefined });
     });
 
     it('should return error for get without id', async () => {
@@ -3473,7 +3473,7 @@ describe('smart ID resolution', () => {
       );
 
       expect(result.isError).toBeUndefined();
-      expect(mockApi.getDiscussion).toHaveBeenCalledWith('1');
+      expect(mockApi.getDiscussion).toHaveBeenCalledWith('1', { include: undefined });
     });
 
     it('should return error for get without id', async () => {

--- a/packages/mcp/src/handlers.test.ts
+++ b/packages/mcp/src/handlers.test.ts
@@ -4146,7 +4146,7 @@ describe('smart ID resolution', () => {
       expect(result.isError).toBeUndefined();
     });
 
-    it('should skip validation for resources with no include map (projects)', async () => {
+    it('should pass through valid includes for projects (now validated)', async () => {
       mockApi.getProjects.mockResolvedValue({
         data: [{ id: '1', type: 'projects', attributes: { name: 'Project 1' } }],
         meta: { current_page: 1, total_pages: 1 },
@@ -4154,11 +4154,37 @@ describe('smart ID resolution', () => {
 
       const result = await executeToolWithCredentials(
         'productive',
+        { resource: 'projects', action: 'list', include: ['company'] },
+        credentials,
+      );
+
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should return error for an invalid include on projects', async () => {
+      const result = await executeToolWithCredentials(
+        'productive',
         { resource: 'projects', action: 'list', include: ['anything'] },
         credentials,
       );
 
-      // Projects has no include map — should not error
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Invalid include value');
+    });
+
+    it('should skip validation for resources with no include map (timers)', async () => {
+      mockApi.getTimers.mockResolvedValue({
+        data: [{ id: '1', type: 'timers', attributes: {} }],
+        meta: { current_page: 1, total_pages: 1 },
+      });
+
+      const result = await executeToolWithCredentials(
+        'productive',
+        { resource: 'timers', action: 'list', include: ['anything'] },
+        credentials,
+      );
+
+      // Timers has no include map — should not error
       expect(result.isError).toBeUndefined();
     });
 

--- a/packages/mcp/src/handlers/people.ts
+++ b/packages/mcp/src/handlers/people.ts
@@ -21,7 +21,7 @@ export async function handlePeople(
   ctx: HandlerContext,
   credentials: ProductiveCredentials,
 ): Promise<ToolResult> {
-  const { formatOptions, filter, page, perPage } = ctx;
+  const { formatOptions, filter, page, perPage, include } = ctx;
   const { id, query, type } = args;
 
   if (action === 'resolve') {
@@ -33,8 +33,8 @@ export async function handlePeople(
   if (action === 'get') {
     if (!id) return inputErrorResult(ErrorMessages.missingId('get'));
 
-    const result = await getPerson({ id }, execCtx);
-    const formatted = formatPerson(result.data, formatOptions);
+    const result = await getPerson({ id, include }, execCtx);
+    const formatted = formatPerson(result.data, { ...formatOptions, included: result.included });
 
     if (ctx.includeHints !== false) {
       return jsonResult({ ...formatted, _hints: getPersonHints(id) });
@@ -44,8 +44,8 @@ export async function handlePeople(
 
   if (action === 'me') {
     if (credentials.userId) {
-      const result = await getPerson({ id: credentials.userId }, execCtx);
-      const formatted = formatPerson(result.data, formatOptions);
+      const result = await getPerson({ id: credentials.userId, include }, execCtx);
+      const formatted = formatPerson(result.data, { ...formatOptions, included: result.included });
 
       if (ctx.includeHints !== false) {
         return jsonResult({ ...formatted, _hints: getPersonHints(credentials.userId) });
@@ -60,9 +60,12 @@ export async function handlePeople(
   }
 
   if (action === 'list') {
-    const result = await listPeople({ page, perPage, additionalFilters: filter }, execCtx);
+    const result = await listPeople({ page, perPage, additionalFilters: filter, include }, execCtx);
 
-    const response = formatListResponse(result.data, formatPerson, result.meta, formatOptions);
+    const response = formatListResponse(result.data, formatPerson, result.meta, {
+      ...formatOptions,
+      included: result.included,
+    });
 
     if (result.resolved && Object.keys(result.resolved).length > 0) {
       return jsonResult({ ...response, _resolved: result.resolved });

--- a/packages/mcp/src/handlers/services.ts
+++ b/packages/mcp/src/handlers/services.ts
@@ -28,10 +28,10 @@ export const handleServices = createResourceHandler<CommonArgs>({
   },
   customActions: {
     list: async (args, ctx, execCtx) => {
-      const { formatOptions, filter, page, perPage } = ctx;
+      const { formatOptions, filter, page, perPage, include } = ctx;
       const additionalFilters = { ...filter };
 
-      const result = await listServices({ page, perPage, additionalFilters }, execCtx);
+      const result = await listServices({ page, perPage, additionalFilters, include }, execCtx);
 
       const response = formatListResponse(result.data, formatService, result.meta, {
         ...formatOptions,

--- a/packages/mcp/src/handlers/valid-includes.test.ts
+++ b/packages/mcp/src/handlers/valid-includes.test.ts
@@ -45,28 +45,48 @@ describe('VALID_INCLUDES', () => {
     expect(VALID_INCLUDES.time).toContain('service');
     expect(VALID_INCLUDES.time).toContain('task');
   });
+
+  it('contains the formerly-unvalidated resources', () => {
+    expect(VALID_INCLUDES.projects).toContain('company');
+    expect(VALID_INCLUDES.people).toContain('company');
+    expect(VALID_INCLUDES.companies).toContain('contacts');
+    expect(VALID_INCLUDES.services).toContain('deal');
+    expect(VALID_INCLUDES.pages).toContain('creator');
+    expect(VALID_INCLUDES.discussions).toContain('page');
+    expect(VALID_INCLUDES.attachments).toContain('task');
+  });
 });
 
 describe('validateIncludes', () => {
-  describe('returns null for unknown resources', () => {
-    it('returns null for projects (no include validation)', () => {
-      expect(validateIncludes('projects', ['company'])).toBeNull();
+  describe('returns null for resources without an include whitelist', () => {
+    it('returns null for timers (no include validation)', () => {
+      expect(validateIncludes('timers', ['service'])).toBeNull();
     });
 
-    it('returns null for services', () => {
-      expect(validateIncludes('services', ['project'])).toBeNull();
-    });
-
-    it('returns null for people', () => {
-      expect(validateIncludes('people', ['company'])).toBeNull();
-    });
-
-    it('returns null for companies', () => {
-      expect(validateIncludes('companies', ['contacts'])).toBeNull();
-    });
-
-    it('returns null for completely unknown resource', () => {
+    it('returns null for a completely unknown resource', () => {
       expect(validateIncludes('foobar', ['anything'])).toBeNull();
+    });
+  });
+
+  describe('validates the formerly-unvalidated resources', () => {
+    it('accepts valid includes for projects, people, companies, services', () => {
+      expect(validateIncludes('projects', ['company'])!.invalid).toEqual([]);
+      expect(validateIncludes('people', ['company'])!.invalid).toEqual([]);
+      expect(validateIncludes('companies', ['contacts'])!.invalid).toEqual([]);
+      expect(validateIncludes('services', ['deal'])!.invalid).toEqual([]);
+    });
+
+    it('accepts valid includes for pages, discussions, attachments', () => {
+      expect(validateIncludes('pages', ['creator'])!.invalid).toEqual([]);
+      expect(validateIncludes('discussions', ['page'])!.invalid).toEqual([]);
+      expect(validateIncludes('attachments', ['task'])!.invalid).toEqual([]);
+    });
+
+    it('catches a typo on projects with a helpful suggestion', () => {
+      const result = validateIncludes('projects', ['copmany']);
+      expect(result!.invalid).toEqual(['copmany']);
+      expect(result!.suggestions.copmany).toContain('Valid includes for projects');
+      expect(result!.suggestions.copmany).toContain('company');
     });
   });
 

--- a/packages/mcp/src/handlers/valid-includes.ts
+++ b/packages/mcp/src/handlers/valid-includes.ts
@@ -1,8 +1,11 @@
 /**
  * Valid include values per resource.
  *
- * Sourced from help.ts and schema.ts include lists.
- * Resources not listed here have no include validation (pass-through).
+ * Sourced from help.ts/schema.ts include lists and each resource's documented
+ * Productive relationships. Resources not listed here have no include
+ * validation (pass-through). Lists are intentionally generous: an unknown
+ * include is hard-rejected before the request is sent, so omitting a genuinely
+ * valid relationship would block it — when in doubt, include the relationship.
  */
 
 export const VALID_INCLUDES: Record<string, string[]> = {
@@ -21,6 +24,13 @@ export const VALID_INCLUDES: Record<string, string[]> = {
   deals: ['company', 'deal_status', 'responsible', 'project'],
   bookings: ['person', 'service', 'event'],
   time: ['person', 'service', 'task'],
+  projects: ['company', 'memberships', 'project_manager', 'last_actor', 'workflow'],
+  people: ['company', 'subsidiary', 'manager', 'teams', 'holiday_schedule'],
+  companies: ['contacts', 'owner', 'subsidiaries', 'parent_company'],
+  services: ['deal', 'service_type', 'person', 'section'],
+  pages: ['project', 'creator', 'parent_page', 'root_page'],
+  discussions: ['page', 'creator'],
+  attachments: ['attachable', 'creator', 'task'],
 };
 
 export interface ValidateIncludesResult {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,9 +41,9 @@
     "@studiometa/productive-api": "*"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "^4.1.7",
-    "vite": "^8.0.14",
-    "vitest": "^4.1.7"
+    "@vitest/coverage-v8": "^4.1.8",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -5,7 +5,7 @@ export type { LoadConfigResult, ConfigSource } from './config.js';
 export { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from './pagination.js';
 export type { PageFetcher } from './pagination.js';
 export { QueryBuilder } from './query-builder.js';
-export type { BaseListOptions } from './query-builder.js';
+export type { BaseListOptions, IncludeOptions } from './query-builder.js';
 export { resolveResource, resolveListResponse, resolveSingleResponse } from './json-api.js';
 export type { ResolvedResource } from './json-api.js';
 export type {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,7 +2,7 @@ export { Productive } from './productive.js';
 export type { ProductiveOptions } from './productive.js';
 export { loadConfig, ConfigurationError } from './config.js';
 export type { LoadConfigResult, ConfigSource } from './config.js';
-export { AsyncPaginatedIterator } from './pagination.js';
+export { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from './pagination.js';
 export type { PageFetcher } from './pagination.js';
 export { QueryBuilder } from './query-builder.js';
 export type { BaseListOptions } from './query-builder.js';

--- a/packages/sdk/src/pagination.ts
+++ b/packages/sdk/src/pagination.ts
@@ -1,13 +1,12 @@
 import type { ProductiveApiMeta } from '@studiometa/productive-api';
 
+import { DEFAULT_PAGE_SIZE } from '@studiometa/productive-api';
+
 /**
- * Default page size used by collection list/iteration helpers.
- *
- * Single source of truth shared across all SDK collections so the
- * `all()` iterators do not diverge from one another (or from the core
- * executors, which default to the same value).
+ * Re-exported from `@studiometa/productive-api` (the single cross-package
+ * source of truth) so SDK consumers can keep importing it from here.
  */
-export const DEFAULT_PAGE_SIZE = 100;
+export { DEFAULT_PAGE_SIZE };
 
 /**
  * Function that fetches a page of results.

--- a/packages/sdk/src/pagination.ts
+++ b/packages/sdk/src/pagination.ts
@@ -1,6 +1,15 @@
 import type { ProductiveApiMeta } from '@studiometa/productive-api';
 
 /**
+ * Default page size used by collection list/iteration helpers.
+ *
+ * Single source of truth shared across all SDK collections so the
+ * `all()` iterators do not diverge from one another (or from the core
+ * executors, which default to the same value).
+ */
+export const DEFAULT_PAGE_SIZE = 100;
+
+/**
  * Function that fetches a page of results.
  */
 export type PageFetcher<T> = (page: number) => Promise<{ data: T[]; meta?: ProductiveApiMeta }>;
@@ -12,7 +21,7 @@ export class AsyncPaginatedIterator<T> {
   private fetchPage: PageFetcher<T>;
   private perPage: number;
 
-  constructor(fetchPage: PageFetcher<T>, perPage = 200) {
+  constructor(fetchPage: PageFetcher<T>, perPage = DEFAULT_PAGE_SIZE) {
     this.fetchPage = fetchPage;
     this.perPage = perPage;
   }

--- a/packages/sdk/src/query-builder.ts
+++ b/packages/sdk/src/query-builder.ts
@@ -1,11 +1,19 @@
 import type { AsyncPaginatedIterator } from './pagination.js';
 
-export interface BaseListOptions {
+/**
+ * Options shared by every single-resource `get()`: which related resources to
+ * sideload via the JSON:API `include` param. Also the `include` half of
+ * {@link BaseListOptions}.
+ */
+export interface IncludeOptions {
+  include?: string[];
+}
+
+export interface BaseListOptions extends IncludeOptions {
   page?: number;
   perPage?: number;
   filter?: Record<string, string>;
   sort?: string;
-  include?: string[];
 }
 
 interface CollectionAdapter<T, R> {

--- a/packages/sdk/src/resources/activities.ts
+++ b/packages/sdk/src/resources/activities.ts
@@ -4,16 +4,10 @@ import type { Activity } from '../types.js';
 
 import { resolveListResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface ActivityListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type ActivityListOptions = BaseListOptions;
 
 export interface ActivityListResult {
   data: Activity[];

--- a/packages/sdk/src/resources/activities.ts
+++ b/packages/sdk/src/resources/activities.ts
@@ -3,7 +3,7 @@ import type { ProductiveActivity, ProductiveApiMeta } from '@studiometa/producti
 import type { Activity } from '../types.js';
 
 import { resolveListResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -40,7 +40,7 @@ export class ActivitiesCollection extends BaseCollection {
    * Iterate over all activities across all pages.
    */
   all(options: Omit<ActivityListOptions, 'page'> = {}): AsyncPaginatedIterator<Activity> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Activity>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/activities.ts
+++ b/packages/sdk/src/resources/activities.ts
@@ -11,6 +11,7 @@ export interface ActivityListOptions {
   page?: number;
   perPage?: number;
   filter?: Record<string, string>;
+  sort?: string;
   include?: string[];
 }
 

--- a/packages/sdk/src/resources/attachments.test.ts
+++ b/packages/sdk/src/resources/attachments.test.ts
@@ -59,6 +59,19 @@ describe('AttachmentsCollection', () => {
         name: 'screenshot.png',
       });
     });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: [], meta: {} }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new AttachmentsCollection(createApi());
+      await col.list({ include: ['task'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=task'),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('get()', () => {
@@ -71,6 +84,19 @@ describe('AttachmentsCollection', () => {
       const col = new AttachmentsCollection(createApi());
       const result = await col.get('42');
       expect(result.data).toMatchObject({ id: '42', name: 'report.pdf' });
+    });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makeAttachment('42', 'report.pdf') }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new AttachmentsCollection(createApi());
+      await col.get('42', { include: ['task'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=task'),
+        expect.any(Object),
+      );
     });
 
     it('wraps 404 into ResourceNotFoundError', async () => {

--- a/packages/sdk/src/resources/attachments.ts
+++ b/packages/sdk/src/resources/attachments.ts
@@ -3,7 +3,7 @@ import type { ProductiveAttachment, ProductiveApiMeta } from '@studiometa/produc
 import type { Attachment } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -64,7 +64,7 @@ export class AttachmentsCollection extends BaseCollection {
    * Iterate over all attachments across all pages.
    */
   all(options: Omit<AttachmentListOptions, 'page'> = {}): AsyncPaginatedIterator<Attachment> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Attachment>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/attachments.ts
+++ b/packages/sdk/src/resources/attachments.ts
@@ -4,14 +4,12 @@ import type { Attachment } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type AttachmentListOptions = BaseListOptions;
 
-export interface AttachmentGetOptions {
-  include?: string[];
-}
+export type AttachmentGetOptions = IncludeOptions;
 
 export interface AttachmentListResult {
   data: Attachment[];

--- a/packages/sdk/src/resources/attachments.ts
+++ b/packages/sdk/src/resources/attachments.ts
@@ -11,6 +11,11 @@ export interface AttachmentListOptions {
   page?: number;
   perPage?: number;
   filter?: Record<string, string>;
+  include?: string[];
+}
+
+export interface AttachmentGetOptions {
+  include?: string[];
 }
 
 export interface AttachmentListResult {
@@ -25,7 +30,7 @@ export interface AttachmentGetResult {
 
 export class AttachmentsCollection extends BaseCollection {
   /**
-   * List attachments with optional filtering and pagination.
+   * List attachments with optional filtering, pagination, and includes.
    */
   async list(options: AttachmentListOptions = {}): Promise<AttachmentListResult> {
     const response = await this.wrapRequest(() => this.api.getAttachments(options));
@@ -33,10 +38,10 @@ export class AttachmentsCollection extends BaseCollection {
   }
 
   /**
-   * Get a single attachment by ID.
+   * Get a single attachment by ID, with optional includes.
    */
-  async get(id: string): Promise<AttachmentGetResult> {
-    const response = await this.wrapRequest(() => this.api.getAttachment(id));
+  async get(id: string, options: AttachmentGetOptions = {}): Promise<AttachmentGetResult> {
+    const response = await this.wrapRequest(() => this.api.getAttachment(id, options));
     return resolveSingleResponse<ProductiveAttachment, Attachment>(response);
   }
 

--- a/packages/sdk/src/resources/attachments.ts
+++ b/packages/sdk/src/resources/attachments.ts
@@ -4,16 +4,10 @@ import type { Attachment } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface AttachmentListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type AttachmentListOptions = BaseListOptions;
 
 export interface AttachmentGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/attachments.ts
+++ b/packages/sdk/src/resources/attachments.ts
@@ -11,6 +11,7 @@ export interface AttachmentListOptions {
   page?: number;
   perPage?: number;
   filter?: Record<string, string>;
+  sort?: string;
   include?: string[];
 }
 

--- a/packages/sdk/src/resources/base.ts
+++ b/packages/sdk/src/resources/base.ts
@@ -1,9 +1,6 @@
 import type { ProductiveApi } from '@studiometa/productive-api';
 
-import type { PageFetcher } from '../pagination.js';
-
 import { wrapError } from '../errors.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
 
 /**
  * Abstract base class for resource collections.
@@ -14,13 +11,6 @@ export abstract class BaseCollection {
 
   constructor(api: ProductiveApi) {
     this.api = api;
-  }
-
-  /**
-   * Create an async paginated iterator for this resource.
-   */
-  protected createIterator<T>(fetcher: PageFetcher<T>, perPage = 200): AsyncPaginatedIterator<T> {
-    return new AsyncPaginatedIterator<T>(fetcher, perPage);
   }
 
   /**

--- a/packages/sdk/src/resources/bookings.ts
+++ b/packages/sdk/src/resources/bookings.ts
@@ -4,16 +4,10 @@ import type { Booking } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface BookingListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type BookingListOptions = BaseListOptions;
 
 export interface BookingGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/bookings.ts
+++ b/packages/sdk/src/resources/bookings.ts
@@ -3,7 +3,7 @@ import type { ProductiveBooking, ProductiveApiMeta } from '@studiometa/productiv
 import type { Booking } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -97,7 +97,7 @@ export class BookingsCollection extends BaseCollection {
    * Iterate over all bookings across all pages.
    */
   all(options: Omit<BookingListOptions, 'page'> = {}): AsyncPaginatedIterator<Booking> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Booking>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/bookings.ts
+++ b/packages/sdk/src/resources/bookings.ts
@@ -4,14 +4,12 @@ import type { Booking } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type BookingListOptions = BaseListOptions;
 
-export interface BookingGetOptions {
-  include?: string[];
-}
+export type BookingGetOptions = IncludeOptions;
 
 export interface BookingCreateData {
   person_id: string;

--- a/packages/sdk/src/resources/comments.ts
+++ b/packages/sdk/src/resources/comments.ts
@@ -4,16 +4,10 @@ import type { Comment } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface CommentListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type CommentListOptions = BaseListOptions;
 
 export interface CommentGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/comments.ts
+++ b/packages/sdk/src/resources/comments.ts
@@ -4,14 +4,12 @@ import type { Comment } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type CommentListOptions = BaseListOptions;
 
-export interface CommentGetOptions {
-  include?: string[];
-}
+export type CommentGetOptions = IncludeOptions;
 
 export interface CommentCreateData {
   body: string;

--- a/packages/sdk/src/resources/comments.ts
+++ b/packages/sdk/src/resources/comments.ts
@@ -3,7 +3,7 @@ import type { ProductiveComment, ProductiveApiMeta } from '@studiometa/productiv
 import type { Comment } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -89,7 +89,7 @@ export class CommentsCollection extends BaseCollection {
    * Iterate over all comments across all pages.
    */
   all(options: Omit<CommentListOptions, 'page'> = {}): AsyncPaginatedIterator<Comment> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Comment>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/comments.ts
+++ b/packages/sdk/src/resources/comments.ts
@@ -11,6 +11,7 @@ export interface CommentListOptions {
   page?: number;
   perPage?: number;
   filter?: Record<string, string>;
+  sort?: string;
   include?: string[];
 }
 

--- a/packages/sdk/src/resources/companies.test.ts
+++ b/packages/sdk/src/resources/companies.test.ts
@@ -49,6 +49,19 @@ describe('CompaniesCollection', () => {
       expect(result.data).toHaveLength(2);
       expect(result.data[0]).toMatchObject({ id: '1', type: 'companies', name: 'Acme' });
     });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: [], meta: {} }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new CompaniesCollection(createApi());
+      await col.list({ include: ['contacts'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=contacts'),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('get()', () => {
@@ -61,6 +74,19 @@ describe('CompaniesCollection', () => {
       const col = new CompaniesCollection(createApi());
       const result = await col.get('42');
       expect(result.data).toMatchObject({ id: '42', name: 'Initech' });
+    });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makeCompany('42', 'Initech') }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new CompaniesCollection(createApi());
+      await col.get('42', { include: ['contacts'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=contacts'),
+        expect.any(Object),
+      );
     });
   });
 

--- a/packages/sdk/src/resources/companies.ts
+++ b/packages/sdk/src/resources/companies.ts
@@ -4,14 +4,12 @@ import type { Company } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type CompanyListOptions = BaseListOptions;
 
-export interface CompanyGetOptions {
-  include?: string[];
-}
+export type CompanyGetOptions = IncludeOptions;
 
 export interface CompanyCreateData {
   name: string;

--- a/packages/sdk/src/resources/companies.ts
+++ b/packages/sdk/src/resources/companies.ts
@@ -12,6 +12,11 @@ export interface CompanyListOptions {
   perPage?: number;
   filter?: Record<string, string>;
   sort?: string;
+  include?: string[];
+}
+
+export interface CompanyGetOptions {
+  include?: string[];
 }
 
 export interface CompanyCreateData {
@@ -46,7 +51,7 @@ export interface CompanyGetResult {
 
 export class CompaniesCollection extends BaseCollection {
   /**
-   * List companies with optional filtering and pagination.
+   * List companies with optional filtering, pagination, and includes.
    */
   async list(options: CompanyListOptions = {}): Promise<CompanyListResult> {
     const response = await this.wrapRequest(() => this.api.getCompanies(options));
@@ -54,10 +59,10 @@ export class CompaniesCollection extends BaseCollection {
   }
 
   /**
-   * Get a single company by ID.
+   * Get a single company by ID, with optional includes.
    */
-  async get(id: string): Promise<CompanyGetResult> {
-    const response = await this.wrapRequest(() => this.api.getCompany(id));
+  async get(id: string, options: CompanyGetOptions = {}): Promise<CompanyGetResult> {
+    const response = await this.wrapRequest(() => this.api.getCompany(id, options));
     return resolveSingleResponse<ProductiveCompany, Company>(response);
   }
 

--- a/packages/sdk/src/resources/companies.ts
+++ b/packages/sdk/src/resources/companies.ts
@@ -3,7 +3,7 @@ import type { ProductiveCompany, ProductiveApiMeta } from '@studiometa/productiv
 import type { Company } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -93,7 +93,7 @@ export class CompaniesCollection extends BaseCollection {
    * Iterate over all companies across all pages.
    */
   all(options: Omit<CompanyListOptions, 'page'> = {}): AsyncPaginatedIterator<Company> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Company>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/companies.ts
+++ b/packages/sdk/src/resources/companies.ts
@@ -4,16 +4,10 @@ import type { Company } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface CompanyListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type CompanyListOptions = BaseListOptions;
 
 export interface CompanyGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/custom-fields.ts
+++ b/packages/sdk/src/resources/custom-fields.ts
@@ -11,6 +11,7 @@ export interface CustomFieldListOptions {
   page?: number;
   perPage?: number;
   filter?: Record<string, string>;
+  sort?: string;
   include?: string[];
 }
 

--- a/packages/sdk/src/resources/custom-fields.ts
+++ b/packages/sdk/src/resources/custom-fields.ts
@@ -3,7 +3,7 @@ import type { ProductiveCustomField, ProductiveApiMeta } from '@studiometa/produ
 import type { CustomField } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -57,7 +57,7 @@ export class CustomFieldsCollection extends BaseCollection {
    * Iterate over all custom field definitions across all pages.
    */
   all(options: Omit<CustomFieldListOptions, 'page'> = {}): AsyncPaginatedIterator<CustomField> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<CustomField>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/custom-fields.ts
+++ b/packages/sdk/src/resources/custom-fields.ts
@@ -4,16 +4,10 @@ import type { CustomField } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface CustomFieldListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type CustomFieldListOptions = BaseListOptions;
 
 export interface CustomFieldListResult {
   data: CustomField[];

--- a/packages/sdk/src/resources/deals.ts
+++ b/packages/sdk/src/resources/deals.ts
@@ -23,6 +23,7 @@ export interface DealCreateData {
   name: string;
   company_id: string;
   date?: string;
+  end_date?: string;
   budget?: boolean;
   responsible_id?: string;
 }

--- a/packages/sdk/src/resources/deals.ts
+++ b/packages/sdk/src/resources/deals.ts
@@ -3,7 +3,7 @@ import type { ProductiveDeal, ProductiveApiMeta } from '@studiometa/productive-a
 import type { Deal } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -90,7 +90,7 @@ export class DealsCollection extends BaseCollection {
    * Iterate over all deals across all pages.
    */
   all(options: Omit<DealListOptions, 'page'> = {}): AsyncPaginatedIterator<Deal> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Deal>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/deals.ts
+++ b/packages/sdk/src/resources/deals.ts
@@ -4,16 +4,10 @@ import type { Deal } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface DealListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type DealListOptions = BaseListOptions;
 
 export interface DealGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/deals.ts
+++ b/packages/sdk/src/resources/deals.ts
@@ -4,14 +4,12 @@ import type { Deal } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type DealListOptions = BaseListOptions;
 
-export interface DealGetOptions {
-  include?: string[];
-}
+export type DealGetOptions = IncludeOptions;
 
 export interface DealCreateData {
   name: string;

--- a/packages/sdk/src/resources/discussions.test.ts
+++ b/packages/sdk/src/resources/discussions.test.ts
@@ -210,4 +210,34 @@ describe('DiscussionsCollection', () => {
       expect(result.data).toHaveLength(1);
     });
   });
+
+  describe('resolve() / reopen() (Finding 5)', () => {
+    it('resolve() patches the discussion and resolves it', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makeDiscussion('1', 'Done') }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new DiscussionsCollection(createApi());
+      const result = await col.resolve('1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/discussions/1'),
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+      expect(result.data).toMatchObject({ id: '1', type: 'discussions' });
+    });
+
+    it('reopen() patches the discussion', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makeDiscussion('1', 'Reopened') }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new DiscussionsCollection(createApi());
+      const result = await col.reopen('1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/discussions/1'),
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+      expect(result.data).toMatchObject({ id: '1' });
+    });
+  });
 });

--- a/packages/sdk/src/resources/discussions.test.ts
+++ b/packages/sdk/src/resources/discussions.test.ts
@@ -59,6 +59,19 @@ describe('DiscussionsCollection', () => {
         title: 'Feature request',
       });
     });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: [], meta: {} }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new DiscussionsCollection(createApi());
+      await col.list({ include: ['page'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=page'),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('get()', () => {
@@ -71,6 +84,19 @@ describe('DiscussionsCollection', () => {
       const col = new DiscussionsCollection(createApi());
       const result = await col.get('42');
       expect(result.data).toMatchObject({ id: '42', title: 'My Discussion' });
+    });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makeDiscussion('42', 'My Discussion') }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new DiscussionsCollection(createApi());
+      await col.get('42', { include: ['page'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=page'),
+        expect.any(Object),
+      );
     });
   });
 

--- a/packages/sdk/src/resources/discussions.ts
+++ b/packages/sdk/src/resources/discussions.ts
@@ -4,14 +4,12 @@ import type { Discussion } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type DiscussionListOptions = BaseListOptions;
 
-export interface DiscussionGetOptions {
-  include?: string[];
-}
+export type DiscussionGetOptions = IncludeOptions;
 
 export interface DiscussionCreateData {
   body: string;

--- a/packages/sdk/src/resources/discussions.ts
+++ b/packages/sdk/src/resources/discussions.ts
@@ -3,7 +3,7 @@ import type { ProductiveDiscussion, ProductiveApiMeta } from '@studiometa/produc
 import type { Discussion } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -107,7 +107,7 @@ export class DiscussionsCollection extends BaseCollection {
    * Iterate over all discussions across all pages.
    */
   all(options: Omit<DiscussionListOptions, 'page'> = {}): AsyncPaginatedIterator<Discussion> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Discussion>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/discussions.ts
+++ b/packages/sdk/src/resources/discussions.ts
@@ -12,6 +12,11 @@ export interface DiscussionListOptions {
   perPage?: number;
   filter?: Record<string, string>;
   sort?: string;
+  include?: string[];
+}
+
+export interface DiscussionGetOptions {
+  include?: string[];
 }
 
 export interface DiscussionCreateData {
@@ -37,7 +42,7 @@ export interface DiscussionGetResult {
 
 export class DiscussionsCollection extends BaseCollection {
   /**
-   * List discussions with optional filtering and pagination.
+   * List discussions with optional filtering, pagination, and includes.
    */
   async list(options: DiscussionListOptions = {}): Promise<DiscussionListResult> {
     const response = await this.wrapRequest(() => this.api.getDiscussions(options));
@@ -45,10 +50,10 @@ export class DiscussionsCollection extends BaseCollection {
   }
 
   /**
-   * Get a single discussion by ID.
+   * Get a single discussion by ID, with optional includes.
    */
-  async get(id: string): Promise<DiscussionGetResult> {
-    const response = await this.wrapRequest(() => this.api.getDiscussion(id));
+  async get(id: string, options: DiscussionGetOptions = {}): Promise<DiscussionGetResult> {
+    const response = await this.wrapRequest(() => this.api.getDiscussion(id, options));
     return resolveSingleResponse<ProductiveDiscussion, Discussion>(response);
   }
 

--- a/packages/sdk/src/resources/discussions.ts
+++ b/packages/sdk/src/resources/discussions.ts
@@ -4,16 +4,10 @@ import type { Discussion } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface DiscussionListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type DiscussionListOptions = BaseListOptions;
 
 export interface DiscussionGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/discussions.ts
+++ b/packages/sdk/src/resources/discussions.ts
@@ -81,6 +81,22 @@ export class DiscussionsCollection extends BaseCollection {
   }
 
   /**
+   * Mark a discussion as resolved.
+   */
+  async resolve(id: string): Promise<DiscussionGetResult> {
+    const response = await this.wrapRequest(() => this.api.resolveDiscussion(id));
+    return resolveSingleResponse<ProductiveDiscussion, Discussion>(response);
+  }
+
+  /**
+   * Reopen a previously resolved discussion.
+   */
+  async reopen(id: string): Promise<DiscussionGetResult> {
+    const response = await this.wrapRequest(() => this.api.reopenDiscussion(id));
+    return resolveSingleResponse<ProductiveDiscussion, Discussion>(response);
+  }
+
+  /**
    * Start a fluent query builder for discussions, optionally with initial filters.
    */
   where(filters: Record<string, string> = {}): QueryBuilder<Discussion, DiscussionListResult> {

--- a/packages/sdk/src/resources/pages.test.ts
+++ b/packages/sdk/src/resources/pages.test.ts
@@ -56,6 +56,19 @@ describe('PagesCollection', () => {
       expect(result.data).toHaveLength(2);
       expect(result.data[0]).toMatchObject({ id: '1', type: 'pages', title: 'Getting Started' });
     });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: [], meta: {} }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new PagesCollection(createApi());
+      await col.list({ include: ['creator'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=creator'),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('get()', () => {
@@ -68,6 +81,19 @@ describe('PagesCollection', () => {
       const col = new PagesCollection(createApi());
       const result = await col.get('42');
       expect(result.data).toMatchObject({ id: '42', title: 'My Page' });
+    });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makePage('42', 'My Page') }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new PagesCollection(createApi());
+      await col.get('42', { include: ['creator'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=creator'),
+        expect.any(Object),
+      );
     });
   });
 

--- a/packages/sdk/src/resources/pages.ts
+++ b/packages/sdk/src/resources/pages.ts
@@ -12,6 +12,11 @@ export interface PageListOptions {
   perPage?: number;
   filter?: Record<string, string>;
   sort?: string;
+  include?: string[];
+}
+
+export interface PageGetOptions {
+  include?: string[];
 }
 
 export interface PageCreateData {
@@ -38,7 +43,7 @@ export interface PageGetResult {
 
 export class PagesCollection extends BaseCollection {
   /**
-   * List pages with optional filtering and pagination.
+   * List pages with optional filtering, pagination, and includes.
    */
   async list(options: PageListOptions = {}): Promise<PageListResult> {
     const response = await this.wrapRequest(() => this.api.getPages(options));
@@ -46,10 +51,10 @@ export class PagesCollection extends BaseCollection {
   }
 
   /**
-   * Get a single page by ID.
+   * Get a single page by ID, with optional includes.
    */
-  async get(id: string): Promise<PageGetResult> {
-    const response = await this.wrapRequest(() => this.api.getPage(id));
+  async get(id: string, options: PageGetOptions = {}): Promise<PageGetResult> {
+    const response = await this.wrapRequest(() => this.api.getPage(id, options));
     return resolveSingleResponse<ProductivePage, Page>(response);
   }
 

--- a/packages/sdk/src/resources/pages.ts
+++ b/packages/sdk/src/resources/pages.ts
@@ -3,7 +3,7 @@ import type { ProductivePage, ProductiveApiMeta } from '@studiometa/productive-a
 import type { Page } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -92,7 +92,7 @@ export class PagesCollection extends BaseCollection {
    * Iterate over all pages across all pages.
    */
   all(options: Omit<PageListOptions, 'page'> = {}): AsyncPaginatedIterator<Page> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Page>(async (pageNum) => {
       return this.list({ ...options, page: pageNum, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/pages.ts
+++ b/packages/sdk/src/resources/pages.ts
@@ -4,14 +4,12 @@ import type { Page } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type PageListOptions = BaseListOptions;
 
-export interface PageGetOptions {
-  include?: string[];
-}
+export type PageGetOptions = IncludeOptions;
 
 export interface PageCreateData {
   title: string;

--- a/packages/sdk/src/resources/pages.ts
+++ b/packages/sdk/src/resources/pages.ts
@@ -4,16 +4,10 @@ import type { Page } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface PageListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type PageListOptions = BaseListOptions;
 
 export interface PageGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/people.test.ts
+++ b/packages/sdk/src/resources/people.test.ts
@@ -54,6 +54,19 @@ describe('PeopleCollection', () => {
       expect(result.data).toHaveLength(2);
       expect(result.data[0]).toMatchObject({ id: '1', type: 'people', name: 'Alice' });
     });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: [], meta: {} }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new PeopleCollection(createApi());
+      await col.list({ include: ['company'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=company'),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('get()', () => {
@@ -66,6 +79,19 @@ describe('PeopleCollection', () => {
       const col = new PeopleCollection(createApi());
       const result = await col.get('10');
       expect(result.data).toMatchObject({ id: '10', name: 'Charlie' });
+    });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makePerson('10', 'Charlie') }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new PeopleCollection(createApi());
+      await col.get('10', { include: ['company'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=company'),
+        expect.any(Object),
+      );
     });
   });
 

--- a/packages/sdk/src/resources/people.ts
+++ b/packages/sdk/src/resources/people.ts
@@ -16,6 +16,11 @@ export interface PeopleListOptions {
   perPage?: number;
   filter?: Record<string, string>;
   sort?: string;
+  include?: string[];
+}
+
+export interface PeopleGetOptions {
+  include?: string[];
 }
 
 export interface PeopleListResult {
@@ -37,7 +42,7 @@ export class PeopleCollection extends BaseCollection {
   }
 
   /**
-   * List people with optional filtering and pagination.
+   * List people with optional filtering, pagination, and includes.
    */
   async list(options: PeopleListOptions = {}): Promise<PeopleListResult> {
     const response = await this.wrapRequest(() => this.api.getPeople(options));
@@ -45,10 +50,10 @@ export class PeopleCollection extends BaseCollection {
   }
 
   /**
-   * Get a single person by ID.
+   * Get a single person by ID, with optional includes.
    */
-  async get(id: string): Promise<PeopleGetResult> {
-    const response = await this.wrapRequest(() => this.api.getPerson(id));
+  async get(id: string, options: PeopleGetOptions = {}): Promise<PeopleGetResult> {
+    const response = await this.wrapRequest(() => this.api.getPerson(id, options));
     return resolveSingleResponse<ProductivePerson, Person>(response);
   }
 

--- a/packages/sdk/src/resources/people.ts
+++ b/packages/sdk/src/resources/people.ts
@@ -8,16 +8,10 @@ import type { Person } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface PeopleListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type PeopleListOptions = BaseListOptions;
 
 export interface PeopleGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/people.ts
+++ b/packages/sdk/src/resources/people.ts
@@ -7,7 +7,7 @@ import type {
 import type { Person } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -79,7 +79,7 @@ export class PeopleCollection extends BaseCollection {
    * Iterate over all people across all pages.
    */
   all(options: Omit<PeopleListOptions, 'page'> = {}): AsyncPaginatedIterator<Person> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Person>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/people.ts
+++ b/packages/sdk/src/resources/people.ts
@@ -8,14 +8,12 @@ import type { Person } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type PeopleListOptions = BaseListOptions;
 
-export interface PeopleGetOptions {
-  include?: string[];
-}
+export type PeopleGetOptions = IncludeOptions;
 
 export interface PeopleListResult {
   data: Person[];

--- a/packages/sdk/src/resources/projects.test.ts
+++ b/packages/sdk/src/resources/projects.test.ts
@@ -65,6 +65,46 @@ describe('ProjectsCollection', () => {
         expect.any(Object),
       );
     });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: [], meta: {} }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new ProjectsCollection(createApi());
+      await col.list({ include: ['company'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=company'),
+        expect.any(Object),
+      );
+    });
+
+    it('resolves the company relationship from the included array (issue #174)', async () => {
+      vi.stubGlobal(
+        'fetch',
+        createMockFetch(() => ({
+          data: [
+            {
+              id: '1',
+              type: 'projects',
+              attributes: { name: 'Project Alpha' },
+              relationships: { company: { data: { id: '99', type: 'companies' } } },
+            },
+          ],
+          included: [{ id: '99', type: 'companies', attributes: { name: 'Acme Inc.' } }],
+          meta: { total: 1 },
+        })),
+      );
+
+      const col = new ProjectsCollection(createApi());
+      const result = await col.where({}).include('company').list();
+
+      expect(result.data[0].company).toMatchObject({
+        id: '99',
+        type: 'companies',
+        name: 'Acme Inc.',
+      });
+    });
   });
 
   describe('get()', () => {
@@ -81,6 +121,19 @@ describe('ProjectsCollection', () => {
       const result = await col.get('42');
 
       expect(result.data).toMatchObject({ id: '42', type: 'projects', name: 'Single Project' });
+    });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makeProject('42', 'P'), meta: {} }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new ProjectsCollection(createApi());
+      await col.get('42', { include: ['company'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=company'),
+        expect.any(Object),
+      );
     });
   });
 

--- a/packages/sdk/src/resources/projects.test.ts
+++ b/packages/sdk/src/resources/projects.test.ts
@@ -2,7 +2,7 @@ import { ProductiveApi } from '@studiometa/productive-api';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ResourceNotFoundError } from '../errors.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { createMockFetch } from '../test-utils.js';
 import { ProjectsCollection } from './projects.js';
@@ -142,6 +142,20 @@ describe('ProjectsCollection', () => {
       const col = new ProjectsCollection(createApi());
       const iter = col.all();
       expect(iter).toBeInstanceOf(AsyncPaginatedIterator);
+    });
+
+    it('defaults to the shared DEFAULT_PAGE_SIZE per request (Finding 8)', async () => {
+      expect(DEFAULT_PAGE_SIZE).toBe(100);
+      const mockFetch = createMockFetch(() => ({ data: [], meta: { total_pages: 1 } }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new ProjectsCollection(createApi());
+      await col.all().toArray();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`page%5Bsize%5D=${DEFAULT_PAGE_SIZE}`),
+        expect.any(Object),
+      );
     });
 
     it('iterates through all pages', async () => {

--- a/packages/sdk/src/resources/projects.ts
+++ b/packages/sdk/src/resources/projects.ts
@@ -4,14 +4,12 @@ import type { Project } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type ProjectListOptions = BaseListOptions;
 
-export interface ProjectGetOptions {
-  include?: string[];
-}
+export type ProjectGetOptions = IncludeOptions;
 
 export interface ProjectListResult {
   data: Project[];

--- a/packages/sdk/src/resources/projects.ts
+++ b/packages/sdk/src/resources/projects.ts
@@ -4,16 +4,10 @@ import type { Project } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface ProjectListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type ProjectListOptions = BaseListOptions;
 
 export interface ProjectGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/projects.ts
+++ b/packages/sdk/src/resources/projects.ts
@@ -3,7 +3,7 @@ import type { ProductiveProject, ProductiveApiMeta } from '@studiometa/productiv
 import type { Project } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -57,7 +57,7 @@ export class ProjectsCollection extends BaseCollection {
    * Iterate over all projects across all pages.
    */
   all(options: Omit<ProjectListOptions, 'page'> = {}): AsyncPaginatedIterator<Project> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Project>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/projects.ts
+++ b/packages/sdk/src/resources/projects.ts
@@ -12,6 +12,11 @@ export interface ProjectListOptions {
   perPage?: number;
   filter?: Record<string, string>;
   sort?: string;
+  include?: string[];
+}
+
+export interface ProjectGetOptions {
+  include?: string[];
 }
 
 export interface ProjectListResult {
@@ -26,7 +31,7 @@ export interface ProjectGetResult {
 
 export class ProjectsCollection extends BaseCollection {
   /**
-   * List projects with optional filtering and pagination.
+   * List projects with optional filtering, pagination, and includes.
    */
   async list(options: ProjectListOptions = {}): Promise<ProjectListResult> {
     const response = await this.wrapRequest(() => this.api.getProjects(options));
@@ -34,10 +39,10 @@ export class ProjectsCollection extends BaseCollection {
   }
 
   /**
-   * Get a single project by ID.
+   * Get a single project by ID, with optional includes.
    */
-  async get(id: string): Promise<ProjectGetResult> {
-    const response = await this.wrapRequest(() => this.api.getProject(id));
+  async get(id: string, options: ProjectGetOptions = {}): Promise<ProjectGetResult> {
+    const response = await this.wrapRequest(() => this.api.getProject(id, options));
     return resolveSingleResponse<ProductiveProject, Project>(response);
   }
 

--- a/packages/sdk/src/resources/services.test.ts
+++ b/packages/sdk/src/resources/services.test.ts
@@ -46,6 +46,19 @@ describe('ServicesCollection', () => {
       const result = await col.get('42');
       expect(result.data).toMatchObject({ id: '42', type: 'services', name: 'Design' });
     });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makeService('42', 'Design') }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new ServicesCollection(createApi());
+      await col.get('42', { include: ['deal'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=deal'),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('list()', () => {
@@ -68,6 +81,19 @@ describe('ServicesCollection', () => {
       const col = new ServicesCollection(createApi());
       const result = await col.list({ page: 1, perPage: 10, filter: { project_id: '5' } });
       expect(result.data).toHaveLength(0);
+    });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: [], meta: {} }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new ServicesCollection(createApi());
+      await col.list({ include: ['deal'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=deal'),
+        expect.any(Object),
+      );
     });
   });
 

--- a/packages/sdk/src/resources/services.test.ts
+++ b/packages/sdk/src/resources/services.test.ts
@@ -147,5 +147,18 @@ describe('ServicesCollection', () => {
       const result = await col.where({ project_id: '5' }).list();
       expect(result.data).toHaveLength(1);
     });
+
+    it('forwards orderBy as the sort param (Finding 4)', async () => {
+      const mockFetch = createMockFetch(() => ({ data: [], meta: {} }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new ServicesCollection(createApi());
+      await col.where({}).orderBy('-created_at').list();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('sort=-created_at'),
+        expect.any(Object),
+      );
+    });
   });
 });

--- a/packages/sdk/src/resources/services.ts
+++ b/packages/sdk/src/resources/services.ts
@@ -11,6 +11,7 @@ export interface ServiceListOptions {
   page?: number;
   perPage?: number;
   filter?: Record<string, string>;
+  sort?: string;
   include?: string[];
 }
 

--- a/packages/sdk/src/resources/services.ts
+++ b/packages/sdk/src/resources/services.ts
@@ -3,7 +3,7 @@ import type { ProductiveService, ProductiveApiMeta } from '@studiometa/productiv
 import type { Service } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -57,7 +57,7 @@ export class ServicesCollection extends BaseCollection {
    * Iterate over all services across all pages.
    */
   all(options: Omit<ServiceListOptions, 'page'> = {}): AsyncPaginatedIterator<Service> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Service>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/services.ts
+++ b/packages/sdk/src/resources/services.ts
@@ -4,16 +4,10 @@ import type { Service } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface ServiceListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type ServiceListOptions = BaseListOptions;
 
 export interface ServiceGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/services.ts
+++ b/packages/sdk/src/resources/services.ts
@@ -4,14 +4,12 @@ import type { Service } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type ServiceListOptions = BaseListOptions;
 
-export interface ServiceGetOptions {
-  include?: string[];
-}
+export type ServiceGetOptions = IncludeOptions;
 
 export interface ServiceListResult {
   data: Service[];

--- a/packages/sdk/src/resources/services.ts
+++ b/packages/sdk/src/resources/services.ts
@@ -11,6 +11,11 @@ export interface ServiceListOptions {
   page?: number;
   perPage?: number;
   filter?: Record<string, string>;
+  include?: string[];
+}
+
+export interface ServiceGetOptions {
+  include?: string[];
 }
 
 export interface ServiceListResult {
@@ -25,15 +30,15 @@ export interface ServiceGetResult {
 
 export class ServicesCollection extends BaseCollection {
   /**
-   * Get a single service by ID.
+   * Get a single service by ID, with optional includes.
    */
-  async get(id: string): Promise<ServiceGetResult> {
-    const response = await this.wrapRequest(() => this.api.getService(id));
+  async get(id: string, options: ServiceGetOptions = {}): Promise<ServiceGetResult> {
+    const response = await this.wrapRequest(() => this.api.getService(id, options));
     return resolveSingleResponse<ProductiveService, Service>(response);
   }
 
   /**
-   * List services with optional filtering and pagination.
+   * List services with optional filtering, pagination, and includes.
    */
   async list(options: ServiceListOptions = {}): Promise<ServiceListResult> {
     const response = await this.wrapRequest(() => this.api.getServices(options));

--- a/packages/sdk/src/resources/tasks.ts
+++ b/packages/sdk/src/resources/tasks.ts
@@ -4,16 +4,10 @@ import type { Task } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface TaskListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type TaskListOptions = BaseListOptions;
 
 export interface TaskGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/tasks.ts
+++ b/packages/sdk/src/resources/tasks.ts
@@ -4,14 +4,12 @@ import type { Task } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type TaskListOptions = BaseListOptions;
 
-export interface TaskGetOptions {
-  include?: string[];
-}
+export type TaskGetOptions = IncludeOptions;
 
 export interface TaskCreateData {
   title: string;

--- a/packages/sdk/src/resources/tasks.ts
+++ b/packages/sdk/src/resources/tasks.ts
@@ -3,7 +3,7 @@ import type { ProductiveTask, ProductiveApiMeta } from '@studiometa/productive-a
 import type { Task } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -97,7 +97,7 @@ export class TasksCollection extends BaseCollection {
    * Iterate over all tasks across all pages.
    */
   all(options: Omit<TaskListOptions, 'page'> = {}): AsyncPaginatedIterator<Task> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Task>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/time.test.ts
+++ b/packages/sdk/src/resources/time.test.ts
@@ -62,6 +62,19 @@ describe('TimeCollection', () => {
       const result = await col.get('5');
       expect(result.data).toMatchObject({ id: '5', time: 90 });
     });
+
+    it('forwards the include param to the request', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makeEntry('5', 90) }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new TimeCollection(createApi());
+      await col.get('5', { include: ['service'] });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('include=service'),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('create()', () => {

--- a/packages/sdk/src/resources/time.ts
+++ b/packages/sdk/src/resources/time.ts
@@ -3,7 +3,7 @@ import type { ProductiveTimeEntry, ProductiveApiMeta } from '@studiometa/product
 import type { TimeEntry } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -95,7 +95,7 @@ export class TimeCollection extends BaseCollection {
    * Iterate over all time entries across all pages.
    */
   all(options: Omit<TimeListOptions, 'page'> = {}): AsyncPaginatedIterator<TimeEntry> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<TimeEntry>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/time.ts
+++ b/packages/sdk/src/resources/time.ts
@@ -4,14 +4,12 @@ import type { TimeEntry } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type TimeListOptions = BaseListOptions;
 
-export interface TimeGetOptions {
-  include?: string[];
-}
+export type TimeGetOptions = IncludeOptions;
 
 export interface TimeCreateData {
   person_id: string;

--- a/packages/sdk/src/resources/time.ts
+++ b/packages/sdk/src/resources/time.ts
@@ -4,16 +4,10 @@ import type { TimeEntry } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface TimeListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type TimeListOptions = BaseListOptions;
 
 export interface TimeGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/time.ts
+++ b/packages/sdk/src/resources/time.ts
@@ -15,6 +15,10 @@ export interface TimeListOptions {
   include?: string[];
 }
 
+export interface TimeGetOptions {
+  include?: string[];
+}
+
 export interface TimeCreateData {
   person_id: string;
   service_id: string;
@@ -50,10 +54,10 @@ export class TimeCollection extends BaseCollection {
   }
 
   /**
-   * Get a single time entry by ID.
+   * Get a single time entry by ID, with optional includes.
    */
-  async get(id: string): Promise<TimeGetResult> {
-    const response = await this.wrapRequest(() => this.api.getTimeEntry(id));
+  async get(id: string, options: TimeGetOptions = {}): Promise<TimeGetResult> {
+    const response = await this.wrapRequest(() => this.api.getTimeEntry(id, options));
     return resolveSingleResponse<ProductiveTimeEntry, TimeEntry>(response);
   }
 

--- a/packages/sdk/src/resources/timers.test.ts
+++ b/packages/sdk/src/resources/timers.test.ts
@@ -135,4 +135,34 @@ describe('TimersCollection', () => {
       expect(result.data).toHaveLength(1);
     });
   });
+
+  describe('start() / stop() (Finding 5)', () => {
+    it('start() posts to /timers and resolves the timer', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makeTimer('1', 0) }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new TimersCollection(createApi());
+      const result = await col.start({ service_id: '5' });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/timers'),
+        expect.objectContaining({ method: 'POST' }),
+      );
+      expect(result.data).toMatchObject({ id: '1', type: 'timers' });
+    });
+
+    it('stop() patches /timers/:id/stop', async () => {
+      const mockFetch = createMockFetch(() => ({ data: makeTimer('1', 3600) }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      const col = new TimersCollection(createApi());
+      const result = await col.stop('1');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('/timers/1/stop'),
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+      expect(result.data).toMatchObject({ id: '1' });
+    });
+  });
 });

--- a/packages/sdk/src/resources/timers.ts
+++ b/packages/sdk/src/resources/timers.ts
@@ -4,16 +4,10 @@ import type { Timer } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
-export interface TimerListOptions {
-  page?: number;
-  perPage?: number;
-  filter?: Record<string, string>;
-  sort?: string;
-  include?: string[];
-}
+export type TimerListOptions = BaseListOptions;
 
 export interface TimerGetOptions {
   include?: string[];

--- a/packages/sdk/src/resources/timers.ts
+++ b/packages/sdk/src/resources/timers.ts
@@ -3,7 +3,7 @@ import type { ProductiveTimer, ProductiveApiMeta } from '@studiometa/productive-
 import type { Timer } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
-import { AsyncPaginatedIterator } from '../pagination.js';
+import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
 import { QueryBuilder } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
@@ -78,7 +78,7 @@ export class TimersCollection extends BaseCollection {
    * Iterate over all timers across all pages.
    */
   all(options: Omit<TimerListOptions, 'page'> = {}): AsyncPaginatedIterator<Timer> {
-    const perPage = options.perPage ?? 200;
+    const perPage = options.perPage ?? DEFAULT_PAGE_SIZE;
     return new AsyncPaginatedIterator<Timer>(async (page) => {
       return this.list({ ...options, page, perPage });
     }, perPage);

--- a/packages/sdk/src/resources/timers.ts
+++ b/packages/sdk/src/resources/timers.ts
@@ -19,6 +19,11 @@ export interface TimerGetOptions {
   include?: string[];
 }
 
+export interface TimerStartData {
+  service_id?: string;
+  time_entry_id?: string;
+}
+
 export interface TimerListResult {
   data: Timer[];
   meta: ProductiveApiMeta | undefined;
@@ -43,6 +48,22 @@ export class TimersCollection extends BaseCollection {
    */
   async get(id: string, options: TimerGetOptions = {}): Promise<TimerGetResult> {
     const response = await this.wrapRequest(() => this.api.getTimer(id, options));
+    return resolveSingleResponse<ProductiveTimer, Timer>(response);
+  }
+
+  /**
+   * Start a new timer, optionally bound to a service or time entry.
+   */
+  async start(data: TimerStartData = {}): Promise<TimerGetResult> {
+    const response = await this.wrapRequest(() => this.api.startTimer(data));
+    return resolveSingleResponse<ProductiveTimer, Timer>(response);
+  }
+
+  /**
+   * Stop a running timer by ID.
+   */
+  async stop(id: string): Promise<TimerGetResult> {
+    const response = await this.wrapRequest(() => this.api.stopTimer(id));
     return resolveSingleResponse<ProductiveTimer, Timer>(response);
   }
 

--- a/packages/sdk/src/resources/timers.ts
+++ b/packages/sdk/src/resources/timers.ts
@@ -4,14 +4,12 @@ import type { Timer } from '../types.js';
 
 import { resolveListResponse, resolveSingleResponse } from '../json-api.js';
 import { AsyncPaginatedIterator, DEFAULT_PAGE_SIZE } from '../pagination.js';
-import { QueryBuilder, type BaseListOptions } from '../query-builder.js';
+import { QueryBuilder, type BaseListOptions, type IncludeOptions } from '../query-builder.js';
 import { BaseCollection } from './base.js';
 
 export type TimerListOptions = BaseListOptions;
 
-export interface TimerGetOptions {
-  include?: string[];
-}
+export type TimerGetOptions = IncludeOptions;
 
 export interface TimerStartData {
   service_id?: string;


### PR DESCRIPTION
## Summary

Started as a fix for #174 (`getProjects`/`getProject` dropping `include`), then an adversarial cross-package audit surfaced the same class of gap elsewhere. Each finding below ships as its own commit with a reproduction test that fails first, then passes. Finally, a structural refactor removes the duplication that caused the whole class of bug.

## Original fix (#174)

- **API**: forward `include` in `getProjects`/`getProject` and every other list/get method that dropped it.
- **SDK**: expose + forward `include` on projects, people, services, companies, attachments, pages, discussions (list/get) and `time.get()`.

## Audit findings fixed

| # | Layer | Gap | Commit |
| - | ----- | --- | ------ |
| 1 | Core | `include` dropped (declared via `PaginationOptions`, never forwarded) on projects/people/services/companies/attachments/time list+get; `included` not returned. `services`/`time` were even validated as include-capable by MCP, then ignored. | `9433686` |
| 2 | Core | comments/bookings/timers list forwarded `include` but discarded `response.included` — sideload fetched then thrown away. | `9ff9682` |
| 3 | Core | pages/discussions returned `included` but never forwarded `include` — always-empty, dead relationship resolution. | `dbc5a0e` |
| 4 + 6 | API/SDK | `getServices`/`getComments`/`getAttachments`/`getActivities`/`getCustomFields`/`getCustomFieldOptions` accepted no `sort`; `QueryBuilder.orderBy()` was silently dropped on those collections. | `36aa8a8` |
| 5 | SDK | `timers.start()`/`stop()` and `discussions.resolve()`/`reopen()` existed in API+core+MCP+CLI but were missing from the SDK. | `09844e9` |
| 7 | API/Core/SDK/CLI | `end_date` was settable on `updateDeal` but silently unavailable on create. | `d50575a` |
| 8 | SDK/Core | `all()` iterators defaulted to 200, core list to 100 (some 25). Consolidated to a shared `DEFAULT_PAGE_SIZE` (100). | `93204e2` |

## Structural refactor (prevents recurrence)

The root cause of findings 1–6 was each layer re-listing and re-forwarding each query param by hand, so any method could silently omit one. These commits make the common params forward **by construction**:

- **API** `ebe09eb`: every list/get method routes through a single exported `buildListQuery(ListParams)` helper (net −161 lines).
- **Core** `513ea65`: a `buildListParams()` helper is spread into every list executor; `DEFAULT_PAGE_SIZE` promoted to `@studiometa/productive-api` as the single cross-package default. Also closes the residual `sort` drop on 5 executors.
- **SDK** `eddfaa5`: every `*ListOptions` aliases the shared `BaseListOptions`, so the fluent builder and option types can't drift apart.

### Scoping notes (adversarial)

- **Finding 7**: only `end_date` is fixed. The other never-settable attributes flagged in the audit (`tag_list`, `profit_margin`, `buyer_reference`, page `cover_image_url`/`icon_id`) are intentionally left out — their writability via the Productive API is unverified and adding speculative setters risks invalid payloads.
- **Finding 8**: the user-facing single-page default (100) is unchanged; only SDK bulk iteration drops from 200→100 (override with `perPage`).
- A separate audit observation — the MCP factory never passes `sort` to list executors — was left as-is (out of scope; no finding depended on it).

## Testing

- 33 new reproduction tests (red → green per finding) + a `buildListQuery` unit test.
- `npm run build`, `typecheck`, `lint` (0 errors), `format` (clean) all pass.
- Unit: **3652 passed**. Integration: **42 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
