### PR TITLE
Fix `productive run` arg forwarding with a `--` separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI**: Add `--include` to the projects, people, companies, services, pages, discussions and attachments list/get commands (via a shared `ctx.getInclude()`) and surface the resolved relationships in the output ([94802f7], [#175])
 - **CLI**: Document `--end-date` in the `deals add` command help — it was wired into the handler but undiscoverable ([f607546], [#175])
 - **Core**: Normalize a non-positive `page`/`perPage` (e.g. from `--size 0`) to the defaults in `buildListParams`, which previously forwarded an out-of-range 0 that `buildListQuery` then silently dropped ([2a9dde4], [#175])
-- **CLI**: Forward named flags and positionals through `productive run` — the global arg parser stripped every `--flag` and misclassified slash-less tokens, so a script's `flags` was always `{}` and a positional after a slash-path crashed with `ERR_MODULE_NOT_FOUND`; `run` now recovers the invocation from raw argv and forwards everything after the script path verbatim ([f8bfe73], [#178])
+- **CLI**: Forward script args through `productive run` via a `--` separator — the global arg parser previously stripped every `--flag` and misclassified slash-less tokens, so a script's `flags` was always `{}` and a positional after a slash-path crashed with `ERR_MODULE_NOT_FOUND`. Everything after `--` is now forwarded to the script verbatim while run-options stay before it, and `parseArgs` honors `--` as end-of-options so `--version`/`--help` after it reach the script instead of the CLI ([740a04c], [#178])
 
 ### Security
 
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1082df4]: https://github.com/studiometa/productive-tools/commit/1082df4
 [2a9dde4]: https://github.com/studiometa/productive-tools/commit/2a9dde4
 [7a0dedc]: https://github.com/studiometa/productive-tools/commit/7a0dedc
-[f8bfe73]: https://github.com/studiometa/productive-tools/commit/f8bfe73
+[740a04c]: https://github.com/studiometa/productive-tools/commit/740a04c
 [#175]: https://github.com/studiometa/productive-tools/pull/175
 [#178]: https://github.com/studiometa/productive-tools/pull/178
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLI**: Add `--include` to the projects, people, companies, services, pages, discussions and attachments list/get commands (via a shared `ctx.getInclude()`) and surface the resolved relationships in the output ([94802f7], [#175])
 - **CLI**: Document `--end-date` in the `deals add` command help — it was wired into the handler but undiscoverable ([f607546], [#175])
 - **Core**: Normalize a non-positive `page`/`perPage` (e.g. from `--size 0`) to the defaults in `buildListParams`, which previously forwarded an out-of-range 0 that `buildListQuery` then silently dropped ([2a9dde4], [#175])
+- **CLI**: Forward named flags and positionals through `productive run` — the global arg parser stripped every `--flag` and misclassified slash-less tokens, so a script's `flags` was always `{}` and a positional after a slash-path crashed with `ERR_MODULE_NOT_FOUND`; `run` now recovers the invocation from raw argv and forwards everything after the script path verbatim ([f8bfe73], [#178])
 
 ### Security
 
@@ -62,7 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1082df4]: https://github.com/studiometa/productive-tools/commit/1082df4
 [2a9dde4]: https://github.com/studiometa/productive-tools/commit/2a9dde4
 [7a0dedc]: https://github.com/studiometa/productive-tools/commit/7a0dedc
+[f8bfe73]: https://github.com/studiometa/productive-tools/commit/f8bfe73
 [#175]: https://github.com/studiometa/productive-tools/pull/175
+[#178]: https://github.com/studiometa/productive-tools/pull/178
 
 ## [0.10.12] - 2026.05.27
 

--- a/packages/cli/examples/README.md
+++ b/packages/cli/examples/README.md
@@ -9,11 +9,11 @@ Ready-to-run script examples for `productive run`. Copy any file to your own
 # From the repo root (using the built CLI)
 productive run packages/cli/examples/my-tasks.ts
 
-# Pass flags
-productive run packages/cli/examples/time-report.ts --from 2025-01-01 --to 2025-01-31
+# Pass flags to the script after `--`
+productive run packages/cli/examples/time-report.ts -- --from 2025-01-01 --to 2025-01-31
 
-# Preview mutations without executing them
-productive run --dry-run packages/cli/examples/log-time.ts --service-id 12345 --hours 2
+# Preview mutations without executing them (run-options go before `--`)
+productive run --dry-run packages/cli/examples/log-time.ts -- --service-id 12345 --hours 2
 ```
 
 ## Examples
@@ -39,8 +39,8 @@ export const meta = defineMeta({
 export default createScript(async ({ client, output, flags }) => {
   // client   → pre-configured Productive SDK client
   // output   → output.table(), .csv(), .json(), .spinner(), .info(), …
-  // flags    → parsed flags: --from 2025-01-01 → flags.from === '2025-01-01'
-  // args     → positional args after the script path
+  // flags    → parsed flags after `--`: -- --from 2025-01-01 → flags.from === '2025-01-01'
+  // args     → positional args after `--`
 });
 ```
 

--- a/packages/cli/skills/SKILL.md
+++ b/packages/cli/skills/SKILL.md
@@ -322,6 +322,8 @@ productive reports budget --project <id>
 
 `productive run` executes a JavaScript or TypeScript script with a pre-configured Productive SDK client. Credentials are loaded from the usual sources (keychain, config file, env vars, CLI flags).
 
+Run-options (credentials, `--dry-run`, `--list`) go **before** the script path; everything **after** the script path is forwarded to the script verbatim and parsed into `args` (positionals) and `flags` (named).
+
 ```bash
 # Run a TypeScript script
 productive run ./scripts/weekly-report.ts
@@ -331,6 +333,9 @@ productive script ./scripts/export-time.ts
 
 # Pass arguments to the script (available as flags.from, flags.to, flags.mine)
 productive run ./scripts/audit.ts --from 2025-01-01 --to 2025-01-31 --mine
+
+# Override credentials for this run (run-options go before the script path)
+productive run --token $TOKEN --org-id $ORG_ID ./scripts/audit.ts
 
 # Dry-run: record mutating calls without executing them
 productive run --dry-run ./scripts/bulk-update.ts

--- a/packages/cli/skills/SKILL.md
+++ b/packages/cli/skills/SKILL.md
@@ -322,7 +322,7 @@ productive reports budget --project <id>
 
 `productive run` executes a JavaScript or TypeScript script with a pre-configured Productive SDK client. Credentials are loaded from the usual sources (keychain, config file, env vars, CLI flags).
 
-Run-options (credentials, `--dry-run`, `--list`) go **before** the script path; everything **after** the script path is forwarded to the script verbatim and parsed into `args` (positionals) and `flags` (named).
+Use a `--` separator to split run-options from script args. Everything **before** `--` configures `run` (script path, credentials, `--dry-run`, `--list`); everything **after** `--` is forwarded to the script verbatim and parsed into `args` (positionals) and `flags` (named). Without a `--`, all flags are treated as run-options.
 
 ```bash
 # Run a TypeScript script
@@ -331,11 +331,11 @@ productive run ./scripts/weekly-report.ts
 # Alias: productive script
 productive script ./scripts/export-time.ts
 
-# Pass arguments to the script (available as flags.from, flags.to, flags.mine)
-productive run ./scripts/audit.ts --from 2025-01-01 --to 2025-01-31 --mine
+# Pass arguments to the script after -- (available as flags.from, flags.to, flags.mine)
+productive run ./scripts/audit.ts -- --from 2025-01-01 --to 2025-01-31 --mine
 
-# Override credentials for this run (run-options go before the script path)
-productive run --token $TOKEN --org-id $ORG_ID ./scripts/audit.ts
+# Override credentials for this run (run-options go before --)
+productive run ./scripts/audit.ts --token $TOKEN --org-id $ORG_ID -- --verbose
 
 # Dry-run: record mutating calls without executing them
 productive run --dry-run ./scripts/bulk-update.ts

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,7 +18,7 @@ import { handlePeopleCommand, showPeopleHelp } from './commands/people/index.js'
 import { handleProjectsCommand, showProjectsHelp } from './commands/projects/index.js';
 import { handleReportsCommand, showReportsHelp } from './commands/reports/index.js';
 import { handleResolveCommand, showResolveHelp } from './commands/resolve/index.js';
-import { handleRunCommand, showRunHelp } from './commands/run/index.js';
+import { extractRunArgs, handleRunCommand, showRunHelp } from './commands/run/index.js';
 import { handleServicesCommand, showServicesHelp } from './commands/services/index.js';
 import { handleTasksCommand, showTasksHelp } from './commands/tasks/index.js';
 import { handleTimeCommand, showTimeHelp } from './commands/time/index.js';
@@ -421,13 +421,20 @@ async function main(): Promise<void> {
         break;
 
       case 'run':
-      case 'script':
-        if (wantsHelp) {
+      case 'script': {
+        // `run` forwards everything after the script path verbatim, so recover
+        // the script invocation from raw argv rather than the globally-parsed
+        // positional/options (which strip the script's own flags). Only flags
+        // BEFORE the script path configure `run` itself.
+        const { cliArgs, scriptArgs } = extractRunArgs(process.argv.slice(2));
+        const runOptions = parseArgs(cliArgs).options;
+        if (runOptions.help || runOptions.h) {
           showRunHelp();
           process.exit(0);
         }
-        await handleRunCommand(subcommand, positional, options);
+        await handleRunCommand(scriptArgs, runOptions);
         break;
+      }
 
       case 'api':
         if (wantsHelp) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -422,17 +422,16 @@ async function main(): Promise<void> {
 
       case 'run':
       case 'script': {
-        // `run` forwards everything after the script path verbatim, so recover
-        // the script invocation from raw argv rather than the globally-parsed
-        // positional/options (which strip the script's own flags). Only flags
-        // BEFORE the script path configure `run` itself.
-        const { cliArgs, scriptArgs } = extractRunArgs(process.argv.slice(2));
+        // `run` forwards everything after the `--` separator to the script
+        // verbatim; flags before it configure `run` itself. Recover the split
+        // from raw argv and parse only the run-options portion.
+        const { cliArgs, scriptPath, scriptArgs } = extractRunArgs(process.argv.slice(2));
         const runOptions = parseArgs(cliArgs).options;
         if (runOptions.help || runOptions.h) {
           showRunHelp();
           process.exit(0);
         }
-        await handleRunCommand(scriptArgs, runOptions);
+        await handleRunCommand(scriptPath, scriptArgs, runOptions);
         break;
       }
 

--- a/packages/cli/src/commands/run/command.test.ts
+++ b/packages/cli/src/commands/run/command.test.ts
@@ -42,69 +42,92 @@ vi.mock('../../utils/cache.js', () => {
 
 // ── extractRunArgs ──────────────────────────────────────────────────────────
 //
-// The global CLI arg parser strips every `--flag` and misclassifies tokens that
-// follow a slash-path, so the `run` command MUST recover the script invocation
-// straight from raw argv. extractRunArgs splits the raw argv into the CLI-level
-// flags (before the script path) and the script args (the script path plus
-// everything after it, forwarded verbatim).
+// The `--` separator divides run-options (left) from script args (right). The
+// script path is the first JS/TS file token before `--`. Everything after `--`
+// is forwarded to the script verbatim — the global parser never sees it.
 
 describe('extractRunArgs', () => {
-  it('forwards named flags after the script path verbatim (the core bug)', async () => {
+  it('forwards named flags placed after the -- separator', async () => {
     const { extractRunArgs } = await import('./command.js');
 
     expect(
-      extractRunArgs(['run', './report.mjs', '--from', '2025-01-01', '--to', '2025-01-31']),
+      extractRunArgs(['run', './report.mjs', '--', '--from', '2025-01-01', '--to', '2025-01-31']),
     ).toEqual({
-      cliArgs: [],
-      scriptArgs: ['./report.mjs', '--from', '2025-01-01', '--to', '2025-01-31'],
+      cliArgs: ['./report.mjs'],
+      scriptPath: './report.mjs',
+      scriptArgs: ['--from', '2025-01-01', '--to', '2025-01-31'],
     });
   });
 
-  it('forwards positional args after a slash-path without misclassifying them', async () => {
+  it('forwards positional args placed after the -- separator', async () => {
     const { extractRunArgs } = await import('./command.js');
 
-    // Previously the global parser routed `2025-01-01` into `command`, so the
-    // script path became `2025-01-01` → ERR_MODULE_NOT_FOUND.
-    expect(extractRunArgs(['run', './report.mjs', '2025-01-01', '2025-01-31'])).toEqual({
-      cliArgs: [],
-      scriptArgs: ['./report.mjs', '2025-01-01', '2025-01-31'],
+    expect(extractRunArgs(['run', './report.mjs', '--', '2025-01-01', '2025-01-31'])).toEqual({
+      cliArgs: ['./report.mjs'],
+      scriptPath: './report.mjs',
+      scriptArgs: ['2025-01-01', '2025-01-31'],
     });
+  });
+
+  it('keeps run-options that follow the script path on the left of --', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(
+      extractRunArgs(['run', './report.mjs', '--token', 'abc', '--org-id', '42', '--', '--mine']),
+    ).toEqual({
+      cliArgs: ['./report.mjs', '--token', 'abc', '--org-id', '42'],
+      scriptPath: './report.mjs',
+      scriptArgs: ['--mine'],
+    });
+  });
+
+  it('detects the script path even when run-options precede it', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', '--dry-run', './report.mjs', '--', '--from', 'x'])).toEqual({
+      cliArgs: ['--dry-run', './report.mjs'],
+      scriptPath: './report.mjs',
+      scriptArgs: ['--from', 'x'],
+    });
+  });
+
+  it('treats flags as run-options (not forwarded) when there is no -- separator', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', './report.mjs', '--from', 'x'])).toEqual({
+      cliArgs: ['./report.mjs', '--from', 'x'],
+      scriptPath: './report.mjs',
+      scriptArgs: [],
+    });
+  });
+
+  it('only splits on the first --, preserving any further -- in script args', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', './report.mjs', '--', '--from', '--', 'x']).scriptArgs).toEqual([
+      '--from',
+      '--',
+      'x',
+    ]);
   });
 
   it('detects a slash-less script path', async () => {
     const { extractRunArgs } = await import('./command.js');
 
-    expect(extractRunArgs(['run', 'report.mjs', '--mine'])).toEqual({
-      cliArgs: [],
-      scriptArgs: ['report.mjs', '--mine'],
+    expect(extractRunArgs(['run', 'report.mjs', '--', '--mine'])).toEqual({
+      cliArgs: ['report.mjs'],
+      scriptPath: 'report.mjs',
+      scriptArgs: ['--mine'],
     });
   });
 
   it('detects an absolute script path', async () => {
     const { extractRunArgs } = await import('./command.js');
 
-    expect(extractRunArgs(['run', '/abs/path/report.ts', '--from', 'x'])).toEqual({
-      cliArgs: [],
-      scriptArgs: ['/abs/path/report.ts', '--from', 'x'],
-    });
-  });
-
-  it('keeps a boolean CLI flag before the script in cliArgs', async () => {
-    const { extractRunArgs } = await import('./command.js');
-
-    expect(extractRunArgs(['run', '--dry-run', './report.mjs', '--from', 'x'])).toEqual({
-      cliArgs: ['--dry-run'],
-      scriptArgs: ['./report.mjs', '--from', 'x'],
-    });
-  });
-
-  it('keeps value-taking CLI flags before the script in cliArgs', async () => {
-    const { extractRunArgs } = await import('./command.js');
-
-    // The flag value `abc` must NOT be mistaken for the script path.
-    expect(extractRunArgs(['run', '--token', 'abc', './report.mjs', '--from', 'x'])).toEqual({
-      cliArgs: ['--token', 'abc'],
-      scriptArgs: ['./report.mjs', '--from', 'x'],
+    expect(extractRunArgs(['run', '/abs/path/report.ts', '--', '--from', 'x'])).toEqual({
+      cliArgs: ['/abs/path/report.ts'],
+      scriptPath: '/abs/path/report.ts',
+      scriptArgs: ['--from', 'x'],
     });
   });
 
@@ -112,35 +135,28 @@ describe('extractRunArgs', () => {
     const { extractRunArgs } = await import('./command.js');
 
     expect(extractRunArgs(['script', './report.ts'])).toEqual({
-      cliArgs: [],
-      scriptArgs: ['./report.ts'],
-    });
-  });
-
-  it('treats a flag after the script path as a forwarded script arg, not a CLI flag', async () => {
-    const { extractRunArgs } = await import('./command.js');
-
-    // `--list` after the script path belongs to the script, not to `run`.
-    expect(extractRunArgs(['run', './report.mjs', '--list'])).toEqual({
-      cliArgs: [],
-      scriptArgs: ['./report.mjs', '--list'],
-    });
-  });
-
-  it('returns no script args for `--list` with no directory', async () => {
-    const { extractRunArgs } = await import('./command.js');
-
-    expect(extractRunArgs(['run', '--list'])).toEqual({
-      cliArgs: ['--list'],
+      cliArgs: ['./report.ts'],
+      scriptPath: './report.ts',
       scriptArgs: [],
     });
   });
 
-  it('keeps `--list <dir>` entirely in cliArgs when dir is not a script file', async () => {
+  it('returns no script path or args for `--list` with no directory', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', '--list'])).toEqual({
+      cliArgs: ['--list'],
+      scriptPath: undefined,
+      scriptArgs: [],
+    });
+  });
+
+  it('keeps `--list <dir>` in cliArgs when dir is not a script file', async () => {
     const { extractRunArgs } = await import('./command.js');
 
     expect(extractRunArgs(['run', '--list', './automation'])).toEqual({
       cliArgs: ['--list', './automation'],
+      scriptPath: undefined,
       scriptArgs: [],
     });
   });
@@ -148,7 +164,21 @@ describe('extractRunArgs', () => {
   it('returns empty args when only the command is present', async () => {
     const { extractRunArgs } = await import('./command.js');
 
-    expect(extractRunArgs(['run'])).toEqual({ cliArgs: [], scriptArgs: [] });
+    expect(extractRunArgs(['run'])).toEqual({
+      cliArgs: [],
+      scriptPath: undefined,
+      scriptArgs: [],
+    });
+  });
+
+  it('returns empty script args for a trailing -- with nothing after it', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', './report.mjs', '--'])).toEqual({
+      cliArgs: ['./report.mjs'],
+      scriptPath: './report.mjs',
+      scriptArgs: [],
+    });
   });
 
   it.each([
@@ -164,16 +194,15 @@ describe('extractRunArgs', () => {
   ])('recognizes %s as a runnable script file', async (file) => {
     const { extractRunArgs } = await import('./command.js');
 
-    expect(extractRunArgs(['run', file, '--flag']).scriptArgs).toEqual([file, '--flag']);
+    expect(extractRunArgs(['run', file]).scriptPath).toBe(file);
   });
 
-  it('does not treat a .json flag value as the script path', async () => {
+  it('does not treat a .json run-option value as the script path', async () => {
     const { extractRunArgs } = await import('./command.js');
 
-    expect(extractRunArgs(['run', '--config', 'app.json', './real.mjs'])).toEqual({
-      cliArgs: ['--config', 'app.json'],
-      scriptArgs: ['./real.mjs'],
-    });
+    expect(extractRunArgs(['run', '--config', 'app.json', './real.mjs']).scriptPath).toBe(
+      './real.mjs',
+    );
   });
 });
 
@@ -192,55 +221,56 @@ describe('handleRunCommand', () => {
     vi.resetModules();
   });
 
-  it('calls scriptRun with the script path', async () => {
+  it('calls scriptRun with the script path and no dry-run by default', async () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand(['./my-script.ts'], {});
+    await handleRunCommand('./my-script.ts', [], {});
 
-    expect(scriptRun).toHaveBeenCalledWith(['./my-script.ts'], expect.anything());
+    expect(scriptRun).toHaveBeenCalledWith(['./my-script.ts'], expect.anything(), {
+      dryRun: false,
+    });
   });
 
   it('forwards script args verbatim to scriptRun', async () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand(['./my-script.ts', '--from', '2025-01-01', '--mine'], {});
+    await handleRunCommand('./my-script.ts', ['--from', '2025-01-01', '--mine'], {});
 
     expect(scriptRun).toHaveBeenCalledWith(
       ['./my-script.ts', '--from', '2025-01-01', '--mine'],
       expect.anything(),
+      { dryRun: false },
     );
   });
 
-  it('re-injects --dry-run ahead of the script args when the CLI flag is set', async () => {
+  it('passes dryRun: true when the --dry-run run-option is set', async () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand(['./my-script.ts', '--from', 'x'], { 'dry-run': true });
+    await handleRunCommand('./my-script.ts', ['--from', 'x'], { 'dry-run': true });
 
-    expect(scriptRun).toHaveBeenCalledWith(
-      ['--dry-run', './my-script.ts', '--from', 'x'],
-      expect.anything(),
-    );
+    expect(scriptRun).toHaveBeenCalledWith(['./my-script.ts', '--from', 'x'], expect.anything(), {
+      dryRun: true,
+    });
   });
 
-  it('does not re-inject --dry-run when the flag is absent', async () => {
+  it('calls scriptRun with empty args when no script path was found', async () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand(['./my-script.ts'], {});
+    await handleRunCommand(undefined, [], {});
 
-    const call = vi.mocked(scriptRun).mock.calls[0][0];
-    expect(call).not.toContain('--dry-run');
+    expect(scriptRun).toHaveBeenCalledWith([], expect.anything(), { dryRun: false });
   });
 
-  it('calls scriptList (no dir) when options.list is true', async () => {
+  it('calls scriptList (no dir) when options.list is true, without running', async () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptList } = await import('./list.js');
     const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand([], { list: true });
+    await handleRunCommand(undefined, [], { list: true });
 
     expect(scriptList).toHaveBeenCalledWith(undefined);
     expect(scriptRun).not.toHaveBeenCalled();
@@ -250,7 +280,7 @@ describe('handleRunCommand', () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptList } = await import('./list.js');
 
-    await handleRunCommand([], { list: './automation' });
+    await handleRunCommand(undefined, [], { list: './automation' });
 
     expect(scriptList).toHaveBeenCalledWith('./automation');
   });
@@ -259,9 +289,9 @@ describe('handleRunCommand', () => {
 // ── End-to-end argv path (the coverage gap called out in the issue) ─────────
 //
 // Feeds a real argv through extractRunArgs → parseArgs → handleRunCommand and
-// asserts that a named flag after the script path reaches scriptRun. The old
-// suite only called scriptRun directly with the flags already present, so it
-// never exercised the global parser stripping them.
+// asserts that a named flag after `--` reaches scriptRun. The old suite only
+// called scriptRun directly with the flags already present, so it never
+// exercised the global parser.
 
 describe('run command: argv → handleRunCommand forwarding', () => {
   beforeEach(() => {
@@ -276,34 +306,40 @@ describe('run command: argv → handleRunCommand forwarding', () => {
     vi.resetModules();
   });
 
-  it('forwards `--from x` from a raw argv all the way to scriptRun', async () => {
+  it('forwards `--from x` after -- from a raw argv all the way to scriptRun', async () => {
     const { extractRunArgs, handleRunCommand } = await import('./command.js');
     const { scriptRun } = await import('./handlers.js');
 
-    const { cliArgs, scriptArgs } = extractRunArgs(['run', 'report.mjs', '--from', 'x']);
-    const options = parseArgs(cliArgs).options;
-    await handleRunCommand(scriptArgs, options);
-
-    expect(scriptRun).toHaveBeenCalledWith(['report.mjs', '--from', 'x'], expect.anything());
-  });
-
-  it('routes a leading --dry-run to dry-run mode while still forwarding flags', async () => {
-    const { extractRunArgs, handleRunCommand } = await import('./command.js');
-    const { scriptRun } = await import('./handlers.js');
-
-    const { cliArgs, scriptArgs } = extractRunArgs([
+    const { scriptPath, scriptArgs, cliArgs } = extractRunArgs([
       'run',
-      '--dry-run',
-      './report.mjs',
+      'report.mjs',
+      '--',
       '--from',
       'x',
     ]);
-    const options = parseArgs(cliArgs).options;
-    await handleRunCommand(scriptArgs, options);
+    await handleRunCommand(scriptPath, scriptArgs, parseArgs(cliArgs).options);
 
-    expect(scriptRun).toHaveBeenCalledWith(
-      ['--dry-run', './report.mjs', '--from', 'x'],
-      expect.anything(),
-    );
+    expect(scriptRun).toHaveBeenCalledWith(['report.mjs', '--from', 'x'], expect.anything(), {
+      dryRun: false,
+    });
+  });
+
+  it('routes a leading --dry-run to dry-run mode while still forwarding script flags', async () => {
+    const { extractRunArgs, handleRunCommand } = await import('./command.js');
+    const { scriptRun } = await import('./handlers.js');
+
+    const { scriptPath, scriptArgs, cliArgs } = extractRunArgs([
+      'run',
+      '--dry-run',
+      './report.mjs',
+      '--',
+      '--from',
+      'x',
+    ]);
+    await handleRunCommand(scriptPath, scriptArgs, parseArgs(cliArgs).options);
+
+    expect(scriptRun).toHaveBeenCalledWith(['./report.mjs', '--from', 'x'], expect.anything(), {
+      dryRun: true,
+    });
   });
 });

--- a/packages/cli/src/commands/run/command.test.ts
+++ b/packages/cli/src/commands/run/command.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { parseArgs } from '../../utils/args.js';
+
 // Mock the handler to avoid spawning real processes
 vi.mock('./handlers.js', () => ({
   scriptRun: vi.fn().mockResolvedValue(undefined),
@@ -38,6 +40,145 @@ vi.mock('../../utils/cache.js', () => {
   };
 });
 
+// ── extractRunArgs ──────────────────────────────────────────────────────────
+//
+// The global CLI arg parser strips every `--flag` and misclassifies tokens that
+// follow a slash-path, so the `run` command MUST recover the script invocation
+// straight from raw argv. extractRunArgs splits the raw argv into the CLI-level
+// flags (before the script path) and the script args (the script path plus
+// everything after it, forwarded verbatim).
+
+describe('extractRunArgs', () => {
+  it('forwards named flags after the script path verbatim (the core bug)', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(
+      extractRunArgs(['run', './report.mjs', '--from', '2025-01-01', '--to', '2025-01-31']),
+    ).toEqual({
+      cliArgs: [],
+      scriptArgs: ['./report.mjs', '--from', '2025-01-01', '--to', '2025-01-31'],
+    });
+  });
+
+  it('forwards positional args after a slash-path without misclassifying them', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    // Previously the global parser routed `2025-01-01` into `command`, so the
+    // script path became `2025-01-01` → ERR_MODULE_NOT_FOUND.
+    expect(extractRunArgs(['run', './report.mjs', '2025-01-01', '2025-01-31'])).toEqual({
+      cliArgs: [],
+      scriptArgs: ['./report.mjs', '2025-01-01', '2025-01-31'],
+    });
+  });
+
+  it('detects a slash-less script path', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', 'report.mjs', '--mine'])).toEqual({
+      cliArgs: [],
+      scriptArgs: ['report.mjs', '--mine'],
+    });
+  });
+
+  it('detects an absolute script path', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', '/abs/path/report.ts', '--from', 'x'])).toEqual({
+      cliArgs: [],
+      scriptArgs: ['/abs/path/report.ts', '--from', 'x'],
+    });
+  });
+
+  it('keeps a boolean CLI flag before the script in cliArgs', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', '--dry-run', './report.mjs', '--from', 'x'])).toEqual({
+      cliArgs: ['--dry-run'],
+      scriptArgs: ['./report.mjs', '--from', 'x'],
+    });
+  });
+
+  it('keeps value-taking CLI flags before the script in cliArgs', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    // The flag value `abc` must NOT be mistaken for the script path.
+    expect(extractRunArgs(['run', '--token', 'abc', './report.mjs', '--from', 'x'])).toEqual({
+      cliArgs: ['--token', 'abc'],
+      scriptArgs: ['./report.mjs', '--from', 'x'],
+    });
+  });
+
+  it('supports the `script` command alias', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['script', './report.ts'])).toEqual({
+      cliArgs: [],
+      scriptArgs: ['./report.ts'],
+    });
+  });
+
+  it('treats a flag after the script path as a forwarded script arg, not a CLI flag', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    // `--list` after the script path belongs to the script, not to `run`.
+    expect(extractRunArgs(['run', './report.mjs', '--list'])).toEqual({
+      cliArgs: [],
+      scriptArgs: ['./report.mjs', '--list'],
+    });
+  });
+
+  it('returns no script args for `--list` with no directory', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', '--list'])).toEqual({
+      cliArgs: ['--list'],
+      scriptArgs: [],
+    });
+  });
+
+  it('keeps `--list <dir>` entirely in cliArgs when dir is not a script file', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', '--list', './automation'])).toEqual({
+      cliArgs: ['--list', './automation'],
+      scriptArgs: [],
+    });
+  });
+
+  it('returns empty args when only the command is present', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run'])).toEqual({ cliArgs: [], scriptArgs: [] });
+  });
+
+  it.each([
+    'script.ts',
+    'script.mts',
+    'script.cts',
+    'script.tsx',
+    'script.js',
+    'script.mjs',
+    'script.cjs',
+    'script.jsx',
+    'SCRIPT.MJS',
+  ])('recognizes %s as a runnable script file', async (file) => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', file, '--flag']).scriptArgs).toEqual([file, '--flag']);
+  });
+
+  it('does not treat a .json flag value as the script path', async () => {
+    const { extractRunArgs } = await import('./command.js');
+
+    expect(extractRunArgs(['run', '--config', 'app.json', './real.mjs'])).toEqual({
+      cliArgs: ['--config', 'app.json'],
+      scriptArgs: ['./real.mjs'],
+    });
+  });
+});
+
+// ── handleRunCommand ──────────────────────────────────────────────────────
+
 describe('handleRunCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -51,73 +192,118 @@ describe('handleRunCommand', () => {
     vi.resetModules();
   });
 
-  it('calls scriptRun with the subcommand as first arg', async () => {
+  it('calls scriptRun with the script path', async () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand('./my-script.ts', [], { format: 'human' });
+    await handleRunCommand(['./my-script.ts'], {});
 
     expect(scriptRun).toHaveBeenCalledWith(['./my-script.ts'], expect.anything());
   });
 
-  it('merges subcommand and positional into allArgs', async () => {
+  it('forwards script args verbatim to scriptRun', async () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand('./my-script.ts', ['--flag', 'value'], { format: 'human' });
+    await handleRunCommand(['./my-script.ts', '--from', '2025-01-01', '--mine'], {});
 
     expect(scriptRun).toHaveBeenCalledWith(
-      ['./my-script.ts', '--flag', 'value'],
+      ['./my-script.ts', '--from', '2025-01-01', '--mine'],
       expect.anything(),
     );
   });
 
-  it('handles undefined subcommand (positional only)', async () => {
+  it('re-injects --dry-run ahead of the script args when the CLI flag is set', async () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand(undefined, ['./my-script.js', 'arg1'], { format: 'human' });
+    await handleRunCommand(['./my-script.ts', '--from', 'x'], { 'dry-run': true });
 
-    expect(scriptRun).toHaveBeenCalledWith(['./my-script.js', 'arg1'], expect.anything());
+    expect(scriptRun).toHaveBeenCalledWith(
+      ['--dry-run', './my-script.ts', '--from', 'x'],
+      expect.anything(),
+    );
   });
 
-  it('calls scriptList when --list flag is present in allArgs', async () => {
+  it('does not re-inject --dry-run when the flag is absent', async () => {
+    const { handleRunCommand } = await import('./command.js');
+    const { scriptRun } = await import('./handlers.js');
+
+    await handleRunCommand(['./my-script.ts'], {});
+
+    const call = vi.mocked(scriptRun).mock.calls[0][0];
+    expect(call).not.toContain('--dry-run');
+  });
+
+  it('calls scriptList (no dir) when options.list is true', async () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptList } = await import('./list.js');
     const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand('--list', [], { format: 'human' });
+    await handleRunCommand([], { list: true });
 
     expect(scriptList).toHaveBeenCalledWith(undefined);
     expect(scriptRun).not.toHaveBeenCalled();
   });
 
-  it('passes a directory argument to scriptList when provided after --list in allArgs', async () => {
+  it('passes the directory to scriptList when options.list is a string', async () => {
     const { handleRunCommand } = await import('./command.js');
     const { scriptList } = await import('./list.js');
 
-    await handleRunCommand('--list', ['./automation'], { format: 'human' });
+    await handleRunCommand([], { list: './automation' });
 
     expect(scriptList).toHaveBeenCalledWith('./automation');
   });
+});
 
-  it('calls scriptList when options.list is true (global arg parser, no dir)', async () => {
-    const { handleRunCommand } = await import('./command.js');
-    const { scriptList } = await import('./list.js');
+// ── End-to-end argv path (the coverage gap called out in the issue) ─────────
+//
+// Feeds a real argv through extractRunArgs → parseArgs → handleRunCommand and
+// asserts that a named flag after the script path reaches scriptRun. The old
+// suite only called scriptRun directly with the flags already present, so it
+// never exercised the global parser stripping them.
+
+describe('run command: argv → handleRunCommand forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('forwards `--from x` from a raw argv all the way to scriptRun', async () => {
+    const { extractRunArgs, handleRunCommand } = await import('./command.js');
     const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand(undefined, [], { format: 'human', list: true });
+    const { cliArgs, scriptArgs } = extractRunArgs(['run', 'report.mjs', '--from', 'x']);
+    const options = parseArgs(cliArgs).options;
+    await handleRunCommand(scriptArgs, options);
 
-    expect(scriptList).toHaveBeenCalledWith(undefined);
-    expect(scriptRun).not.toHaveBeenCalled();
+    expect(scriptRun).toHaveBeenCalledWith(['report.mjs', '--from', 'x'], expect.anything());
   });
 
-  it('passes directory to scriptList when options.list is a string (global arg parser with dir)', async () => {
-    const { handleRunCommand } = await import('./command.js');
-    const { scriptList } = await import('./list.js');
+  it('routes a leading --dry-run to dry-run mode while still forwarding flags', async () => {
+    const { extractRunArgs, handleRunCommand } = await import('./command.js');
+    const { scriptRun } = await import('./handlers.js');
 
-    await handleRunCommand(undefined, [], { format: 'human', list: './automation' });
+    const { cliArgs, scriptArgs } = extractRunArgs([
+      'run',
+      '--dry-run',
+      './report.mjs',
+      '--from',
+      'x',
+    ]);
+    const options = parseArgs(cliArgs).options;
+    await handleRunCommand(scriptArgs, options);
 
-    expect(scriptList).toHaveBeenCalledWith('./automation');
+    expect(scriptRun).toHaveBeenCalledWith(
+      ['--dry-run', './report.mjs', '--from', 'x'],
+      expect.anything(),
+    );
   });
 });

--- a/packages/cli/src/commands/run/command.ts
+++ b/packages/cli/src/commands/run/command.ts
@@ -1,12 +1,18 @@
 /**
  * `productive run` command entry point.
  *
- * Unlike other commands, `run` cannot rely on the global CLI arg parser: that
- * parser strips every `--flag` into `options` and routes slash-less tokens into
- * `command`, so a script's own flags and positionals never survive the trip to
- * the handler. Instead, the script invocation is recovered straight from the
- * raw argv by {@link extractRunArgs}, which forwards everything from the script
- * path onward to the script verbatim.
+ * Argument contract:
+ *
+ *   productive run [run-options] <script> [run-options] -- [script args...]
+ *
+ * Everything BEFORE the `--` separator configures `run` itself (the script
+ * path plus credentials, `--dry-run`, `--list`, `--format`, `--help`,
+ * `--version`). Everything AFTER `--` is forwarded to the script verbatim and
+ * parsed inside the script into `args` (positionals) and `flags` (named).
+ *
+ * The explicit `--` boundary makes forwarding predictable: the global CLI arg
+ * parser can keep owning the run-options without ever swallowing a flag the
+ * script meant to receive, and a script's flags can never collide with `run`'s.
  */
 
 import type { CommandOptions } from '../../context.js';
@@ -18,77 +24,79 @@ import { scriptList } from './list.js';
 
 /**
  * A runnable script file: `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.mts`,
- * `.cts`, or `.tsx` (case-insensitive). Used to locate the script path within
- * the raw argv. Flag values (`json`, `2025-01-01`, `app.json`, a base URL, …)
- * never match, so they are not mistaken for the script.
+ * `.cts`, or `.tsx` (case-insensitive). Used to locate the script path among
+ * the run-options. Run-option values (`json`, an org ID, a base URL, …) never
+ * match, so they are not mistaken for the script.
  */
 const SCRIPT_FILE = /\.[cm]?[jt]sx?$/i;
 
-/** The CLI-level flags and the script args recovered from a raw argv. */
+/** The pieces of a `productive run` invocation recovered from a raw argv. */
 export interface RunArgs {
-  /** Flags for `run` itself — everything before the script path. */
+  /** Run-option tokens (everything before `--`); parsed for credentials, `--dry-run`, `--list`, … */
   cliArgs: string[];
-  /** The script path plus everything after it, forwarded to the script verbatim. */
+  /** The script path — the first JS/TS file token before `--`, or undefined. */
+  scriptPath: string | undefined;
+  /** Tokens after `--`, forwarded to the script verbatim. */
   scriptArgs: string[];
 }
 
 /**
- * Split a raw argv (`process.argv.slice(2)`) into the CLI-level flags for
- * `run` and the script args to forward.
+ * Split a raw argv (`process.argv.slice(2)`) into the run-options, the script
+ * path, and the script args to forward.
  *
- * The script path is the first token that looks like a runnable JS/TS file;
- * everything from there onward is forwarded untouched. Tokens before it
- * (credentials, `--dry-run`, `--list`, `--format`, …) configure `run` itself.
- *
- * When no script file is present (e.g. `--list` or a bare `run`), every
- * post-command token is treated as a CLI flag and `scriptArgs` is empty.
+ * The `--` separator divides run-options (left) from script args (right). The
+ * script path is the first JS/TS file token on the left, so the run-options may
+ * appear in any order around it.
  *
  * @example
  * ```ts
- * extractRunArgs(['run', './report.mjs', '--from', 'x'])
- * // → { cliArgs: [], scriptArgs: ['./report.mjs', '--from', 'x'] }
+ * extractRunArgs(['run', './report.mjs', '--dry-run', '--', '--from', 'x'])
+ * // → { cliArgs: ['./report.mjs', '--dry-run'], scriptPath: './report.mjs', scriptArgs: ['--from', 'x'] }
  *
- * extractRunArgs(['run', '--dry-run', './report.mjs', '--from', 'x'])
- * // → { cliArgs: ['--dry-run'], scriptArgs: ['./report.mjs', '--from', 'x'] }
+ * extractRunArgs(['run', '--list'])
+ * // → { cliArgs: ['--list'], scriptPath: undefined, scriptArgs: [] }
  * ```
  */
 export function extractRunArgs(argv: string[]): RunArgs {
-  // Locate the `run` / `script` command token; forward only what follows it.
+  // Locate the `run` / `script` command token; consider only what follows it.
   const commandIndex = argv.findIndex((arg) => arg === 'run' || arg === 'script');
   const post = commandIndex === -1 ? argv : argv.slice(commandIndex + 1);
 
-  const scriptIndex = post.findIndex((arg) => SCRIPT_FILE.test(arg));
-  if (scriptIndex === -1) {
-    return { cliArgs: post, scriptArgs: [] };
-  }
+  // Everything after the first `--` is forwarded to the script untouched.
+  const separatorIndex = post.indexOf('--');
+  const cliArgs = separatorIndex === -1 ? post : post.slice(0, separatorIndex);
+  const scriptArgs = separatorIndex === -1 ? [] : post.slice(separatorIndex + 1);
 
-  return { cliArgs: post.slice(0, scriptIndex), scriptArgs: post.slice(scriptIndex) };
+  const scriptPath = cliArgs.find((arg) => SCRIPT_FILE.test(arg));
+
+  return { cliArgs, scriptPath, scriptArgs };
 }
 
 /**
  * Handle the `productive run` (and `productive script`) command.
  *
- * @param scriptArgs - [scriptPath, ...scriptArgs] recovered by {@link extractRunArgs}
- * @param options    - CLI-level options parsed from the flags before the script
- *                     path (credentials, format, `--dry-run`, `--list`)
+ * @param scriptPath - The script path resolved by {@link extractRunArgs}
+ * @param scriptArgs - Args after `--`, forwarded to the script verbatim
+ * @param options    - Run-options parsed from the flags before `--`
+ *                     (credentials, format, `--dry-run`, `--list`)
  */
 export async function handleRunCommand(
+  scriptPath: string | undefined,
   scriptArgs: string[],
   options: Record<string, OptionValue>,
 ): Promise<void> {
-  const ctx = createContext(options as CommandOptions);
-
-  // --list discovers scripts in a directory without running any. It only
-  // applies when it precedes the script path (so it lands in `options`); a
-  // `--list` after the script path stays in `scriptArgs` and is forwarded.
+  // --list discovers scripts in a directory without running any. It needs no
+  // API client or credentials, so handle it before building a context.
   if ('list' in options) {
     const dir = typeof options.list === 'string' ? options.list : undefined;
     await scriptList(dir);
     return;
   }
 
-  // --dry-run is a CLI-level flag (before the script path). scriptRun reads it
-  // back off its arg list, so re-inject it ahead of the forwarded script args.
+  const ctx = createContext(options as CommandOptions);
+
+  // --dry-run is a run-option; pass it through explicitly rather than smuggling
+  // it back into the script's arg list.
   const dryRun = 'dry-run' in options;
-  await scriptRun(dryRun ? ['--dry-run', ...scriptArgs] : scriptArgs, ctx);
+  await scriptRun(scriptPath ? [scriptPath, ...scriptArgs] : [], ctx, { dryRun });
 }

--- a/packages/cli/src/commands/run/command.ts
+++ b/packages/cli/src/commands/run/command.ts
@@ -1,55 +1,94 @@
 /**
  * `productive run` command entry point.
  *
- * Unlike other commands, `run` does not use `createCommandRouter` because it
- * forwards all positional arguments — including the script path — directly to
- * the handler rather than treating the first positional as a subcommand.
+ * Unlike other commands, `run` cannot rely on the global CLI arg parser: that
+ * parser strips every `--flag` into `options` and routes slash-less tokens into
+ * `command`, so a script's own flags and positionals never survive the trip to
+ * the handler. Instead, the script invocation is recovered straight from the
+ * raw argv by {@link extractRunArgs}, which forwards everything from the script
+ * path onward to the script verbatim.
  */
 
 import type { CommandOptions } from '../../context.js';
+import type { OptionValue } from '../../utils/args.js';
 
 import { createContext } from '../../context.js';
 import { scriptRun } from './handlers.js';
 import { scriptList } from './list.js';
 
 /**
+ * A runnable script file: `.js`, `.mjs`, `.cjs`, `.jsx`, `.ts`, `.mts`,
+ * `.cts`, or `.tsx` (case-insensitive). Used to locate the script path within
+ * the raw argv. Flag values (`json`, `2025-01-01`, `app.json`, a base URL, …)
+ * never match, so they are not mistaken for the script.
+ */
+const SCRIPT_FILE = /\.[cm]?[jt]sx?$/i;
+
+/** The CLI-level flags and the script args recovered from a raw argv. */
+export interface RunArgs {
+  /** Flags for `run` itself — everything before the script path. */
+  cliArgs: string[];
+  /** The script path plus everything after it, forwarded to the script verbatim. */
+  scriptArgs: string[];
+}
+
+/**
+ * Split a raw argv (`process.argv.slice(2)`) into the CLI-level flags for
+ * `run` and the script args to forward.
+ *
+ * The script path is the first token that looks like a runnable JS/TS file;
+ * everything from there onward is forwarded untouched. Tokens before it
+ * (credentials, `--dry-run`, `--list`, `--format`, …) configure `run` itself.
+ *
+ * When no script file is present (e.g. `--list` or a bare `run`), every
+ * post-command token is treated as a CLI flag and `scriptArgs` is empty.
+ *
+ * @example
+ * ```ts
+ * extractRunArgs(['run', './report.mjs', '--from', 'x'])
+ * // → { cliArgs: [], scriptArgs: ['./report.mjs', '--from', 'x'] }
+ *
+ * extractRunArgs(['run', '--dry-run', './report.mjs', '--from', 'x'])
+ * // → { cliArgs: ['--dry-run'], scriptArgs: ['./report.mjs', '--from', 'x'] }
+ * ```
+ */
+export function extractRunArgs(argv: string[]): RunArgs {
+  // Locate the `run` / `script` command token; forward only what follows it.
+  const commandIndex = argv.findIndex((arg) => arg === 'run' || arg === 'script');
+  const post = commandIndex === -1 ? argv : argv.slice(commandIndex + 1);
+
+  const scriptIndex = post.findIndex((arg) => SCRIPT_FILE.test(arg));
+  if (scriptIndex === -1) {
+    return { cliArgs: post, scriptArgs: [] };
+  }
+
+  return { cliArgs: post.slice(0, scriptIndex), scriptArgs: post.slice(scriptIndex) };
+}
+
+/**
  * Handle the `productive run` (and `productive script`) command.
  *
- * @param _subcommand - Ignored; the script path is taken from `positional`.
- * @param positional  - [scriptPath, ...scriptArgs]
- * @param options     - Global CLI options (auth, format, etc.)
+ * @param scriptArgs - [scriptPath, ...scriptArgs] recovered by {@link extractRunArgs}
+ * @param options    - CLI-level options parsed from the flags before the script
+ *                     path (credentials, format, `--dry-run`, `--list`)
  */
 export async function handleRunCommand(
-  _subcommand: string | undefined,
-  positional: string[],
-  options: Record<string, string | boolean | string[]>,
+  scriptArgs: string[],
+  options: Record<string, OptionValue>,
 ): Promise<void> {
   const ctx = createContext(options as CommandOptions);
 
-  // If called as `productive run list.ts`, the subcommand IS the script path.
-  // Merge subcommand back into positional if it looks like a file.
-  const allArgs = _subcommand ? [_subcommand, ...positional] : positional;
-
-  // --list discovers scripts in a directory without running any.
-  //
-  // Two sources to check:
-  //   1. `options.list` — set by the global CLI arg parser when the flag is
-  //      encountered before any positional (e.g. `productive run --list ./dir`
-  //      is parsed as options.list = './dir' or options.list = true)
-  //   2. `allArgs` — raw forwarded args for the unusual case where --list
-  //      appears after a positional (e.g. `productive run ./script --list`)
-  if ('list' in options || allArgs.includes('--list')) {
-    const dir =
-      typeof options.list === 'string'
-        ? options.list
-        : (() => {
-            const listIndex = allArgs.indexOf('--list');
-            const next = allArgs[listIndex + 1];
-            return next && !next.startsWith('-') ? next : undefined;
-          })();
+  // --list discovers scripts in a directory without running any. It only
+  // applies when it precedes the script path (so it lands in `options`); a
+  // `--list` after the script path stays in `scriptArgs` and is forwarded.
+  if ('list' in options) {
+    const dir = typeof options.list === 'string' ? options.list : undefined;
     await scriptList(dir);
     return;
   }
 
-  await scriptRun(allArgs, ctx);
+  // --dry-run is a CLI-level flag (before the script path). scriptRun reads it
+  // back off its arg list, so re-inject it ahead of the forwarded script args.
+  const dryRun = 'dry-run' in options;
+  await scriptRun(dryRun ? ['--dry-run', ...scriptArgs] : scriptArgs, ctx);
 }

--- a/packages/cli/src/commands/run/handlers.test.ts
+++ b/packages/cli/src/commands/run/handlers.test.ts
@@ -160,7 +160,7 @@ describe('scriptRun', () => {
       .mockResolvedValue('file:///node_modules/@studiometa/productive-sdk/dist/index.js');
 
     // Both .ts and .js files should get --enable-source-maps
-    await scriptRun(['/tmp/test-script.js'], ctx, mockResolver);
+    await scriptRun(['/tmp/test-script.js'], ctx, {}, mockResolver);
     expect(vi.mocked(spawn).mock.calls[0][1]).toContain('--enable-source-maps');
   });
 
@@ -180,7 +180,7 @@ describe('scriptRun', () => {
       .fn()
       .mockResolvedValue('file:///node_modules/@studiometa/productive-sdk/dist/index.js');
 
-    await scriptRun(['/tmp/test-script.ts'], ctx, mockResolver);
+    await scriptRun(['/tmp/test-script.ts'], ctx, {}, mockResolver);
 
     const spawnArgs = vi.mocked(spawn).mock.calls[0];
     expect(spawnArgs[1]).toContain('--enable-source-maps');
@@ -204,7 +204,7 @@ describe('scriptRun', () => {
       .fn()
       .mockResolvedValue('file:///node_modules/@studiometa/productive-sdk/dist/index.js');
 
-    await scriptRun(['/tmp/test-script.js'], ctx, mockResolver);
+    await scriptRun(['/tmp/test-script.js'], ctx, {}, mockResolver);
 
     const spawnArgs = vi.mocked(spawn).mock.calls[0];
     expect(spawnArgs[1]).not.toContain('--experimental-strip-types');
@@ -230,7 +230,7 @@ describe('scriptRun', () => {
     });
 
     const mockResolver = vi.fn().mockResolvedValue('file:///sdk/dist/index.js');
-    await scriptRun(['/tmp/test-script.js'], ctx, mockResolver);
+    await scriptRun(['/tmp/test-script.js'], ctx, {}, mockResolver);
 
     const spawnOptions = vi.mocked(spawn).mock.calls[0][2] as { env: Record<string, string> };
     expect(spawnOptions.env.PRODUCTIVE_API_TOKEN).toBe('my-token');
@@ -255,7 +255,7 @@ describe('scriptRun', () => {
     const ctx = makeCtx();
     const mockResolver = vi.fn().mockResolvedValue('file:///sdk/dist/index.js');
 
-    await scriptRun(['/tmp/test-script.js'], ctx, mockResolver);
+    await scriptRun(['/tmp/test-script.js'], ctx, {}, mockResolver);
 
     expect(processExitSpy).toHaveBeenCalledWith(42);
   });
@@ -275,7 +275,7 @@ describe('scriptRun', () => {
     const ctx = makeCtx();
     const mockResolver = vi.fn().mockResolvedValue('file:///sdk/dist/index.js');
 
-    await scriptRun(['/tmp/test-script.js'], ctx, mockResolver);
+    await scriptRun(['/tmp/test-script.js'], ctx, {}, mockResolver);
 
     expect(writeFile).toHaveBeenCalledWith(
       expect.stringContaining('wrapper.mjs'),
@@ -299,7 +299,7 @@ describe('scriptRun', () => {
     const ctx = makeCtx();
     const mockResolver = vi.fn().mockResolvedValue('file:///sdk/dist/index.js');
 
-    await scriptRun(['/tmp/test-script.js'], ctx, mockResolver);
+    await scriptRun(['/tmp/test-script.js'], ctx, {}, mockResolver);
 
     expect(rm).toHaveBeenCalledWith(
       expect.stringContaining('productive-script'),
@@ -307,7 +307,7 @@ describe('scriptRun', () => {
     );
   });
 
-  it('strips --dry-run from script args and sets PRODUCTIVE_DRY_RUN=1', async () => {
+  it('sets PRODUCTIVE_DRY_RUN=1 and still forwards script args when dryRun is passed', async () => {
     const { spawn } = await import('node:child_process');
     const { scriptRun } = await import('./handlers.js');
 
@@ -322,23 +322,24 @@ describe('scriptRun', () => {
     const mockResolver = vi.fn().mockResolvedValue('file:///sdk/dist/index.js');
 
     await scriptRun(
-      ['--dry-run', '/tmp/test-script.js', '--from', '2025-01-01'],
+      ['/tmp/test-script.js', '--from', '2025-01-01'],
       ctx,
+      { dryRun: true },
       mockResolver,
     );
 
     const spawnArgs = vi.mocked(spawn).mock.calls[0];
-    // --dry-run must NOT be passed to the subprocess as a script arg
-    expect(spawnArgs[1]).not.toContain('--dry-run');
     // PRODUCTIVE_DRY_RUN must be set in env
     const spawnOptions = spawnArgs[2] as { env: Record<string, string> };
     expect(spawnOptions.env.PRODUCTIVE_DRY_RUN).toBe('1');
-    // Script path must still be the wrapper, not the --dry-run value
+    // The forwarded script args reach the subprocess after the wrapper path
     const nodeArgs = spawnArgs[1] as string[];
+    expect(nodeArgs).toContain('--from');
+    expect(nodeArgs).toContain('2025-01-01');
     expect(nodeArgs.some((a) => a.endsWith('wrapper.mjs'))).toBe(true);
   });
 
-  it('does not set PRODUCTIVE_DRY_RUN when --dry-run is absent', async () => {
+  it('does not set PRODUCTIVE_DRY_RUN when dryRun is not passed', async () => {
     const { spawn } = await import('node:child_process');
     const { scriptRun } = await import('./handlers.js');
 
@@ -352,7 +353,7 @@ describe('scriptRun', () => {
     const ctx = makeCtx();
     const mockResolver = vi.fn().mockResolvedValue('file:///sdk/dist/index.js');
 
-    await scriptRun(['/tmp/test-script.js'], ctx, mockResolver);
+    await scriptRun(['/tmp/test-script.js'], ctx, {}, mockResolver);
 
     const spawnOptions = vi.mocked(spawn).mock.calls[0][2] as { env: Record<string, string> };
     expect(spawnOptions.env.PRODUCTIVE_DRY_RUN).toBeUndefined();

--- a/packages/cli/src/commands/run/handlers.ts
+++ b/packages/cli/src/commands/run/handlers.ts
@@ -53,20 +53,20 @@ export function waitForProcess(child: ReturnType<typeof spawn>): Promise<number>
 /**
  * Run a script with `productive run`.
  *
- * @param rawArgs   - Positional args from the CLI: [scriptPath, ...scriptArgs]
+ * @param rawArgs   - [scriptPath, ...scriptArgs] — the script path followed by
+ *                    the args to forward (everything after the CLI's `--`)
  * @param ctx       - Command context (config, formatter)
+ * @param options   - Run options. `dryRun` intercepts mutating API calls
+ *                    without executing them.
  * @param resolver  - Module resolver (defaults to import.meta.resolve)
  */
 export async function scriptRun(
   rawArgs: string[],
   ctx: CommandContext,
+  { dryRun = false }: { dryRun?: boolean } = {},
   resolver: ModuleResolver = createDefaultResolver(import.meta.url),
 ): Promise<void> {
-  // Extract CLI-level flags before the script path and script args.
-  // --dry-run intercepts mutating API calls without executing them.
-  const dryRun = rawArgs.includes('--dry-run');
-  const argsWithoutCliFlags = rawArgs.filter((a) => a !== '--dry-run');
-  const [rawScriptPath, ...scriptArgs] = argsWithoutCliFlags;
+  const [rawScriptPath, ...scriptArgs] = rawArgs;
 
   if (!rawScriptPath) {
     ctx.formatter.error('Usage: productive run <script.[ts|js|mjs]> [args...]');

--- a/packages/cli/src/commands/run/help.ts
+++ b/packages/cli/src/commands/run/help.ts
@@ -12,20 +12,22 @@ ${colors.bold('ALIASES:')}
   productive script
 
 ${colors.bold('USAGE:')}
-  productive run [run-options] <script> [script args...]
+  productive run [run-options] <script> -- [script args...]
 
 ${colors.bold('ARGUMENTS:')}
   <script>            Path to a .ts, .js, or .mjs script file
-  [script args...]    Arguments forwarded to the script verbatim, parsed into
-                      \`args\` (positionals) and \`flags\` (named)
+  [script args...]    Arguments after \`--\`, forwarded to the script verbatim and
+                      parsed inside it into \`args\` (positionals) and \`flags\` (named)
 
 ${colors.bold('DESCRIPTION:')}
   Executes a script with credentials already loaded from the CLI config
   (keychain, config file, environment variables, or CLI flags).
 
-  Flags placed ${colors.bold('before')} the script path configure \`run\` itself (credentials,
-  --dry-run, --list). Everything ${colors.bold('after')} the script path is forwarded to the
-  script untouched, so the script can define its own --flags freely.
+  Use a \`--\` separator to split run-options from script args. Everything
+  ${colors.bold('before')} \`--\` configures \`run\` itself (the script path, credentials,
+  --dry-run, --list). Everything ${colors.bold('after')} \`--\` is forwarded to the script
+  untouched, so a script can define its own --flags without colliding with the
+  CLI's. Without a \`--\`, all flags are treated as run-options.
 
   Use \`--list\` to discover scripts in a directory (defaults to \`./scripts\`)
   without running any of them. Scripts can export a \`meta\` object to provide
@@ -69,8 +71,8 @@ ${colors.bold('DESCRIPTION:')}
 ${colors.bold('AVAILABLE GLOBALS:')}
   productive          Pre-configured Productive SDK client
   output              Output utilities (see below)
-  args                Positional arguments after the script path (strings only)
-  flags               Named flags parsed from the script arguments
+  args                Positional arguments after \`--\` (strings only)
+  flags               Named flags parsed from the arguments after \`--\`
 
 ${colors.bold('OUTPUT UTILITIES:')}
   output.table(data)        Render an array of objects as an ASCII table
@@ -109,11 +111,11 @@ ${colors.bold('EXAMPLES:')}
   # Run a TypeScript script
   productive run ./scripts/weekly-report.ts
 
-  # Pass named flags (available as \`flags.from\`, \`flags.to\`, \`flags.mine\`)
-  productive run ./scripts/export-time.ts --from 2025-01-01 --to 2025-01-31 --mine
+  # Pass named flags after -- (available as \`flags.from\`, \`flags.to\`, \`flags.mine\`)
+  productive run ./scripts/export-time.ts -- --from 2025-01-01 --to 2025-01-31 --mine
 
-  # Override credentials for this run (run-options go BEFORE the script path)
-  productive run --token $TOKEN --org-id $ORG_ID ./scripts/audit.ts
+  # Override credentials for this run (run-options go before --)
+  productive run ./scripts/audit.ts --token $TOKEN --org-id $ORG_ID -- --verbose
 
   # Test a script without making any mutating API calls
   productive run --dry-run ./scripts/bulk-update.ts

--- a/packages/cli/src/commands/run/help.ts
+++ b/packages/cli/src/commands/run/help.ts
@@ -12,15 +12,20 @@ ${colors.bold('ALIASES:')}
   productive script
 
 ${colors.bold('USAGE:')}
-  productive run <script> [args...]
+  productive run [run-options] <script> [script args...]
 
 ${colors.bold('ARGUMENTS:')}
   <script>            Path to a .ts, .js, or .mjs script file
-  [args...]           Arguments forwarded to the script as \`args\`
+  [script args...]    Arguments forwarded to the script verbatim, parsed into
+                      \`args\` (positionals) and \`flags\` (named)
 
 ${colors.bold('DESCRIPTION:')}
   Executes a script with credentials already loaded from the CLI config
   (keychain, config file, environment variables, or CLI flags).
+
+  Flags placed ${colors.bold('before')} the script path configure \`run\` itself (credentials,
+  --dry-run, --list). Everything ${colors.bold('after')} the script path is forwarded to the
+  script untouched, so the script can define its own --flags freely.
 
   Use \`--list\` to discover scripts in a directory (defaults to \`./scripts\`)
   without running any of them. Scripts can export a \`meta\` object to provide
@@ -107,8 +112,8 @@ ${colors.bold('EXAMPLES:')}
   # Pass named flags (available as \`flags.from\`, \`flags.to\`, \`flags.mine\`)
   productive run ./scripts/export-time.ts --from 2025-01-01 --to 2025-01-31 --mine
 
-  # Override credentials for this run
-  productive run ./scripts/audit.ts --token $TOKEN --org-id $ORG_ID
+  # Override credentials for this run (run-options go BEFORE the script path)
+  productive run --token $TOKEN --org-id $ORG_ID ./scripts/audit.ts
 
   # Test a script without making any mutating API calls
   productive run --dry-run ./scripts/bulk-update.ts

--- a/packages/cli/src/commands/run/index.ts
+++ b/packages/cli/src/commands/run/index.ts
@@ -1,2 +1,2 @@
-export { handleRunCommand } from './command.js';
+export { extractRunArgs, handleRunCommand } from './command.js';
 export { showRunHelp } from './help.js';

--- a/packages/cli/src/utils/args.test.ts
+++ b/packages/cli/src/utils/args.test.ts
@@ -68,6 +68,30 @@ describe('parseArgs', () => {
     expect(result.options['no-color']).toBe(true);
   });
 
+  describe('-- end-of-options separator', () => {
+    it('forwards everything after -- as positionals without parsing flags', () => {
+      const result = parseArgs(['run', './script.mjs', '--', '--from', '2025-01-01', '-v']);
+      expect(result.command).toEqual(['run']);
+      expect(result.positional).toEqual(['./script.mjs', '--from', '2025-01-01', '-v']);
+      // Post-separator flags must NOT leak into options
+      expect(result.options.from).toBeUndefined();
+      expect(result.options.v).toBeUndefined();
+    });
+
+    it('does not set a bogus empty-key option for a bare --', () => {
+      const result = parseArgs(['--']);
+      expect(result.options).toEqual({});
+      expect(result.positional).toEqual([]);
+    });
+
+    it('keeps flags before -- as options', () => {
+      const result = parseArgs(['--format', 'json', '--', '--version']);
+      expect(result.options.format).toBe('json');
+      expect(result.options.version).toBeUndefined();
+      expect(result.positional).toEqual(['--version']);
+    });
+  });
+
   describe('repeatable options', () => {
     it('should collect repeated --filter into array', () => {
       const result = parseArgs(['--filter', 'project_id=123', '--filter', 'status=1']);

--- a/packages/cli/src/utils/args.ts
+++ b/packages/cli/src/utils/args.ts
@@ -37,6 +37,17 @@ export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
 
+    if (arg === '--') {
+      // End-of-options separator (getopt convention): forward the remaining
+      // tokens verbatim as positionals so they are never parsed as flags. This
+      // keeps a passthrough command's args (e.g. `productive run … -- --flag`)
+      // out of the global option set.
+      for (let j = i + 1; j < argv.length; j++) {
+        positional.push(argv[j]);
+      }
+      break;
+    }
+
     if (arg.startsWith('--')) {
       // Long option: --key=value or --key value or --flag
       const equalIndex = arg.indexOf('=');

--- a/tests/integration/cli/run.test.ts
+++ b/tests/integration/cli/run.test.ts
@@ -51,24 +51,32 @@ describe('CLI: run argument forwarding', () => {
     await mockServer.close();
   });
 
-  it('forwards named flags after the script path (the reported bug)', async () => {
-    const result = await cli.run('run', scriptPath, '--from', '2025-01-01', '--to', '2025-01-31');
+  it('forwards named flags placed after the -- separator (the reported bug)', async () => {
+    const result = await cli.run(
+      'run',
+      scriptPath,
+      '--',
+      '--from',
+      '2025-01-01',
+      '--to',
+      '2025-01-31',
+    );
 
     expect(result.exitCode).toBe(0);
     const { flags } = parseForwarded(result.stdout);
     expect(flags).toEqual({ from: '2025-01-01', to: '2025-01-31' });
   });
 
-  it('forwards a boolean named flag', async () => {
-    const result = await cli.run('run', scriptPath, '--mine');
+  it('forwards a boolean named flag after --', async () => {
+    const result = await cli.run('run', scriptPath, '--', '--mine');
 
     expect(result.exitCode).toBe(0);
     const { flags } = parseForwarded(result.stdout);
     expect(flags.mine).toBe(true);
   });
 
-  it('forwards positional args after a slash-containing script path (no module-not-found crash)', async () => {
-    const result = await cli.run('run', scriptPath, '2025-01-01', '2025-01-31');
+  it('forwards positional args after -- with no module-not-found crash', async () => {
+    const result = await cli.run('run', scriptPath, '--', '2025-01-01', '2025-01-31');
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).not.toContain('ERR_MODULE_NOT_FOUND');
@@ -76,8 +84,16 @@ describe('CLI: run argument forwarding', () => {
     expect(args).toEqual(['2025-01-01', '2025-01-31']);
   });
 
-  it('treats a leading --dry-run as a CLI flag and still forwards script flags', async () => {
-    const result = await cli.run('run', '--dry-run', scriptPath, '--from', 'x');
+  it('forwards --version after -- to the script instead of printing the CLI version', async () => {
+    const result = await cli.run('run', scriptPath, '--', '--version');
+
+    expect(result.exitCode).toBe(0);
+    const { flags } = parseForwarded(result.stdout);
+    expect(flags.version).toBe(true);
+  });
+
+  it('treats a leading --dry-run as a run-option and still forwards script flags after --', async () => {
+    const result = await cli.run('run', '--dry-run', scriptPath, '--', '--from', 'x');
 
     expect(result.exitCode).toBe(0);
     const { flags } = parseForwarded(result.stdout);
@@ -85,7 +101,7 @@ describe('CLI: run argument forwarding', () => {
   });
 
   it('supports the `script` alias', async () => {
-    const result = await cli.run('script', scriptPath, '--from', 'y');
+    const result = await cli.run('script', scriptPath, '--', '--from', 'y');
 
     expect(result.exitCode).toBe(0);
     const { flags } = parseForwarded(result.stdout);

--- a/tests/integration/cli/run.test.ts
+++ b/tests/integration/cli/run.test.ts
@@ -1,0 +1,94 @@
+/**
+ * CLI integration tests — `productive run` argument forwarding
+ *
+ * Exercises the real CLI binary end-to-end: spawns `productive run <script>`
+ * with assorted argument shapes and asserts that the script actually receives
+ * the forwarded positional args and named flags.
+ *
+ * This is the coverage the issue (#176) called out as missing — the previous
+ * unit test called the handler directly with flags already present, so it never
+ * exercised the path where the global arg parser strips them before `run` runs.
+ */
+
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import { createCliRunner, type CliRunner } from '../helpers/cli-runner.js';
+import { startMockServer, type MockServer } from '../helpers/mock-server.js';
+
+/**
+ * A pattern-B script that echoes the forwarded args/flags as JSON on a marked
+ * line. It makes no API calls, so the mock server is never hit.
+ */
+const ECHO_SCRIPT = `export const meta = { name: 'Echo' };
+console.log('FORWARDED:' + JSON.stringify({ args: globalThis.args, flags: globalThis.flags }));
+`;
+
+/** Parse the `FORWARDED:{...}` line out of the script's stdout. */
+function parseForwarded(stdout: string): { args: string[]; flags: Record<string, unknown> } {
+  const line = stdout.split('\n').find((l) => l.startsWith('FORWARDED:'));
+  if (!line) {
+    throw new Error(`No FORWARDED line in output:\n${stdout}`);
+  }
+  return JSON.parse(line.slice('FORWARDED:'.length));
+}
+
+describe('CLI: run argument forwarding', () => {
+  let mockServer: MockServer;
+  let cli: CliRunner;
+  let scriptPath: string;
+
+  beforeAll(async () => {
+    mockServer = await startMockServer();
+    cli = await createCliRunner(mockServer.apiUrl);
+    scriptPath = join(cli.sandbox.dir, 'echo.mjs');
+    await writeFile(scriptPath, ECHO_SCRIPT);
+  });
+
+  afterAll(async () => {
+    await cli.sandbox.cleanup();
+    await mockServer.close();
+  });
+
+  it('forwards named flags after the script path (the reported bug)', async () => {
+    const result = await cli.run('run', scriptPath, '--from', '2025-01-01', '--to', '2025-01-31');
+
+    expect(result.exitCode).toBe(0);
+    const { flags } = parseForwarded(result.stdout);
+    expect(flags).toEqual({ from: '2025-01-01', to: '2025-01-31' });
+  });
+
+  it('forwards a boolean named flag', async () => {
+    const result = await cli.run('run', scriptPath, '--mine');
+
+    expect(result.exitCode).toBe(0);
+    const { flags } = parseForwarded(result.stdout);
+    expect(flags.mine).toBe(true);
+  });
+
+  it('forwards positional args after a slash-containing script path (no module-not-found crash)', async () => {
+    const result = await cli.run('run', scriptPath, '2025-01-01', '2025-01-31');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain('ERR_MODULE_NOT_FOUND');
+    const { args } = parseForwarded(result.stdout);
+    expect(args).toEqual(['2025-01-01', '2025-01-31']);
+  });
+
+  it('treats a leading --dry-run as a CLI flag and still forwards script flags', async () => {
+    const result = await cli.run('run', '--dry-run', scriptPath, '--from', 'x');
+
+    expect(result.exitCode).toBe(0);
+    const { flags } = parseForwarded(result.stdout);
+    expect(flags).toEqual({ from: 'x' });
+  });
+
+  it('supports the `script` alias', async () => {
+    const result = await cli.run('script', scriptPath, '--from', 'y');
+
+    expect(result.exitCode).toBe(0);
+    const { flags } = parseForwarded(result.stdout);
+    expect(flags).toEqual({ from: 'y' });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #176 — `productive run <script> [args...]` never forwarded named flags to the script (`flags` was always `{}`), and positional args after a slash-containing script path were misclassified (a value was mistaken for the script path → `ERR_MODULE_NOT_FOUND`).

### Root cause

The **global** CLI arg parser (`parseArgs`) ran over the whole command line before the `run` handler: every `--flag` was consumed into `options` (never reaching the script) and slash-less tokens were routed into `command`.

### Fix — an explicit `--` separator

```
productive run [run-options] <script> -- [script args...]
```

Everything **before** `--` configures `run` itself (the script path, credentials, `--dry-run`, `--list`, `--format`, `--help`, `--version`). Everything **after** `--` is forwarded to the script verbatim and parsed inside it into `args` (positionals) and `flags` (named). Without a `--`, all flags are treated as run-options.

This separator-based contract is predictable and unambiguous, and resolves the three gaps an earlier extension-heuristic attempt left (surfaced in self-review):

- **`--version`/`-v`/`--help` after the script** no longer hit the global handlers in `main()` and exit early — `parseArgs` now treats a bare `--` as end-of-options (getopt convention), so post-`--` tokens stay out of the global option set and reach the script.
- **Credentials** are run-options (before `--`) and reliably reach `createContext`, instead of leaking into the script's args.
- **`--dry-run`** is passed to `scriptRun` as an explicit boolean rather than round-tripped through the arg list, so a script may define its own `--dry-run` after `--` without it being intercepted.

### Key changes

- `utils/args.ts` — `parseArgs` forwards everything after a bare `--` as positionals without flag parsing.
- `commands/run/command.ts` — `extractRunArgs` splits at `--` and returns `{ cliArgs, scriptPath, scriptArgs }` (script path detected by JS/TS extension among the run-options); `handleRunCommand(scriptPath, scriptArgs, options)` skips context creation in `--list` mode.
- `commands/run/handlers.ts` — `scriptRun(rawArgs, ctx, { dryRun }, resolver)`.
- `cli.ts` — builds the run invocation from the `--` split; `--help` computed from the run-options only.

## Test coverage

The issue called out that the only forwarding test bypassed `parseArgs`/`handleRunCommand`. This PR adds:

- **Unit tests** for `extractRunArgs` (the `--` split, script-path detection, slash-less/absolute paths, all extensions, `--list`, the `script` alias, first-`--`-only splitting) and for `parseArgs` `--` end-of-options handling.
- **An argv → handler forwarding test** (`extractRunArgs` → `parseArgs` → `handleRunCommand` → `scriptRun`).
- **A real end-to-end CLI integration test** (`tests/integration/cli/run.test.ts`) spawning the actual binary, including `--version` after `--` being forwarded to the script.

## Verification

Manually verified against the built binary:

| Command | Result |
| --- | --- |
| `run ./report.mjs -- --from 2025-01-01 --to 2025-01-31` | `flags: {from, to}` |
| `run ./report.mjs -- 2025-01-01 2025-01-31` | `args: [...]`, no crash |
| `run ./report.mjs -- --version` | forwarded → `flags.version: true` |
| `run --dry-run ./report.mjs -- --mine` | dry-run mode + `flags.mine: true` |
| `run --list ./dir` | lists scripts |
| `run --version` (no script) | prints CLI version |

## Checks

- `npm run check` (lint, format, typecheck, colocation) ✅
- `npm run test` — 3745 unit tests ✅
- `npm run test:integration` — 48 integration tests (incl. 6 for run) ✅
- pre-push build + test ✅

Docs updated: `run` help text, `packages/cli/skills/SKILL.md`, `packages/cli/examples/README.md`, and `CHANGELOG.md`.

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
