### PR TITLE
Add a sandboxed run_script tool to the MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **MCP**: Add a sandboxed `run_script` tool that runs agent-authored JavaScript/TypeScript in a QuickJS WASM isolate with no direct network or filesystem access — Productive API access is provided through an injected `productive`/`api` client whose calls are executed on the host and re-enter the same validated, rate-limited tool pipeline, with `output.*` buffering, `args`/`flags` inputs, `dry_run` mutation recording, and memory/CPU/wall-clock/API-call/output limits; disabled unless `PRODUCTIVE_MCP_ENABLE_RUN=true` ([ceb3579], [#180])
+- **MCP**: Add a sandboxed `run_script` tool that runs agent-authored JavaScript/TypeScript in a QuickJS WASM isolate with no direct network or filesystem access — Productive API access is provided through an injected `productive`/`api` client whose calls are executed on the host and re-enter the same validated, rate-limited tool pipeline, with `args`/`flags` inputs, `dry_run` mutation recording, and memory/CPU/wall-clock/API-call/output limits. Results are returned as MCP `structuredContent` (with a declared `outputSchema`) plus a Markdown rendering in the text block — `output.table`/`csv`/`json` become Markdown tables and fenced code blocks. Disabled unless `PRODUCTIVE_MCP_ENABLE_RUN=true` ([ceb3579], [#180])
 
 [#180]: https://github.com/studiometa/productive-tools/pull/180
 [ceb3579]: https://github.com/studiometa/productive-tools/commit/ceb3579

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **MCP**: Add a sandboxed `run_script` tool that runs agent-authored JavaScript/TypeScript in a QuickJS WASM isolate with no network or filesystem access — scripts reach Productive only through an injected `productive`/`api` client that re-enters the same validated, rate-limited tool pipeline, with `output.*` buffering, `args`/`flags` inputs, `dry_run` mutation recording, and memory/CPU/wall-clock/API-call/output limits; disabled unless `PRODUCTIVE_MCP_ENABLE_RUN=true` ([ceb3579], [#180])
+- **MCP**: Add a sandboxed `run_script` tool that runs agent-authored JavaScript/TypeScript in a QuickJS WASM isolate with no direct network or filesystem access — Productive API access is provided through an injected `productive`/`api` client whose calls are executed on the host and re-enter the same validated, rate-limited tool pipeline, with `output.*` buffering, `args`/`flags` inputs, `dry_run` mutation recording, and memory/CPU/wall-clock/API-call/output limits; disabled unless `PRODUCTIVE_MCP_ENABLE_RUN=true` ([ceb3579], [#180])
 
 [#180]: https://github.com/studiometa/productive-tools/pull/180
 [ceb3579]: https://github.com/studiometa/productive-tools/commit/ceb3579

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP**: Add a sandboxed `run_script` tool that runs agent-authored JavaScript/TypeScript in a QuickJS WASM isolate with no network or filesystem access — scripts reach Productive only through an injected `productive`/`api` client that re-enters the same validated, rate-limited tool pipeline, with `output.*` buffering, `args`/`flags` inputs, `dry_run` mutation recording, and memory/CPU/wall-clock/API-call/output limits; disabled unless `PRODUCTIVE_MCP_ENABLE_RUN=true` ([ceb3579], [#180])
+
+[#180]: https://github.com/studiometa/productive-tools/pull/180
+[ceb3579]: https://github.com/studiometa/productive-tools/commit/ceb3579
+
 ## [0.10.14] - 2026.06.09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -132,6 +132,21 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jitl/quickjs-ffi-types": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-ffi-types/-/quickjs-ffi-types-0.32.0.tgz",
+      "integrity": "sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==",
+      "license": "MIT"
+    },
+    "node_modules/@jitl/quickjs-singlefile-cjs-release-sync": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@jitl/quickjs-singlefile-cjs-release-sync/-/quickjs-singlefile-cjs-release-sync-0.32.0.tgz",
+      "integrity": "sha512-NjUUcw26PoeJHND6nmflAH8nIvAJvxJ2qkSPi95wfiBqPim80GtcdWommroiWb8hh1/7fVettEwodAsGt2Mrsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -3921,6 +3936,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quickjs-emscripten-core": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/quickjs-emscripten-core/-/quickjs-emscripten-core-0.32.0.tgz",
+      "integrity": "sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jitl/quickjs-ffi-types": "0.32.0"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4877,10 +4901,12 @@
       "version": "0.10.14",
       "license": "MIT",
       "dependencies": {
+        "@jitl/quickjs-singlefile-cjs-release-sync": "^0.32.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@studiometa/productive-api": "*",
         "@studiometa/productive-core": "*",
         "h3": "^2.0.1-rc.22",
+        "quickjs-emscripten-core": "^0.32.0",
         "zod": "4.3.6"
       },
       "bin": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -81,10 +81,12 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
+    "@jitl/quickjs-singlefile-cjs-release-sync": "^0.32.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@studiometa/productive-api": "*",
     "@studiometa/productive-core": "*",
     "h3": "^2.0.1-rc.22",
+    "quickjs-emscripten-core": "^0.32.0",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/packages/mcp/skills/SKILL.md
+++ b/packages/mcp/skills/SKILL.md
@@ -104,8 +104,12 @@ Imports/`require` are not available — use the injected globals only.
 }
 ```
 
-Returns `{ result, output, _run: { apiCalls, dryRun } }`. With `dry_run: true`, mutating calls
-are not executed and are listed under `_run.recorded`.
+The response carries both forms (per the MCP structured-output convention): machine-readable
+`structuredContent` as `{ result, output, _run: { apiCalls, dryRun } }`, and a human-readable
+Markdown rendering in the text block — `output.table(rows)` becomes a Markdown table,
+`output.csv`/`output.json` become fenced code blocks, log lines are labelled, and the returned
+value appears under **Result**. With `dry_run: true`, mutating calls are not executed and are
+listed under `_run.recorded`.
 
 ### Limits (operator-configurable)
 

--- a/packages/mcp/skills/SKILL.md
+++ b/packages/mcp/skills/SKILL.md
@@ -73,7 +73,7 @@ keeps credentials out of the sandbox and constrains egress to the Productive API
 
 **Disabled by default** — the server operator must set `PRODUCTIVE_MCP_ENABLE_RUN=true`.
 
-Call **`run_script_search_docs`** (optionally with a `query`) for the full scripting API reference — globals, available resources, output rendering, `dry_run`, limits, and examples.
+Call **`run_script_search_docs`** to discover the scripting API — no query returns a table of contents, a `query` loads a topic (globals, resources, output rendering, `dry_run`, limits, examples).
 
 ### Parameters
 

--- a/packages/mcp/skills/SKILL.md
+++ b/packages/mcp/skills/SKILL.md
@@ -65,9 +65,11 @@ conditional flows — use `run_script` instead of many individual calls. It runs
 JavaScript/TypeScript script in a sandbox and returns the value the script returns plus any
 buffered output, all in a single tool call.
 
-The sandbox has **no network or filesystem access**. Scripts reach Productive only through an
-injected client, so every call goes through the same validated, rate-limited API pipeline as
-normal tool calls.
+The sandbox has **no direct network or filesystem access** — scripts cannot open sockets, call
+`fetch`, reach arbitrary URLs, or read files. Productive API access **is** available: calls made
+through the injected `productive`/`api` client are executed on the host (which performs the real
+HTTP request) and go through the same validated, rate-limited pipeline as normal tool calls. This
+keeps credentials out of the sandbox and constrains egress to the Productive API.
 
 **Disabled by default** — the server operator must set `PRODUCTIVE_MCP_ENABLE_RUN=true`.
 

--- a/packages/mcp/skills/SKILL.md
+++ b/packages/mcp/skills/SKILL.md
@@ -73,6 +73,8 @@ keeps credentials out of the sandbox and constrains egress to the Productive API
 
 **Disabled by default** — the server operator must set `PRODUCTIVE_MCP_ENABLE_RUN=true`.
 
+Call **`run_script_search_docs`** (optionally with a `query`) for the full scripting API reference — globals, available resources, output rendering, `dry_run`, limits, and examples.
+
 ### Parameters
 
 | Parameter | Type    | Description                                                          |

--- a/packages/mcp/skills/SKILL.md
+++ b/packages/mcp/skills/SKILL.md
@@ -13,7 +13,7 @@ Before your first interaction with any resource, call `action=help` with that re
 
 ## MCP Tools
 
-This server exposes one high-level tool and two low-level raw API tools.
+This server exposes one high-level tool, two low-level raw API tools, and a sandboxed scripting tool (`run_script`).
 
 ### `productive`
 
@@ -57,6 +57,59 @@ Use `action: "help"` to get detailed documentation for any resource:
 ```
 
 Returns filters, fields, includes, and examples for that resource.
+
+## Running Scripts (`run_script`)
+
+For advanced multi-step logic — fetching across resources, filtering, aggregating, or
+conditional flows — use `run_script` instead of many individual calls. It runs a
+JavaScript/TypeScript script in a sandbox and returns the value the script returns plus any
+buffered output, all in a single tool call.
+
+The sandbox has **no network or filesystem access**. Scripts reach Productive only through an
+injected client, so every call goes through the same validated, rate-limited API pipeline as
+normal tool calls.
+
+**Disabled by default** — the server operator must set `PRODUCTIVE_MCP_ENABLE_RUN=true`.
+
+### Parameters
+
+| Parameter | Type    | Description                                                          |
+| --------- | ------- | -------------------------------------------------------------------- |
+| `code`    | string  | **Required**. JavaScript/TypeScript source to run.                   |
+| `args`    | array   | Positional strings exposed to the script as `args`.                  |
+| `flags`   | object  | Named values exposed to the script as `flags`.                       |
+| `dry_run` | boolean | Record mutating calls (create/update/delete/…) instead of executing. |
+
+### Globals available inside a script
+
+- `productive(resource, action, params)` — low-level call, mirrors the `productive` tool.
+- `productive.<resource>.list(filter?, opts?)`, `.get(id, opts?)`, `.create(params)`, `.update(id, params)` — convenience accessors for data resources.
+- `api.read(path, opts?)` / `api.write(method, path, body)` — raw API access.
+- `output.json(data)`, `output.table(rows)`, `output.csv(rows)`, `output.log(...)`, `output.info/warn/error/success(msg)` — buffered output returned alongside the result.
+- `args` (string[]) and `flags` (object) — the inputs above.
+- `return <value>` to surface a result. `await` is supported.
+
+Imports/`require` are not available — use the injected globals only.
+
+### Example
+
+```json
+{
+  "name": "run_script",
+  "arguments": {
+    "code": "const projects = await productive.projects.list();\nconst tasks = await productive.tasks.list({ status: 'open' });\noutput.json({ projects: projects.length, openTasks: tasks.length });\nreturn 'summary ready';"
+  }
+}
+```
+
+Returns `{ result, output, _run: { apiCalls, dryRun } }`. With `dry_run: true`, mutating calls
+are not executed and are listed under `_run.recorded`.
+
+### Limits (operator-configurable)
+
+`PRODUCTIVE_MCP_RUN_TIMEOUT_MS` (5000), `PRODUCTIVE_MCP_RUN_MEMORY_MB` (64),
+`PRODUCTIVE_MCP_RUN_MAX_API_CALLS` (50), `PRODUCTIVE_MCP_RUN_MAX_OUTPUT_KB` (256),
+`PRODUCTIVE_MCP_RUN_MAX_CODE_KB` (128).
 
 ## Common Parameters
 

--- a/packages/mcp/src/handlers/index.ts
+++ b/packages/mcp/src/handlers/index.ts
@@ -17,6 +17,7 @@ import { ErrorMessages, UserInputError, isUserInputError } from '../errors.js';
 import {
   ApiReadToolInputSchema,
   ApiWriteToolInputSchema,
+  RunScriptToolInputSchema,
   formatValidationErrors,
 } from '../schema.js';
 import { handleActivities } from './activities.js';
@@ -38,6 +39,7 @@ import { runPreValidationGuards } from './pre-validation-guards.js';
 import { handleProjects } from './projects.js';
 import { handleReports } from './reports.js';
 import { type ResolvableResourceType } from './resolve.js';
+import { handleRunScript } from './run.js';
 import { handleSchema, handleSchemaOverview } from './schema.js';
 import { handleSearch } from './search.js';
 import { handleServices } from './services.js';
@@ -246,6 +248,14 @@ export async function executeToolWithCredentials(
       includeSuggestions: false,
       executor: () => execCtx,
     });
+  }
+
+  if (name === 'run_script') {
+    const parsed = RunScriptToolInputSchema.safeParse(args);
+    if (!parsed.success) {
+      return inputErrorResult(new UserInputError(formatValidationErrors(parsed.error)));
+    }
+    return handleRunScript(parsed.data, credentials, executeToolWithCredentials);
   }
 
   // Handle the single consolidated tool

--- a/packages/mcp/src/handlers/index.ts
+++ b/packages/mcp/src/handlers/index.ts
@@ -39,7 +39,7 @@ import { runPreValidationGuards } from './pre-validation-guards.js';
 import { handleProjects } from './projects.js';
 import { handleReports } from './reports.js';
 import { type ResolvableResourceType } from './resolve.js';
-import { handleRunScript } from './run.js';
+import { handleRunScript, handleRunScriptDocs } from './run.js';
 import { handleSchema, handleSchemaOverview } from './schema.js';
 import { handleSearch } from './search.js';
 import { handleServices } from './services.js';
@@ -248,6 +248,10 @@ export async function executeToolWithCredentials(
       includeSuggestions: false,
       executor: () => execCtx,
     });
+  }
+
+  if (name === 'run_script_search_docs') {
+    return handleRunScriptDocs(args);
   }
 
   if (name === 'run_script') {

--- a/packages/mcp/src/handlers/run.test.ts
+++ b/packages/mcp/src/handlers/run.test.ts
@@ -23,8 +23,13 @@ function jsonOk(data: unknown): ToolResult {
 }
 
 function parse(result: ToolResult): Record<string, unknown> {
+  if (result.structuredContent) return result.structuredContent as Record<string, unknown>;
+  throw new Error('expected structuredContent');
+}
+
+function text(result: ToolResult): string {
   const content = result.content[0];
-  if (content?.type === 'text') return JSON.parse(content.text);
+  if (content?.type === 'text') return content.text;
   throw new Error('unexpected result');
 }
 
@@ -79,7 +84,7 @@ describe('handleRunScript', () => {
     );
   });
 
-  it('captures buffered output', async () => {
+  it('captures buffered output in structuredContent', async () => {
     const exec = vi.fn(async () => jsonOk({})) as ToolExecutor;
     const result = await handleRunScript(
       { code: `output.json({ hello: 'world' });` },
@@ -89,6 +94,24 @@ describe('handleRunScript', () => {
     );
     const body = parse(result);
     expect(body.output).toEqual([{ type: 'json', data: { hello: 'world' } }]);
+  });
+
+  it('renders the text block as Markdown', async () => {
+    const exec = vi.fn(async () => jsonOk({})) as ToolExecutor;
+    const result = await handleRunScript(
+      {
+        code: `output.table([{ id: 1, name: 'A' }]); return 'done';`,
+      },
+      credentials,
+      exec,
+      enabledEnv,
+    );
+    const md = text(result);
+    expect(md).toContain('| id | name |');
+    expect(md).toContain('| 1 | A |');
+    expect(md).toContain('**Result:**');
+    // structuredContent still carries the raw data.
+    expect(parse(result).result).toBe('done');
   });
 
   it('records mutating calls in dry-run mode without executing them', async () => {

--- a/packages/mcp/src/handlers/run.test.ts
+++ b/packages/mcp/src/handlers/run.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for the run_script handler.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { ToolExecutor } from '../run/bridge.js';
+import type { ToolResult } from './types.js';
+
+import { handleRunScript } from './run.js';
+
+const credentials: ProductiveCredentials = {
+  apiToken: 'test-token',
+  organizationId: 'test-org',
+  userId: 'test-user',
+};
+
+const enabledEnv = { PRODUCTIVE_MCP_ENABLE_RUN: 'true' } as NodeJS.ProcessEnv;
+
+function jsonOk(data: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+function parse(result: ToolResult): Record<string, unknown> {
+  const content = result.content[0];
+  if (content?.type === 'text') return JSON.parse(content.text);
+  throw new Error('unexpected result');
+}
+
+describe('handleRunScript', () => {
+  it('is disabled unless explicitly enabled', async () => {
+    const exec = vi.fn() as unknown as ToolExecutor;
+    const result = await handleRunScript(
+      { code: 'return 1;' },
+      credentials,
+      exec,
+      {} as NodeJS.ProcessEnv,
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('PRODUCTIVE_MCP_ENABLE_RUN');
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('requires non-empty code', async () => {
+    const exec = vi.fn() as unknown as ToolExecutor;
+    const result = await handleRunScript({ code: '   ' }, credentials, exec, enabledEnv);
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('code is required');
+  });
+
+  it('rejects code exceeding the size limit', async () => {
+    const exec = vi.fn() as unknown as ToolExecutor;
+    const bigCode = `/*${'x'.repeat(1100)}*/ return 1;`;
+    const result = await handleRunScript({ code: bigCode }, credentials, exec, {
+      PRODUCTIVE_MCP_ENABLE_RUN: 'true',
+      PRODUCTIVE_MCP_RUN_MAX_CODE_KB: '1',
+    } as unknown as NodeJS.ProcessEnv);
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('too large');
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('runs a script and returns its result plus run stats', async () => {
+    const exec = vi.fn(async () => jsonOk([{ id: '1' }])) as ToolExecutor;
+    const result = await handleRunScript(
+      { code: `const t = await productive.tasks.list(); return t.length;` },
+      credentials,
+      exec,
+      enabledEnv,
+    );
+    const body = parse(result);
+    expect(body.result).toBe(1);
+    expect(body._run).toMatchObject({ apiCalls: 1, dryRun: false });
+    expect(exec).toHaveBeenCalledWith(
+      'productive',
+      expect.objectContaining({ resource: 'tasks' }),
+      credentials,
+    );
+  });
+
+  it('captures buffered output', async () => {
+    const exec = vi.fn(async () => jsonOk({})) as ToolExecutor;
+    const result = await handleRunScript(
+      { code: `output.json({ hello: 'world' });` },
+      credentials,
+      exec,
+      enabledEnv,
+    );
+    const body = parse(result);
+    expect(body.output).toEqual([{ type: 'json', data: { hello: 'world' } }]);
+  });
+
+  it('records mutating calls in dry-run mode without executing them', async () => {
+    const exec = vi.fn() as unknown as ToolExecutor;
+    const result = await handleRunScript(
+      {
+        code: `await productive.tasks.create({ title: 'X', project_id: '1', task_list_id: '2' }); return 'ok';`,
+        dry_run: true,
+      },
+      credentials,
+      exec,
+      enabledEnv,
+    );
+    const body = parse(result);
+    expect(body.result).toBe('ok');
+    expect(body._run).toMatchObject({ dryRun: true });
+    expect((body._run as { recorded: unknown[] }).recorded).toHaveLength(1);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('passes args and flags to the script', async () => {
+    const exec = vi.fn() as unknown as ToolExecutor;
+    const result = await handleRunScript(
+      { code: `return { args, flags };`, args: ['a', 1], flags: { mine: true } },
+      credentials,
+      exec,
+      enabledEnv,
+    );
+    const body = parse(result);
+    expect(body.result).toEqual({ args: ['a', '1'], flags: { mine: true } });
+  });
+
+  it('returns an error result when the script throws', async () => {
+    const exec = vi.fn() as unknown as ToolExecutor;
+    const result = await handleRunScript(
+      { code: `throw new Error('kaboom');` },
+      credentials,
+      exec,
+      enabledEnv,
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('kaboom');
+  });
+});

--- a/packages/mcp/src/handlers/run.test.ts
+++ b/packages/mcp/src/handlers/run.test.ts
@@ -8,7 +8,7 @@ import type { ProductiveCredentials } from '../auth.js';
 import type { ToolExecutor } from '../run/bridge.js';
 import type { ToolResult } from './types.js';
 
-import { handleRunScript } from './run.js';
+import { handleRunScript, handleRunScriptDocs } from './run.js';
 
 const credentials: ProductiveCredentials = {
   apiToken: 'test-token',
@@ -142,6 +142,16 @@ describe('handleRunScript', () => {
     );
     const body = parse(result);
     expect(body.result).toEqual({ args: ['a', '1'], flags: { mine: true } });
+  });
+
+  it('serves the scripting docs (full reference and filtered)', () => {
+    const full = text(handleRunScriptDocs({}));
+    expect(full).toContain('## productive client');
+    expect(full).toContain('output.table');
+
+    const filtered = text(handleRunScriptDocs({ query: 'dry_run' }));
+    expect(filtered).toContain('## dry run');
+    expect(filtered).not.toContain('## output helpers');
   });
 
   it('returns an error result when the script throws', async () => {

--- a/packages/mcp/src/handlers/run.test.ts
+++ b/packages/mcp/src/handlers/run.test.ts
@@ -144,10 +144,11 @@ describe('handleRunScript', () => {
     expect(body.result).toEqual({ args: ['a', '1'], flags: { mine: true } });
   });
 
-  it('serves the scripting docs (full reference and filtered)', () => {
-    const full = text(handleRunScriptDocs({}));
-    expect(full).toContain('## productive client');
-    expect(full).toContain('output.table');
+  it('serves a table of contents with no query and full sections when filtered', () => {
+    const toc = text(handleRunScriptDocs({}));
+    expect(toc).toContain('Call this tool again with a `query`');
+    expect(toc).toContain('**productive client**');
+    expect(toc).not.toContain('## output helpers');
 
     const filtered = text(handleRunScriptDocs({ query: 'dry_run' }));
     expect(filtered).toContain('## dry run');

--- a/packages/mcp/src/handlers/run.ts
+++ b/packages/mcp/src/handlers/run.ts
@@ -17,8 +17,9 @@ import { UserInputError } from '../errors.js';
 import { createBridge } from '../run/bridge.js';
 import { runScript, ScriptError } from '../run/engine.js';
 import { isRunScriptEnabled, resolveRunLimits } from '../run/limits.js';
+import { renderRunResult } from '../run/render.js';
 import { stripTypes } from '../run/strip.js';
-import { errorResult, inputErrorResult, jsonResult } from './utils.js';
+import { errorResult, inputErrorResult } from './utils.js';
 
 export interface RunScriptArgs {
   code?: unknown;
@@ -92,16 +93,25 @@ export async function handleRunScript(
     });
 
     const stats = bridge.getStats();
-    return jsonResult({
-      result: result.result,
-      output: result.output,
-      _run: {
-        apiCalls: stats.apiCalls,
-        dryRun,
-        ...(result.truncated ? { outputTruncated: true } : {}),
-        ...(dryRun ? { recorded: stats.recorded } : {}),
-      },
-    });
+    const run = {
+      apiCalls: stats.apiCalls,
+      dryRun,
+      ...(result.truncated ? { outputTruncated: true } : {}),
+      ...(dryRun ? { recorded: stats.recorded } : {}),
+    };
+
+    // Return both: `structuredContent` for hosts that consume structured tool
+    // output (matches the tool's declared outputSchema), and a Markdown `text`
+    // block so text-only clients see formatted tables/JSON/logs.
+    return {
+      content: [
+        {
+          type: 'text',
+          text: renderRunResult({ result: result.result, output: result.output, run }),
+        },
+      ],
+      structuredContent: { result: result.result, output: result.output, _run: run },
+    };
   } catch (error) {
     if (error instanceof ScriptError) {
       return errorResult(error.message);

--- a/packages/mcp/src/handlers/run.ts
+++ b/packages/mcp/src/handlers/run.ts
@@ -1,0 +1,113 @@
+/**
+ * Handler for the `run_script` tool.
+ *
+ * Executes an agent-authored JavaScript/TypeScript script inside a QuickJS
+ * sandbox. The script reaches Productive only through the host bridge, which
+ * re-enters `executeToolWithCredentials` — so it inherits credential scoping,
+ * rate limiting, and validation, and has no other capabilities.
+ *
+ * Disabled by default; enable with `PRODUCTIVE_MCP_ENABLE_RUN=true`.
+ */
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { BridgeChannel, ToolExecutor } from '../run/bridge.js';
+import type { ToolResult } from './types.js';
+
+import { UserInputError } from '../errors.js';
+import { createBridge } from '../run/bridge.js';
+import { runScript, ScriptError } from '../run/engine.js';
+import { isRunScriptEnabled, resolveRunLimits } from '../run/limits.js';
+import { stripTypes } from '../run/strip.js';
+import { errorResult, inputErrorResult, jsonResult } from './utils.js';
+
+export interface RunScriptArgs {
+  code?: unknown;
+  args?: unknown;
+  flags?: unknown;
+  dry_run?: unknown;
+}
+
+/** Coerce the `args` argument into a string array. */
+function normalizeArgs(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((v) => String(v));
+}
+
+/** Coerce the `flags` argument into a plain object. */
+function normalizeFlags(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+/**
+ * Execute the `run_script` tool.
+ */
+export async function handleRunScript(
+  rawArgs: RunScriptArgs,
+  credentials: ProductiveCredentials,
+  exec: ToolExecutor,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ToolResult> {
+  if (!isRunScriptEnabled(env)) {
+    return inputErrorResult(
+      new UserInputError(
+        'run_script is disabled. Set PRODUCTIVE_MCP_ENABLE_RUN=true to enable it.',
+      ),
+    );
+  }
+
+  if (typeof rawArgs.code !== 'string' || rawArgs.code.trim() === '') {
+    return inputErrorResult(
+      new UserInputError('code is required and must be a non-empty string.', [
+        'Provide a JavaScript/TypeScript script in the "code" parameter.',
+        'Available globals: productive(resource, action, params), api.read/write, output.*, args, flags.',
+        'Return a value to surface it as the result; use output.json(...) for additional data.',
+      ]),
+    );
+  }
+
+  const limits = resolveRunLimits(env);
+  const codeBytes = Buffer.byteLength(rawArgs.code, 'utf8');
+  if (codeBytes > limits.maxCodeBytes) {
+    return inputErrorResult(
+      new UserInputError(`Script is too large (${codeBytes} bytes, max ${limits.maxCodeBytes}).`),
+    );
+  }
+
+  const dryRun = rawArgs.dry_run === true;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), limits.timeoutMs);
+
+  try {
+    const bridge = createBridge({ credentials, exec, limits, dryRun, signal: controller.signal });
+    const result = await runScript({
+      code: stripTypes(rawArgs.code),
+      args: normalizeArgs(rawArgs.args),
+      flags: normalizeFlags(rawArgs.flags),
+      limits,
+      signal: controller.signal,
+      hostCall: (channel, payload) => bridge.call(channel as BridgeChannel, payload),
+    });
+
+    const stats = bridge.getStats();
+    return jsonResult({
+      result: result.result,
+      output: result.output,
+      _run: {
+        apiCalls: stats.apiCalls,
+        dryRun,
+        ...(result.truncated ? { outputTruncated: true } : {}),
+        ...(dryRun ? { recorded: stats.recorded } : {}),
+      },
+    });
+  } catch (error) {
+    if (error instanceof ScriptError) {
+      return errorResult(error.message);
+    }
+    return errorResult(error instanceof Error ? error.message : String(error));
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/mcp/src/handlers/run.ts
+++ b/packages/mcp/src/handlers/run.ts
@@ -15,6 +15,7 @@ import type { ToolResult } from './types.js';
 
 import { UserInputError } from '../errors.js';
 import { createBridge } from '../run/bridge.js';
+import { searchDocs } from '../run/docs.js';
 import { runScript, ScriptError } from '../run/engine.js';
 import { isRunScriptEnabled, resolveRunLimits } from '../run/limits.js';
 import { renderRunResult } from '../run/render.js';
@@ -26,6 +27,15 @@ export interface RunScriptArgs {
   args?: unknown;
   flags?: unknown;
   dry_run?: unknown;
+}
+
+/**
+ * Companion `run_script_search_docs` tool — returns the scripting-API reference
+ * (optionally filtered by a query). Needs no credentials or sandbox.
+ */
+export function handleRunScriptDocs(args: { query?: unknown }): ToolResult {
+  const query = typeof args.query === 'string' ? args.query : undefined;
+  return { content: [{ type: 'text', text: searchDocs(query) }] };
 }
 
 /** Coerce the `args` argument into a string array. */

--- a/packages/mcp/src/run/bridge.test.ts
+++ b/packages/mcp/src/run/bridge.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the sandbox host bridge.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { ToolResult } from '../handlers/types.js';
+import type { RunLimits } from './limits.js';
+
+import { createBridge, type ToolExecutor } from './bridge.js';
+
+const credentials: ProductiveCredentials = {
+  apiToken: 'test-token',
+  organizationId: 'test-org',
+  userId: 'test-user',
+};
+
+const limits: RunLimits = {
+  timeoutMs: 5_000,
+  memoryBytes: 64 * 1024 * 1024,
+  maxApiCalls: 3,
+  maxOutputBytes: 256 * 1024,
+  maxCodeBytes: 128 * 1024,
+};
+
+function jsonOk(data: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(data) }] };
+}
+
+function errorTool(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+function makeBridge(overrides: Partial<Parameters<typeof createBridge>[0]> = {}) {
+  const exec = overrides.exec ?? (vi.fn(async () => jsonOk({ ok: true })) as ToolExecutor);
+  const controller = new AbortController();
+  const bridge = createBridge({
+    credentials,
+    exec,
+    limits,
+    dryRun: false,
+    signal: controller.signal,
+    ...overrides,
+  });
+  return { bridge, exec, controller };
+}
+
+describe('createBridge', () => {
+  it('routes productive calls and returns parsed JSON', async () => {
+    const exec = vi.fn(async () => jsonOk([{ id: '1' }])) as ToolExecutor;
+    const { bridge } = makeBridge({ exec });
+
+    const result = await bridge.call('productive', { resource: 'tasks', action: 'list' });
+
+    expect(result).toEqual([{ id: '1' }]);
+    expect(exec).toHaveBeenCalledWith(
+      'productive',
+      { resource: 'tasks', action: 'list' },
+      credentials,
+    );
+  });
+
+  it('routes api_read and api_write to their tool names', async () => {
+    const exec = vi.fn(async () => jsonOk({ data: 1 })) as ToolExecutor;
+    const { bridge } = makeBridge({ exec });
+
+    await bridge.call('api_read', { path: '/invoices' });
+    await bridge.call('api_write', { method: 'POST', path: '/x', confirm: true });
+
+    expect(exec).toHaveBeenNthCalledWith(1, 'api_read', { path: '/invoices' }, credentials);
+    expect(exec).toHaveBeenNthCalledWith(
+      2,
+      'api_write',
+      { method: 'POST', path: '/x', confirm: true },
+      credentials,
+    );
+  });
+
+  it('throws when the tool returns an error result', async () => {
+    const exec = vi.fn(async () => errorTool('**Error:** boom')) as ToolExecutor;
+    const { bridge } = makeBridge({ exec });
+
+    await expect(bridge.call('productive', { resource: 'tasks', action: 'get' })).rejects.toThrow(
+      'boom',
+    );
+  });
+
+  it('returns raw text when the result is not JSON', async () => {
+    const exec = vi.fn(async () => ({
+      content: [{ type: 'text', text: 'plain' }],
+    })) as ToolExecutor;
+    const { bridge } = makeBridge({ exec });
+
+    expect(await bridge.call('productive', { resource: 'tasks', action: 'get' })).toBe('plain');
+  });
+
+  it('enforces the API call budget', async () => {
+    const { bridge, exec } = makeBridge();
+
+    await bridge.call('productive', { resource: 'tasks', action: 'list' });
+    await bridge.call('productive', { resource: 'tasks', action: 'list' });
+    await bridge.call('productive', { resource: 'tasks', action: 'list' });
+    await expect(bridge.call('productive', { resource: 'tasks', action: 'list' })).rejects.toThrow(
+      'API call budget exceeded (max 3)',
+    );
+
+    expect(exec).toHaveBeenCalledTimes(3);
+    expect(bridge.getStats().apiCalls).toBe(4);
+  });
+
+  it('rejects calls once the signal is aborted', async () => {
+    const { bridge, controller, exec } = makeBridge();
+    controller.abort();
+
+    await expect(bridge.call('productive', { resource: 'tasks', action: 'list' })).rejects.toThrow(
+      'timed out',
+    );
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  describe('dry run', () => {
+    it('records mutating productive actions without executing them', async () => {
+      const exec = vi.fn() as unknown as ToolExecutor;
+      const { bridge } = makeBridge({ exec, dryRun: true });
+
+      const result = await bridge.call('productive', {
+        resource: 'tasks',
+        action: 'create',
+        title: 'T',
+      });
+
+      expect(result).toMatchObject({ _dryRun: true });
+      expect(exec).not.toHaveBeenCalled();
+      expect(bridge.getStats().recorded).toHaveLength(1);
+    });
+
+    it('records api_write but still executes read-only calls', async () => {
+      const exec = vi.fn(async () => jsonOk([{ id: '1' }])) as ToolExecutor;
+      const { bridge } = makeBridge({ exec, dryRun: true });
+
+      await bridge.call('api_write', { method: 'DELETE', path: '/x', confirm: true });
+      const reads = await bridge.call('productive', { resource: 'tasks', action: 'list' });
+
+      expect(exec).toHaveBeenCalledTimes(1);
+      expect(exec).toHaveBeenCalledWith('productive', expect.anything(), credentials);
+      expect(reads).toEqual([{ id: '1' }]);
+      expect(bridge.getStats().recorded).toHaveLength(1);
+    });
+  });
+});

--- a/packages/mcp/src/run/bridge.test.ts
+++ b/packages/mcp/src/run/bridge.test.ts
@@ -106,7 +106,8 @@ describe('createBridge', () => {
     );
 
     expect(exec).toHaveBeenCalledTimes(3);
-    expect(bridge.getStats().apiCalls).toBe(4);
+    // Counter is not incremented for the rejected over-budget call.
+    expect(bridge.getStats().apiCalls).toBe(3);
   });
 
   it('rejects an unknown channel', async () => {

--- a/packages/mcp/src/run/bridge.test.ts
+++ b/packages/mcp/src/run/bridge.test.ts
@@ -47,13 +47,13 @@ function makeBridge(overrides: Partial<Parameters<typeof createBridge>[0]> = {})
 }
 
 describe('createBridge', () => {
-  it('routes productive calls and returns parsed JSON', async () => {
+  it('routes productive calls and returns the tool JSON text', async () => {
     const exec = vi.fn(async () => jsonOk([{ id: '1' }])) as ToolExecutor;
     const { bridge } = makeBridge({ exec });
 
     const result = await bridge.call('productive', { resource: 'tasks', action: 'list' });
 
-    expect(result).toEqual([{ id: '1' }]);
+    expect(JSON.parse(result)).toEqual([{ id: '1' }]);
     expect(exec).toHaveBeenCalledWith(
       'productive',
       { resource: 'tasks', action: 'list' },
@@ -86,7 +86,7 @@ describe('createBridge', () => {
     );
   });
 
-  it('returns raw text when the result is not JSON', async () => {
+  it('passes the tool text through verbatim', async () => {
     const exec = vi.fn(async () => ({
       content: [{ type: 'text', text: 'plain' }],
     })) as ToolExecutor;
@@ -139,7 +139,7 @@ describe('createBridge', () => {
         title: 'T',
       });
 
-      expect(result).toMatchObject({ _dryRun: true });
+      expect(JSON.parse(result)).toMatchObject({ _dryRun: true });
       expect(exec).not.toHaveBeenCalled();
       expect(bridge.getStats().recorded).toHaveLength(1);
     });
@@ -153,7 +153,7 @@ describe('createBridge', () => {
 
       expect(exec).toHaveBeenCalledTimes(1);
       expect(exec).toHaveBeenCalledWith('productive', expect.anything(), credentials);
-      expect(reads).toEqual([{ id: '1' }]);
+      expect(JSON.parse(reads)).toEqual([{ id: '1' }]);
       expect(bridge.getStats().recorded).toHaveLength(1);
     });
   });

--- a/packages/mcp/src/run/bridge.test.ts
+++ b/packages/mcp/src/run/bridge.test.ts
@@ -109,6 +109,14 @@ describe('createBridge', () => {
     expect(bridge.getStats().apiCalls).toBe(4);
   });
 
+  it('rejects an unknown channel', async () => {
+    const { bridge, exec } = makeBridge();
+    await expect(
+      bridge.call('evil' as unknown as 'productive', { resource: 'x', action: 'y' }),
+    ).rejects.toThrow('Unknown bridge channel: evil');
+    expect(exec).not.toHaveBeenCalled();
+  });
+
   it('rejects calls once the signal is aborted', async () => {
     const { bridge, controller, exec } = makeBridge();
     controller.abort();

--- a/packages/mcp/src/run/bridge.ts
+++ b/packages/mcp/src/run/bridge.ts
@@ -108,10 +108,12 @@ export function createBridge(opts: BridgeOptions): Bridge {
       throw new Error('Script execution timed out');
     }
 
-    apiCalls += 1;
-    if (apiCalls > opts.limits.maxApiCalls) {
+    // Check before incrementing so the counter never exceeds the budget and
+    // reported stats reflect only calls that actually proceeded.
+    if (apiCalls >= opts.limits.maxApiCalls) {
       throw new Error(`API call budget exceeded (max ${opts.limits.maxApiCalls})`);
     }
+    apiCalls += 1;
 
     if (opts.dryRun && isMutating(channel, payload)) {
       recorded.push({ channel, payload });

--- a/packages/mcp/src/run/bridge.ts
+++ b/packages/mcp/src/run/bridge.ts
@@ -42,8 +42,14 @@ export interface BridgeOptions {
 }
 
 export interface Bridge {
-  /** Execute a single bridged call, returning the parsed JSON payload. */
-  call(channel: BridgeChannel, payload: Record<string, unknown>): Promise<unknown>;
+  /**
+   * Execute a single bridged call, returning the result as a JSON **string**
+   * (the text the tool already produced). Returning text rather than a parsed
+   * value lets the engine hand it straight to the guest without an extra
+   * parse-then-restringify round trip. Throws on error results so guest-side
+   * `try/catch` works naturally.
+   */
+  call(channel: BridgeChannel, payload: Record<string, unknown>): Promise<string>;
   /** Snapshot of usage so the handler can report it. */
   getStats(): { apiCalls: number; recorded: RecordedCall[] };
 }
@@ -73,10 +79,11 @@ function toolNameFor(channel: BridgeChannel): string {
 }
 
 /**
- * Extract the JSON payload from a tool result, throwing on error results so
- * that guest-side `try/catch` works naturally.
+ * Extract the JSON text from a tool result, throwing on error results so that
+ * guest-side `try/catch` works naturally. The text is returned verbatim (MCP
+ * handlers already produce JSON via `jsonResult`); the guest parses it once.
  */
-function unwrapToolResult(result: ToolResult): unknown {
+function toJsonText(result: ToolResult): string {
   const content = result.content?.[0];
   const text = content && content.type === 'text' ? content.text : undefined;
 
@@ -86,11 +93,7 @@ function unwrapToolResult(result: ToolResult): unknown {
   if (text === undefined) {
     throw new Error('Tool returned no content');
   }
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
+  return text;
 }
 
 /**
@@ -100,7 +103,7 @@ export function createBridge(opts: BridgeOptions): Bridge {
   let apiCalls = 0;
   const recorded: RecordedCall[] = [];
 
-  async function call(channel: BridgeChannel, payload: Record<string, unknown>): Promise<unknown> {
+  async function call(channel: BridgeChannel, payload: Record<string, unknown>): Promise<string> {
     if (channel !== 'productive' && channel !== 'api_read' && channel !== 'api_write') {
       throw new Error(`Unknown bridge channel: ${channel}`);
     }
@@ -117,11 +120,11 @@ export function createBridge(opts: BridgeOptions): Bridge {
 
     if (opts.dryRun && isMutating(channel, payload)) {
       recorded.push({ channel, payload });
-      return { _dryRun: true, channel, payload };
+      return JSON.stringify({ _dryRun: true, channel, payload });
     }
 
     const result = await opts.exec(toolNameFor(channel), payload, opts.credentials);
-    return unwrapToolResult(result);
+    return toJsonText(result);
   }
 
   return {

--- a/packages/mcp/src/run/bridge.ts
+++ b/packages/mcp/src/run/bridge.ts
@@ -1,0 +1,126 @@
+/**
+ * Host-side capability bridge for sandboxed scripts.
+ *
+ * The QuickJS sandbox has no network, filesystem, or process access. The only
+ * way a script reaches Productive is through this bridge, which re-enters the
+ * exact same `executeToolWithCredentials` pipeline used by every other MCP tool
+ * call. That means scripts automatically inherit credential scoping, rate
+ * limiting, include validation, and formatting — and egress is constrained to
+ * the Productive API by construction.
+ *
+ * The bridge also enforces the per-run API-call budget, honours the run's
+ * abort signal (wall-clock timeout), and implements dry-run by classifying
+ * mutating operations and recording them instead of executing.
+ */
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { ToolResult } from '../handlers/types.js';
+import type { RunLimits } from './limits.js';
+
+/** The subset of `executeToolWithCredentials` the bridge depends on. */
+export type ToolExecutor = (
+  name: string,
+  args: Record<string, unknown>,
+  credentials: ProductiveCredentials,
+) => Promise<ToolResult>;
+
+/** Logical channels a script may call through. */
+export type BridgeChannel = 'productive' | 'api_read' | 'api_write';
+
+/** A mutating call recorded (not executed) during a dry run. */
+export interface RecordedCall {
+  channel: BridgeChannel;
+  payload: Record<string, unknown>;
+}
+
+export interface BridgeOptions {
+  credentials: ProductiveCredentials;
+  exec: ToolExecutor;
+  limits: RunLimits;
+  dryRun: boolean;
+  signal: AbortSignal;
+}
+
+export interface Bridge {
+  /** Execute a single bridged call, returning the parsed JSON payload. */
+  call(channel: BridgeChannel, payload: Record<string, unknown>): Promise<unknown>;
+  /** Snapshot of usage so the handler can report it. */
+  getStats(): { apiCalls: number; recorded: RecordedCall[] };
+}
+
+/** Productive actions that mutate data — intercepted in dry-run mode. */
+const MUTATING_ACTIONS = new Set([
+  'create',
+  'update',
+  'delete',
+  'start',
+  'stop',
+  'reopen',
+  'complete_task',
+  'log_day',
+]);
+
+/** Whether a call would mutate data (used for dry-run classification). */
+function isMutating(channel: BridgeChannel, payload: Record<string, unknown>): boolean {
+  if (channel === 'api_write') return true;
+  if (channel === 'productive') return MUTATING_ACTIONS.has(String(payload.action));
+  return false;
+}
+
+/** Map a channel to its tool name. */
+function toolNameFor(channel: BridgeChannel): string {
+  return channel === 'productive' ? 'productive' : channel;
+}
+
+/**
+ * Extract the JSON payload from a tool result, throwing on error results so
+ * that guest-side `try/catch` works naturally.
+ */
+function unwrapToolResult(result: ToolResult): unknown {
+  const content = result.content?.[0];
+  const text = content && content.type === 'text' ? content.text : undefined;
+
+  if (result.isError) {
+    throw new Error(text ?? 'Unknown tool error');
+  }
+  if (text === undefined) {
+    throw new Error('Tool returned no content');
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * Create a bridge bound to a set of credentials and limits.
+ */
+export function createBridge(opts: BridgeOptions): Bridge {
+  let apiCalls = 0;
+  const recorded: RecordedCall[] = [];
+
+  async function call(channel: BridgeChannel, payload: Record<string, unknown>): Promise<unknown> {
+    if (opts.signal.aborted) {
+      throw new Error('Script execution timed out');
+    }
+
+    apiCalls += 1;
+    if (apiCalls > opts.limits.maxApiCalls) {
+      throw new Error(`API call budget exceeded (max ${opts.limits.maxApiCalls})`);
+    }
+
+    if (opts.dryRun && isMutating(channel, payload)) {
+      recorded.push({ channel, payload });
+      return { _dryRun: true, channel, payload };
+    }
+
+    const result = await opts.exec(toolNameFor(channel), payload, opts.credentials);
+    return unwrapToolResult(result);
+  }
+
+  return {
+    call,
+    getStats: () => ({ apiCalls, recorded: [...recorded] }),
+  };
+}

--- a/packages/mcp/src/run/bridge.ts
+++ b/packages/mcp/src/run/bridge.ts
@@ -1,10 +1,10 @@
 /**
  * Host-side capability bridge for sandboxed scripts.
  *
- * The QuickJS sandbox has no network, filesystem, or process access. The only
- * way a script reaches Productive is through this bridge, which re-enters the
- * exact same `executeToolWithCredentials` pipeline used by every other MCP tool
- * call. That means scripts automatically inherit credential scoping, rate
+ * The QuickJS sandbox has no direct network, filesystem, or process access.
+ * The only way a script reaches the Productive API is through this bridge,
+ * which re-enters the exact same `executeToolWithCredentials` pipeline used by
+ * every other MCP tool call — the real HTTP request happens here, on the host. That means scripts automatically inherit credential scoping, rate
  * limiting, include validation, and formatting — and egress is constrained to
  * the Productive API by construction.
  *

--- a/packages/mcp/src/run/bridge.ts
+++ b/packages/mcp/src/run/bridge.ts
@@ -101,6 +101,9 @@ export function createBridge(opts: BridgeOptions): Bridge {
   const recorded: RecordedCall[] = [];
 
   async function call(channel: BridgeChannel, payload: Record<string, unknown>): Promise<unknown> {
+    if (channel !== 'productive' && channel !== 'api_read' && channel !== 'api_write') {
+      throw new Error(`Unknown bridge channel: ${channel}`);
+    }
     if (opts.signal.aborted) {
       throw new Error('Script execution timed out');
     }

--- a/packages/mcp/src/run/docs.test.ts
+++ b/packages/mcp/src/run/docs.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests for the run_script scripting-API docs.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { searchDocs, DOC_SECTIONS } from './docs.js';
+import { SCRIPT_RESOURCES } from './prelude.js';
+
+describe('searchDocs', () => {
+  it('returns the full reference when no query is given', () => {
+    const docs = searchDocs();
+    for (const section of DOC_SECTIONS) {
+      expect(docs).toContain(`## ${section.title}`);
+    }
+    expect(docs).toContain('productive(resource, action, params)');
+    expect(docs).toContain('output.table');
+  });
+
+  it('lists the actual script resources (derived from the prelude)', () => {
+    const docs = searchDocs();
+    for (const resource of SCRIPT_RESOURCES) {
+      expect(docs).toContain(resource);
+    }
+  });
+
+  it('filters to matching sections by keyword', () => {
+    const docs = searchDocs('csv');
+    expect(docs).toContain('## output helpers');
+    expect(docs).not.toContain('## dry run');
+  });
+
+  it('matches on title and keyword aliases', () => {
+    expect(searchDocs('dry_run')).toContain('## dry run');
+    expect(searchDocs('api')).toContain('## api client (raw)');
+  });
+
+  it('is case-insensitive', () => {
+    expect(searchDocs('TABLE')).toContain('## output helpers');
+  });
+
+  it('returns a topic index when nothing matches', () => {
+    const docs = searchDocs('zzz-nonexistent');
+    expect(docs).toContain('No sections matched');
+    expect(docs).toContain('Available topics:');
+    expect(docs).toContain('Overview');
+  });
+});

--- a/packages/mcp/src/run/docs.test.ts
+++ b/packages/mcp/src/run/docs.test.ts
@@ -8,17 +8,28 @@ import { searchDocs, DOC_SECTIONS } from './docs.js';
 import { SCRIPT_RESOURCES } from './prelude.js';
 
 describe('searchDocs', () => {
-  it('returns the full reference when no query is given', () => {
+  it('returns a compact table of contents when no query is given', () => {
     const docs = searchDocs();
+    // Lists every section title and its summary as a bullet...
     for (const section of DOC_SECTIONS) {
-      expect(docs).toContain(`## ${section.title}`);
+      expect(docs).toContain(`**${section.title}**`);
+      expect(docs).toContain(section.summary);
     }
-    expect(docs).toContain('productive(resource, action, params)');
-    expect(docs).toContain('output.table');
+    expect(docs).toContain('Call this tool again with a `query`');
+    // ...but does NOT inline the full section bodies.
+    expect(docs).not.toContain('## productive client');
+    expect(docs).not.toContain('output.table(rows)');
   });
 
-  it('lists the actual script resources (derived from the prelude)', () => {
-    const docs = searchDocs();
+  it('returns full section bodies only when queried', () => {
+    const docs = searchDocs('productive');
+    expect(docs).toContain('## productive client');
+    expect(docs).toContain('productive(resource, action, params)');
+  });
+
+  it('lists the actual script resources when querying that topic', () => {
+    const docs = searchDocs('resources');
+    expect(docs).toContain('## resources & actions');
     for (const resource of SCRIPT_RESOURCES) {
       expect(docs).toContain(resource);
     }
@@ -39,10 +50,10 @@ describe('searchDocs', () => {
     expect(searchDocs('TABLE')).toContain('## output helpers');
   });
 
-  it('returns a topic index when nothing matches', () => {
+  it('falls back to the table of contents when nothing matches', () => {
     const docs = searchDocs('zzz-nonexistent');
     expect(docs).toContain('No sections matched');
-    expect(docs).toContain('Available topics:');
-    expect(docs).toContain('Overview');
+    expect(docs).toContain('Call this tool again with a `query`');
+    expect(docs).toContain('**Overview**');
   });
 });

--- a/packages/mcp/src/run/docs.ts
+++ b/packages/mcp/src/run/docs.ts
@@ -4,7 +4,9 @@
  *
  * Keeping the full reference here (returned in a tool *response*) rather than in
  * the `run_script` tool's `inputSchema`/`description` keeps the tool definition
- * small while still making the API discoverable on demand.
+ * small while still making the API discoverable on demand. Calling the tool
+ * with no query returns a compact table of contents (cheap); a query returns
+ * only the matching sections — so the full reference is never loaded wholesale.
  *
  * The resource list is derived from {@link SCRIPT_RESOURCES} so it can't drift
  * from what the prelude actually exposes.
@@ -14,6 +16,8 @@ import { SCRIPT_RESOURCES } from './prelude.js';
 
 export interface DocSection {
   title: string;
+  /** One-line description shown in the table of contents. */
+  summary: string;
   keywords: string[];
   body: string;
 }
@@ -21,6 +25,7 @@ export interface DocSection {
 export const DOC_SECTIONS: DocSection[] = [
   {
     title: 'Overview',
+    summary: 'What run_script is and how the sandbox works.',
     keywords: ['overview', 'intro', 'sandbox', 'how', 'start'],
     body: [
       '`run_script` runs JavaScript/TypeScript in a sandboxed QuickJS isolate. There is no direct',
@@ -31,6 +36,7 @@ export const DOC_SECTIONS: DocSection[] = [
   },
   {
     title: 'productive client',
+    summary: 'productive(...) and per-resource list/get/create/update accessors.',
     keywords: [
       'productive',
       'client',
@@ -55,6 +61,7 @@ export const DOC_SECTIONS: DocSection[] = [
   },
   {
     title: 'api client (raw)',
+    summary: 'api.read / api.write for raw API endpoints.',
     keywords: ['api', 'read', 'write', 'raw', 'endpoint', 'path', 'fetch'],
     body: [
       '`api.read(path, opts?)` — raw GET, e.g. `await api.read("/invoices", { page: 2 })`.',
@@ -63,6 +70,7 @@ export const DOC_SECTIONS: DocSection[] = [
   },
   {
     title: 'output helpers',
+    summary: 'output.json/table/csv/log/... and how they render.',
     keywords: [
       'output',
       'table',
@@ -87,6 +95,7 @@ export const DOC_SECTIONS: DocSection[] = [
   },
   {
     title: 'args, flags & result',
+    summary: 'Inputs (args, flags) and returning a result.',
     keywords: ['args', 'flags', 'input', 'parameters', 'return', 'result'],
     body: [
       '`args` (string[]) and `flags` (object) are the values passed in the tool call.',
@@ -95,6 +104,7 @@ export const DOC_SECTIONS: DocSection[] = [
   },
   {
     title: 'resources & actions',
+    summary: 'Available resources and how to discover their filters/fields.',
     keywords: ['resources', 'actions', 'help', 'schema', 'filters', 'fields', 'includes'],
     body: [
       `Resource accessors: ${SCRIPT_RESOURCES.join(', ')}.`,
@@ -106,11 +116,13 @@ export const DOC_SECTIONS: DocSection[] = [
   },
   {
     title: 'dry run',
+    summary: 'Preview mutations without executing them (dry_run).',
     keywords: ['dry_run', 'dry', 'preview', 'mutation', 'safe'],
     body: 'Pass `dry_run: true` to record mutating calls (create/update/delete/start/stop/...) instead of executing them; they are listed under `_run.recorded`.',
   },
   {
     title: 'limits & gating',
+    summary: 'Timeouts, memory, budgets, and the enable flag.',
     keywords: ['limit', 'limits', 'timeout', 'memory', 'budget', 'gating', 'enable', 'disabled'],
     body: [
       'Disabled unless the server sets `PRODUCTIVE_MCP_ENABLE_RUN=true`.',
@@ -119,6 +131,7 @@ export const DOC_SECTIONS: DocSection[] = [
   },
   {
     title: 'example',
+    summary: 'A complete example script.',
     keywords: ['example', 'examples', 'sample'],
     body: [
       '```js',
@@ -131,22 +144,39 @@ export const DOC_SECTIONS: DocSection[] = [
   },
 ];
 
+const HEADER = '# run_script scripting API';
+
 /** Render a single section as Markdown. */
 function renderSection(section: DocSection): string {
   return `## ${section.title}\n\n${section.body}`;
 }
 
+/** Render a compact table of contents with query hints. */
+function renderTableOfContents(): string {
+  const lines = DOC_SECTIONS.map((section) => {
+    const hint = section.keywords.slice(0, 3).join(', ');
+    return `- **${section.title}** — ${section.summary} _(query: ${hint})_`;
+  });
+  return [
+    HEADER,
+    '',
+    'Call this tool again with a `query` (e.g. one of the terms in parentheses) to load a topic.',
+    '',
+    ...lines,
+  ].join('\n');
+}
+
 /**
- * Return the scripting-API reference, optionally filtered by a query. With no
- * query the full reference is returned; with a query, only matching sections
- * (falling back to a topic index when nothing matches).
+ * Return the scripting-API reference. With no query, a compact table of
+ * contents is returned (so the full reference is never loaded wholesale); with
+ * a query, only the matching sections (falling back to the table of contents
+ * when nothing matches).
  */
 export function searchDocs(query?: string): string {
-  const header = '# run_script scripting API';
   const q = query?.trim().toLowerCase();
 
   if (!q) {
-    return `${header}\n\n${DOC_SECTIONS.map(renderSection).join('\n\n')}`;
+    return renderTableOfContents();
   }
 
   const matches = DOC_SECTIONS.filter(
@@ -157,9 +187,8 @@ export function searchDocs(query?: string): string {
   );
 
   if (matches.length === 0) {
-    const topics = DOC_SECTIONS.map((s) => s.title).join(', ');
-    return `${header}\n\nNo sections matched "${query}". Available topics: ${topics}.`;
+    return `${HEADER}\n\nNo sections matched "${query}".\n\n${renderTableOfContents()}`;
   }
 
-  return `${header}\n\n${matches.map(renderSection).join('\n\n')}`;
+  return `${HEADER}\n\n${matches.map(renderSection).join('\n\n')}`;
 }

--- a/packages/mcp/src/run/docs.ts
+++ b/packages/mcp/src/run/docs.ts
@@ -1,0 +1,165 @@
+/**
+ * Scripting-API reference for `run_script`, served by the companion
+ * `run_script_search_docs` tool.
+ *
+ * Keeping the full reference here (returned in a tool *response*) rather than in
+ * the `run_script` tool's `inputSchema`/`description` keeps the tool definition
+ * small while still making the API discoverable on demand.
+ *
+ * The resource list is derived from {@link SCRIPT_RESOURCES} so it can't drift
+ * from what the prelude actually exposes.
+ */
+
+import { SCRIPT_RESOURCES } from './prelude.js';
+
+export interface DocSection {
+  title: string;
+  keywords: string[];
+  body: string;
+}
+
+export const DOC_SECTIONS: DocSection[] = [
+  {
+    title: 'Overview',
+    keywords: ['overview', 'intro', 'sandbox', 'how', 'start'],
+    body: [
+      '`run_script` runs JavaScript/TypeScript in a sandboxed QuickJS isolate. There is no direct',
+      'network or filesystem access — the injected client performs Productive API calls on the host.',
+      'Write code using the globals below and `return` a value to surface it as the result.',
+      'No `import`/`require`: use the injected globals only.',
+    ].join(' '),
+  },
+  {
+    title: 'productive client',
+    keywords: [
+      'productive',
+      'client',
+      'resource',
+      'action',
+      'list',
+      'get',
+      'create',
+      'update',
+      'call',
+    ],
+    body: [
+      '`productive(resource, action, params)` — low-level call, mirrors the `productive` tool.',
+      'Per-resource accessors (all async — `await` them):',
+      '- `productive.<resource>.list(filter?, opts?)`',
+      '- `productive.<resource>.get(id, opts?)`',
+      '- `productive.<resource>.create(params)`',
+      '- `productive.<resource>.update(id, params)`',
+      '',
+      "Example: `const tasks = await productive.tasks.list({ status: 'open' });`",
+    ].join('\n'),
+  },
+  {
+    title: 'api client (raw)',
+    keywords: ['api', 'read', 'write', 'raw', 'endpoint', 'path', 'fetch'],
+    body: [
+      '`api.read(path, opts?)` — raw GET, e.g. `await api.read("/invoices", { page: 2 })`.',
+      '`api.write(method, path, body)` — raw POST/PATCH/PUT/DELETE (requires api_write enabled on the server).',
+    ].join('\n'),
+  },
+  {
+    title: 'output helpers',
+    keywords: [
+      'output',
+      'table',
+      'csv',
+      'json',
+      'log',
+      'print',
+      'info',
+      'warn',
+      'error',
+      'success',
+      'render',
+    ],
+    body: [
+      'Buffer output that is returned alongside the result and rendered to Markdown:',
+      '- `output.json(data)` — fenced JSON block',
+      '- `output.table(rows)` — Markdown table (rows = array of objects)',
+      '- `output.csv(rows)` — fenced CSV block',
+      '- `output.text(s)` / `output.log(...args)` — plain lines',
+      '- `output.info/warn/error/success(msg)` — labelled lines',
+    ].join('\n'),
+  },
+  {
+    title: 'args, flags & result',
+    keywords: ['args', 'flags', 'input', 'parameters', 'return', 'result'],
+    body: [
+      '`args` (string[]) and `flags` (object) are the values passed in the tool call.',
+      '`return <value>` surfaces a JSON-serializable result (also available as `structuredContent.result`).',
+    ].join('\n'),
+  },
+  {
+    title: 'resources & actions',
+    keywords: ['resources', 'actions', 'help', 'schema', 'filters', 'fields', 'includes'],
+    body: [
+      `Resource accessors: ${SCRIPT_RESOURCES.join(', ')}.`,
+      'Actions, filters, and fields mirror the `productive` tool — call `productive` with action="help"',
+      'or action="schema" for a resource to discover them. Use the low-level',
+      '`productive(resource, action, params)` for actions without an accessor (e.g. delete, resolve,',
+      'reports, summaries, workflows).',
+    ].join(' '),
+  },
+  {
+    title: 'dry run',
+    keywords: ['dry_run', 'dry', 'preview', 'mutation', 'safe'],
+    body: 'Pass `dry_run: true` to record mutating calls (create/update/delete/start/stop/...) instead of executing them; they are listed under `_run.recorded`.',
+  },
+  {
+    title: 'limits & gating',
+    keywords: ['limit', 'limits', 'timeout', 'memory', 'budget', 'gating', 'enable', 'disabled'],
+    body: [
+      'Disabled unless the server sets `PRODUCTIVE_MCP_ENABLE_RUN=true`.',
+      'Operator-tunable per-run limits: wall-clock timeout, memory, API-call budget, output size, code size.',
+    ].join(' '),
+  },
+  {
+    title: 'example',
+    keywords: ['example', 'examples', 'sample'],
+    body: [
+      '```js',
+      'const projects = await productive.projects.list();',
+      'const open = await productive.tasks.list({ status: "open" });',
+      'output.json({ projects: projects, openTasks: open });',
+      "return 'summary ready';",
+      '```',
+    ].join('\n'),
+  },
+];
+
+/** Render a single section as Markdown. */
+function renderSection(section: DocSection): string {
+  return `## ${section.title}\n\n${section.body}`;
+}
+
+/**
+ * Return the scripting-API reference, optionally filtered by a query. With no
+ * query the full reference is returned; with a query, only matching sections
+ * (falling back to a topic index when nothing matches).
+ */
+export function searchDocs(query?: string): string {
+  const header = '# run_script scripting API';
+  const q = query?.trim().toLowerCase();
+
+  if (!q) {
+    return `${header}\n\n${DOC_SECTIONS.map(renderSection).join('\n\n')}`;
+  }
+
+  const matches = DOC_SECTIONS.filter(
+    (section) =>
+      section.title.toLowerCase().includes(q) ||
+      section.keywords.some((k) => k.includes(q) || q.includes(k)) ||
+      section.body.toLowerCase().includes(q),
+  );
+
+  if (matches.length === 0) {
+    const topics = DOC_SECTIONS.map((s) => s.title).join(', ');
+    return `${header}\n\nNo sections matched "${query}". Available topics: ${topics}.`;
+  }
+
+  return `${header}\n\n${matches.map(renderSection).join('\n\n')}`;
+}

--- a/packages/mcp/src/run/engine.test.ts
+++ b/packages/mcp/src/run/engine.test.ts
@@ -167,6 +167,30 @@ describe('runScript', () => {
     expect(truncated).toBe(true);
   });
 
+  it('counts output by UTF-8 bytes, not code units', async () => {
+    // 10 CJK chars = 30 UTF-8 bytes; the JSON wrapper adds ~25 ASCII bytes.
+    // Code-unit length (~35) is under the cap but the byte length (~55) is over,
+    // so only byte-accurate counting trips truncation here.
+    const { promise } = run(`output.text('中'.repeat(10)); return 'done';`, {
+      limits: { ...baseLimits, maxOutputBytes: 45 },
+    });
+    const { truncated } = await promise;
+    expect(truncated).toBe(true);
+  });
+
+  it('does not let a colliding param override routing keys', async () => {
+    const hostCall = vi.fn(async () => ({})) as HostCall;
+    await run(`await productive.tasks.update('5', { id: '9', title: 'x' }); return 1;`, {
+      hostCall,
+    }).promise;
+    expect(hostCall).toHaveBeenCalledWith('productive', {
+      resource: 'tasks',
+      action: 'update',
+      id: '5',
+      title: 'x',
+    });
+  });
+
   it('rejects when the result is not serializable', async () => {
     const { promise } = run(`const a = {}; a.self = a; return a;`);
     await expect(promise).rejects.toThrow('not serializable');

--- a/packages/mcp/src/run/engine.test.ts
+++ b/packages/mcp/src/run/engine.test.ts
@@ -28,7 +28,7 @@ function run(code: string, overrides: Partial<RunScriptInput> = {}) {
     flags: {},
     limits: baseLimits,
     signal: controller.signal,
-    hostCall: vi.fn(async () => ({ ok: true })) as HostCall,
+    hostCall: vi.fn(async () => JSON.stringify({ ok: true })) as HostCall,
     ...overrides,
   };
   return { promise: runScript(input), controller, input };
@@ -70,7 +70,7 @@ describe('runScript', () => {
   });
 
   it('round-trips a productive call through the host bridge', async () => {
-    const hostCall = vi.fn(async () => [{ id: '1', name: 'Task' }]) as HostCall;
+    const hostCall = vi.fn(async () => JSON.stringify([{ id: '1', name: 'Task' }])) as HostCall;
     const { promise } = run(
       `const t = await productive.tasks.list({ status: 'open' }); return t;`,
       {
@@ -88,7 +88,7 @@ describe('runScript', () => {
 
   it('supports multiple awaited calls and loops', async () => {
     let n = 0;
-    const hostCall = vi.fn(async () => ({ n: ++n })) as HostCall;
+    const hostCall = vi.fn(async () => JSON.stringify({ n: ++n })) as HostCall;
     const { promise } = run(
       `
       const out = [];
@@ -105,7 +105,7 @@ describe('runScript', () => {
   });
 
   it('routes api.read and api.write through the bridge', async () => {
-    const hostCall = vi.fn(async () => ({ ok: true })) as HostCall;
+    const hostCall = vi.fn(async () => JSON.stringify({ ok: true })) as HostCall;
     const { promise } = run(
       `
       await api.read('/invoices', { page: 2 });
@@ -179,7 +179,7 @@ describe('runScript', () => {
   });
 
   it('does not let a colliding param override routing keys', async () => {
-    const hostCall = vi.fn(async () => ({})) as HostCall;
+    const hostCall = vi.fn(async () => JSON.stringify({})) as HostCall;
     await run(`await productive.tasks.update('5', { id: '9', title: 'x' }); return 1;`, {
       hostCall,
     }).promise;
@@ -196,11 +196,19 @@ describe('runScript', () => {
     await expect(promise).rejects.toThrow('not serializable');
   });
 
+  it('keeps output.* best-effort when a value is not serializable', async () => {
+    const { promise } = run(`const a = {}; a.self = a; output.json(a); return 'ok';`);
+    const { result, output } = await promise;
+    expect(result).toBe('ok');
+    expect(output).toHaveLength(1);
+    expect(String(output[0].data)).toContain('unserializable');
+  });
+
   it('aborts when the external signal fires mid-run', async () => {
     const controller = new AbortController();
     const hostCall = vi.fn(async () => {
       controller.abort();
-      return {};
+      return JSON.stringify({});
     }) as HostCall;
     const promise = runScript({
       code: `await productive.tasks.list(); return 'unreached';`,
@@ -210,6 +218,24 @@ describe('runScript', () => {
       signal: controller.signal,
       hostCall,
     });
+    await expect(promise).rejects.toThrow('timed out');
+  });
+
+  it('disposes cleanly when aborted with a host call still in flight', async () => {
+    const controller = new AbortController();
+    // Never resolves — the run is torn down while the deferred is still pending.
+    const hostCall = vi.fn(() => new Promise<string>(() => {})) as HostCall;
+    setTimeout(() => controller.abort(), 20);
+    const promise = runScript({
+      code: `await productive.tasks.list(); return 'unreached';`,
+      args: [],
+      flags: {},
+      limits: { ...baseLimits, timeoutMs: 1_000 },
+      signal: controller.signal,
+      hostCall,
+    });
+    // Without disposing the pending deferred this throws a fatal QuickJS GC
+    // assertion instead of a clean timeout.
     await expect(promise).rejects.toThrow('timed out');
   });
 

--- a/packages/mcp/src/run/engine.test.ts
+++ b/packages/mcp/src/run/engine.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the QuickJS execution engine.
+ *
+ * These run the real (WASM) QuickJS engine with a fake `hostCall` — no network
+ * is involved, satisfying the "no real API calls" rule.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import type { HostCall, RunScriptInput } from './engine.js';
+import type { RunLimits } from './limits.js';
+
+import { runScript, ScriptError, getQuickJSModule } from './engine.js';
+
+const baseLimits: RunLimits = {
+  timeoutMs: 2_000,
+  memoryBytes: 64 * 1024 * 1024,
+  maxApiCalls: 50,
+  maxOutputBytes: 4 * 1024,
+  maxCodeBytes: 128 * 1024,
+};
+
+function run(code: string, overrides: Partial<RunScriptInput> = {}) {
+  const controller = new AbortController();
+  const input: RunScriptInput = {
+    code,
+    args: [],
+    flags: {},
+    limits: baseLimits,
+    signal: controller.signal,
+    hostCall: vi.fn(async () => ({ ok: true })) as HostCall,
+    ...overrides,
+  };
+  return { promise: runScript(input), controller, input };
+}
+
+describe('runScript', () => {
+  it('returns the value the script returns', async () => {
+    const { promise } = run('return 21 + 21;');
+    await expect(promise).resolves.toMatchObject({ result: 42 });
+  });
+
+  it('returns null when the script returns nothing', async () => {
+    const { promise } = run('const x = 1;');
+    await expect(promise).resolves.toMatchObject({ result: null });
+  });
+
+  it('injects args and flags', async () => {
+    const { promise } = run('return { args, flags };', {
+      args: ['x'],
+      flags: { mine: true },
+    });
+    await expect(promise).resolves.toMatchObject({
+      result: { args: ['x'], flags: { mine: true } },
+    });
+  });
+
+  it('buffers output entries', async () => {
+    const { promise } = run(`
+      output.json({ a: 1 });
+      output.log('hello', 2);
+      output.warn('careful');
+    `);
+    const { output } = await promise;
+    expect(output).toEqual([
+      { type: 'json', data: { a: 1 } },
+      { type: 'log', data: 'hello 2' },
+      { type: 'warn', data: 'careful' },
+    ]);
+  });
+
+  it('round-trips a productive call through the host bridge', async () => {
+    const hostCall = vi.fn(async () => [{ id: '1', name: 'Task' }]) as HostCall;
+    const { promise } = run(
+      `const t = await productive.tasks.list({ status: 'open' }); return t;`,
+      {
+        hostCall,
+      },
+    );
+    const { result } = await promise;
+    expect(result).toEqual([{ id: '1', name: 'Task' }]);
+    expect(hostCall).toHaveBeenCalledWith('productive', {
+      resource: 'tasks',
+      action: 'list',
+      filter: { status: 'open' },
+    });
+  });
+
+  it('supports multiple awaited calls and loops', async () => {
+    let n = 0;
+    const hostCall = vi.fn(async () => ({ n: ++n })) as HostCall;
+    const { promise } = run(
+      `
+      const out = [];
+      for (let i = 0; i < 3; i++) {
+        out.push(await productive('tasks', 'get', { id: String(i) }));
+      }
+      return out;
+    `,
+      { hostCall },
+    );
+    const { result } = await promise;
+    expect(result).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+    expect(hostCall).toHaveBeenCalledTimes(3);
+  });
+
+  it('routes api.read and api.write through the bridge', async () => {
+    const hostCall = vi.fn(async () => ({ ok: true })) as HostCall;
+    const { promise } = run(
+      `
+      await api.read('/invoices', { page: 2 });
+      await api.write('POST', '/x', { foo: 1 });
+      return 'done';
+    `,
+      { hostCall },
+    );
+    await promise;
+    expect(hostCall).toHaveBeenNthCalledWith(1, 'api_read', { path: '/invoices', page: 2 });
+    expect(hostCall).toHaveBeenNthCalledWith(2, 'api_write', {
+      method: 'POST',
+      path: '/x',
+      body: { foo: 1 },
+      confirm: true,
+    });
+  });
+
+  it('propagates a host-call rejection to the guest', async () => {
+    const hostCall = vi.fn(async () => {
+      throw new Error('budget exceeded');
+    }) as HostCall;
+    const { promise } = run(
+      `
+      try {
+        await productive.tasks.list();
+        return 'no-throw';
+      } catch (e) {
+        return 'caught: ' + e.message;
+      }
+    `,
+      { hostCall },
+    );
+    await expect(promise).resolves.toMatchObject({ result: 'caught: budget exceeded' });
+  });
+
+  it('rejects with the guest error message on uncaught throw', async () => {
+    const { promise } = run(`throw new Error('boom');`);
+    await expect(promise).rejects.toThrow(ScriptError);
+    await expect(promise).rejects.toThrow('boom');
+  });
+
+  it('rejects on a syntax error', async () => {
+    const { promise } = run(`const = = =;`);
+    await expect(promise).rejects.toThrow(ScriptError);
+  });
+
+  it('times out on an infinite loop', async () => {
+    const { promise } = run(`while (true) {}`, { limits: { ...baseLimits, timeoutMs: 100 } });
+    await expect(promise).rejects.toThrow('timed out');
+  });
+
+  it('flags truncation when output exceeds the cap', async () => {
+    const { promise } = run(
+      `for (let i = 0; i < 100; i++) { output.text('x'.repeat(100)); } return 'done';`,
+      { limits: { ...baseLimits, maxOutputBytes: 512 } },
+    );
+    const { truncated } = await promise;
+    expect(truncated).toBe(true);
+  });
+
+  it('rejects when the result is not serializable', async () => {
+    const { promise } = run(`const a = {}; a.self = a; return a;`);
+    await expect(promise).rejects.toThrow('not serializable');
+  });
+
+  it('caches the WASM module across runs', async () => {
+    const a = await getQuickJSModule();
+    const b = await getQuickJSModule();
+    expect(a).toBe(b);
+  });
+});

--- a/packages/mcp/src/run/engine.test.ts
+++ b/packages/mcp/src/run/engine.test.ts
@@ -172,6 +172,28 @@ describe('runScript', () => {
     await expect(promise).rejects.toThrow('not serializable');
   });
 
+  it('aborts when the external signal fires mid-run', async () => {
+    const controller = new AbortController();
+    const hostCall = vi.fn(async () => {
+      controller.abort();
+      return {};
+    }) as HostCall;
+    const promise = runScript({
+      code: `await productive.tasks.list(); return 'unreached';`,
+      args: [],
+      flags: {},
+      limits: baseLimits,
+      signal: controller.signal,
+      hostCall,
+    });
+    await expect(promise).rejects.toThrow('timed out');
+  });
+
+  it('reports a thrown non-Error value', async () => {
+    const { promise } = run(`throw 'just a string';`);
+    await expect(promise).rejects.toThrow('just a string');
+  });
+
   it('caches the WASM module across runs', async () => {
     const a = await getQuickJSModule();
     const b = await getQuickJSModule();

--- a/packages/mcp/src/run/engine.ts
+++ b/packages/mcp/src/run/engine.ts
@@ -133,7 +133,9 @@ function installHostFunctions(
 ): void {
   const emit = ctx.newFunction('__emit', (handle) => {
     const raw = ctx.getString(handle);
-    state.bytes += raw.length;
+    // Count UTF-8 bytes (not UTF-16 code units) so multi-byte output can't
+    // overshoot the byte cap.
+    state.bytes += Buffer.byteLength(raw, 'utf8');
     if (state.bytes > input.limits.maxOutputBytes) {
       state.truncated = true;
       return;

--- a/packages/mcp/src/run/engine.ts
+++ b/packages/mcp/src/run/engine.ts
@@ -1,0 +1,305 @@
+/**
+ * QuickJS-WASM execution engine for sandboxed scripts.
+ *
+ * Each run gets a fresh QuickJS context (isolated globals + heap) created from
+ * a single, process-wide cached WASM module. The sandbox has no ambient
+ * capabilities: the only host functions exposed are `__hostCall` (bridged API
+ * access, returns a real guest Promise so scripts can `await` naturally) and
+ * `__emit` (output buffering).
+ *
+ * Limits enforced here:
+ * - memory   — `runtime.setMemoryLimit`
+ * - CPU/loop — an interrupt handler with a wall-clock deadline (fires even
+ *              while the host event loop is blocked by a synchronous loop)
+ * - hang     — an abort-signal race around the async completion wait
+ * - output   — buffered output is capped and flagged as truncated
+ */
+
+import variant from '@jitl/quickjs-singlefile-cjs-release-sync';
+import {
+  newQuickJSWASMModuleFromVariant,
+  type QuickJSContext,
+  type QuickJSWASMModule,
+} from 'quickjs-emscripten-core';
+
+import type { RunLimits } from './limits.js';
+
+import { buildPrelude } from './prelude.js';
+
+/** A single buffered output entry produced by `output.*`. */
+export interface OutputEntry {
+  type: string;
+  data: unknown;
+}
+
+/** Successful engine result. */
+export interface EngineResult {
+  result: unknown;
+  output: OutputEntry[];
+  truncated: boolean;
+}
+
+/** Host call performed on behalf of the guest. */
+export type HostCall = (channel: string, payload: Record<string, unknown>) => Promise<unknown>;
+
+export interface RunScriptInput {
+  code: string;
+  args: string[];
+  flags: Record<string, unknown>;
+  limits: RunLimits;
+  signal: AbortSignal;
+  hostCall: HostCall;
+}
+
+/** Error raised when a script fails to compile, throws, or times out. */
+export class ScriptError extends Error {
+  public readonly stackTrace?: string;
+  constructor(message: string, stackTrace?: string) {
+    super(message);
+    this.name = 'ScriptError';
+    this.stackTrace = stackTrace;
+  }
+}
+
+let modulePromise: Promise<QuickJSWASMModule> | undefined;
+
+/**
+ * Lazily create and cache the QuickJS WASM module (decision: cache the
+ * compiled module across runs; each run still gets a fresh context).
+ */
+export function getQuickJSModule(): Promise<QuickJSWASMModule> {
+  if (!modulePromise) {
+    modulePromise = newQuickJSWASMModuleFromVariant(variant);
+  }
+  return modulePromise;
+}
+
+/** Build the full source: prelude + user code wrapped in an async entrypoint. */
+function buildSource(input: RunScriptInput): string {
+  const prelude = buildPrelude({ args: input.args, flags: input.flags });
+  return `${prelude}
+async function __main() {
+${input.code}
+}
+__main().then(
+  (v) => {
+    try {
+      __resolve(JSON.stringify(v === undefined ? null : v));
+    } catch (e) {
+      __reject(JSON.stringify({ message: 'Result is not serializable: ' + String((e && e.message) || e) }));
+    }
+  },
+  (e) => __reject(JSON.stringify({ message: String((e && e.message) || e), stack: String((e && e.stack) || '') })),
+);`;
+}
+
+/** A promise that rejects when the abort signal fires. */
+function abortPromise(signal: AbortSignal): { promise: Promise<never>; cleanup: () => void } {
+  let onAbort: () => void = () => {};
+  const promise = new Promise<never>((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(new ScriptError('Script execution timed out'));
+      return;
+    }
+    onAbort = () => reject(new ScriptError('Script execution timed out'));
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+  // Swallow the rejection if it is never raced (avoids unhandled rejection).
+  promise.catch(() => {});
+  return { promise, cleanup: () => signal.removeEventListener('abort', onAbort) };
+}
+
+interface Captured {
+  ok: boolean;
+  value?: unknown;
+  message?: string;
+  stack?: string;
+}
+
+/**
+ * Register the synchronous host functions (`__emit`, `__resolve`, `__reject`)
+ * and the async `__hostCall`, wiring output buffering and result capture.
+ */
+function installHostFunctions(
+  ctx: QuickJSContext,
+  input: RunScriptInput,
+  state: { output: OutputEntry[]; bytes: number; truncated: boolean; captured?: Captured },
+): void {
+  const emit = ctx.newFunction('__emit', (handle) => {
+    const raw = ctx.getString(handle);
+    state.bytes += raw.length;
+    if (state.bytes > input.limits.maxOutputBytes) {
+      state.truncated = true;
+      return;
+    }
+    try {
+      state.output.push(JSON.parse(raw) as OutputEntry);
+    } catch {
+      // Ignore malformed emit payloads.
+    }
+  });
+  emit.consume((f) => ctx.setProp(ctx.global, '__emit', f));
+
+  const resolve = ctx.newFunction('__resolve', (handle) => {
+    const raw = ctx.getString(handle);
+    try {
+      state.captured = { ok: true, value: JSON.parse(raw) };
+    } catch {
+      state.captured = { ok: true, value: raw };
+    }
+  });
+  resolve.consume((f) => ctx.setProp(ctx.global, '__resolve', f));
+
+  const reject = ctx.newFunction('__reject', (handle) => {
+    const raw = ctx.getString(handle);
+    try {
+      const parsed = JSON.parse(raw) as { message?: string; stack?: string };
+      state.captured = { ok: false, message: parsed.message ?? 'Error', stack: parsed.stack };
+    } catch {
+      state.captured = { ok: false, message: raw };
+    }
+  });
+  reject.consume((f) => ctx.setProp(ctx.global, '__reject', f));
+
+  const hostCall = ctx.newFunction('__hostCall', (channelHandle, payloadHandle) => {
+    const channel = ctx.getString(channelHandle);
+    const payloadStr = ctx.getString(payloadHandle);
+    const deferred = ctx.newPromise();
+
+    void (async () => {
+      let payload: Record<string, unknown> = {};
+      try {
+        payload = JSON.parse(payloadStr) as Record<string, unknown>;
+      } catch {
+        // Treat unparseable payloads as empty.
+      }
+      const value = await input.hostCall(channel, payload);
+      return JSON.stringify(value === undefined ? null : value);
+    })().then(
+      (jsonStr) => {
+        const handle = ctx.newString(jsonStr);
+        deferred.resolve(handle);
+        handle.dispose();
+      },
+      (err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        // Reject with a guest Error so scripts can read `e.message`.
+        const handle = ctx.newError(message);
+        deferred.reject(handle);
+        handle.dispose();
+      },
+    );
+
+    // Drive the guest microtask queue whenever this promise settles.
+    deferred.settled.then(() => ctx.runtime.executePendingJobs());
+    return deferred.handle;
+  });
+  hostCall.consume((f) => ctx.setProp(ctx.global, '__hostCall', f));
+}
+
+/**
+ * Run a script to completion in a sandboxed QuickJS context.
+ *
+ * @throws {ScriptError} on compile error, uncaught guest error, or timeout.
+ */
+export async function runScript(input: RunScriptInput): Promise<EngineResult> {
+  const mod = await getQuickJSModule();
+  const ctx = mod.newContext();
+  const runtime = ctx.runtime;
+
+  runtime.setMemoryLimit(input.limits.memoryBytes);
+  runtime.setMaxStackSize(1024 * 1024);
+
+  const deadline = Date.now() + input.limits.timeoutMs;
+  let interrupted = false;
+  runtime.setInterruptHandler(() => {
+    if (Date.now() > deadline || input.signal.aborted) {
+      interrupted = true;
+      return true;
+    }
+    return false;
+  });
+
+  const state = {
+    output: [] as OutputEntry[],
+    bytes: 0,
+    truncated: false,
+    captured: undefined as Captured | undefined,
+  };
+  const abort = abortPromise(input.signal);
+
+  // Internal timer so the engine is self-bounding even when no external signal
+  // fires. The +50ms lets the interrupt handler's deadline win for CPU loops
+  // (clearer "timed out" semantics) before this host timer trips.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      interrupted = true;
+      reject(new ScriptError('Script execution timed out'));
+    }, input.limits.timeoutMs + 50);
+  });
+  timeout.catch(() => {});
+
+  try {
+    installHostFunctions(ctx, input, state);
+
+    const evalResult = ctx.evalCode(buildSource(input), 'script.js');
+    if (evalResult.error) {
+      const dumped = safeDump(ctx, evalResult.error);
+      evalResult.error.dispose();
+      if (interrupted) {
+        throw new ScriptError('Script execution timed out');
+      }
+      throw new ScriptError(formatGuestError(dumped));
+    }
+
+    const topPromise = evalResult.value;
+    const native = ctx.resolvePromise(topPromise);
+    topPromise.dispose();
+    runtime.executePendingJobs();
+
+    const settled = await Promise.race([native, abort.promise, timeout]);
+    if (settled.error) settled.error.dispose();
+    else settled.value.dispose();
+  } finally {
+    clearTimeout(timer);
+    abort.cleanup();
+    ctx.dispose();
+  }
+
+  if (interrupted || input.signal.aborted) {
+    throw new ScriptError('Script execution timed out');
+  }
+  if (!state.captured) {
+    throw new ScriptError('Script did not complete');
+  }
+  if (!state.captured.ok) {
+    throw new ScriptError(state.captured.message ?? 'Script error', state.captured.stack);
+  }
+
+  return { result: state.captured.value, output: state.output, truncated: state.truncated };
+}
+
+/** Dump a guest handle to a host value, tolerating dump failures (e.g. OOM). */
+function safeDump(
+  ctx: QuickJSContext,
+  handle: import('quickjs-emscripten-core').QuickJSHandle,
+): unknown {
+  try {
+    return ctx.dump(handle);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Format a dumped guest error into a single-line message. */
+function formatGuestError(dumped: unknown): string {
+  if (dumped && typeof dumped === 'object') {
+    const err = dumped as { name?: string; message?: string };
+    if (err.message) {
+      return err.name ? `${err.name}: ${err.message}` : err.message;
+    }
+  }
+  if (typeof dumped === 'string') return dumped;
+  return 'Script failed to compile';
+}

--- a/packages/mcp/src/run/engine.ts
+++ b/packages/mcp/src/run/engine.ts
@@ -123,7 +123,13 @@ interface Captured {
 function installHostFunctions(
   ctx: QuickJSContext,
   input: RunScriptInput,
-  state: { output: OutputEntry[]; bytes: number; truncated: boolean; captured?: Captured },
+  state: {
+    output: OutputEntry[];
+    bytes: number;
+    truncated: boolean;
+    captured?: Captured;
+    disposed: boolean;
+  },
 ): void {
   const emit = ctx.newFunction('__emit', (handle) => {
     const raw = ctx.getString(handle);
@@ -177,11 +183,15 @@ function installHostFunctions(
       return JSON.stringify(value === undefined ? null : value);
     })().then(
       (jsonStr) => {
+        // The run may have been torn down (timeout/abort) while the host call
+        // was in flight — touching a disposed context would throw.
+        if (state.disposed) return;
         const handle = ctx.newString(jsonStr);
         deferred.resolve(handle);
         handle.dispose();
       },
       (err: unknown) => {
+        if (state.disposed) return;
         const message = err instanceof Error ? err.message : String(err);
         // Reject with a guest Error so scripts can read `e.message`.
         const handle = ctx.newError(message);
@@ -191,7 +201,9 @@ function installHostFunctions(
     );
 
     // Drive the guest microtask queue whenever this promise settles.
-    deferred.settled.then(() => ctx.runtime.executePendingJobs());
+    deferred.settled.then(() => {
+      if (!state.disposed) ctx.runtime.executePendingJobs();
+    });
     return deferred.handle;
   });
   hostCall.consume((f) => ctx.setProp(ctx.global, '__hostCall', f));
@@ -225,6 +237,7 @@ export async function runScript(input: RunScriptInput): Promise<EngineResult> {
     bytes: 0,
     truncated: false,
     captured: undefined as Captured | undefined,
+    disposed: false,
   };
   const abort = abortPromise(input.signal);
 
@@ -264,6 +277,9 @@ export async function runScript(input: RunScriptInput): Promise<EngineResult> {
   } finally {
     clearTimeout(timer);
     abort.cleanup();
+    // Mark disposed before tearing down so any in-flight host-call
+    // continuation skips touching the context.
+    state.disposed = true;
     ctx.dispose();
   }
 

--- a/packages/mcp/src/run/engine.ts
+++ b/packages/mcp/src/run/engine.ts
@@ -19,6 +19,7 @@ import variant from '@jitl/quickjs-singlefile-cjs-release-sync';
 import {
   newQuickJSWASMModuleFromVariant,
   type QuickJSContext,
+  type QuickJSDeferredPromise,
   type QuickJSWASMModule,
 } from 'quickjs-emscripten-core';
 
@@ -39,8 +40,12 @@ export interface EngineResult {
   truncated: boolean;
 }
 
-/** Host call performed on behalf of the guest. */
-export type HostCall = (channel: string, payload: Record<string, unknown>) => Promise<unknown>;
+/**
+ * Host call performed on behalf of the guest. Returns the result as a JSON
+ * **string** (the text the tool already produced), which is handed straight to
+ * the guest without a re-serialization round trip.
+ */
+export type HostCall = (channel: string, payload: Record<string, unknown>) => Promise<string>;
 
 export interface RunScriptInput {
   code: string;
@@ -129,6 +134,7 @@ function installHostFunctions(
     truncated: boolean;
     captured?: Captured;
     disposed: boolean;
+    pendingDeferreds: Set<QuickJSDeferredPromise>;
   },
 ): void {
   const emit = ctx.newFunction('__emit', (handle) => {
@@ -173,6 +179,10 @@ function installHostFunctions(
     const channel = ctx.getString(channelHandle);
     const payloadStr = ctx.getString(payloadHandle);
     const deferred = ctx.newPromise();
+    // Track until settled so an aborted/timed-out run can dispose any
+    // still-pending deferred before tearing down the context — disposing a
+    // context with a live, unsettled promise trips a fatal QuickJS GC assert.
+    state.pendingDeferreds.add(deferred);
 
     void (async () => {
       let payload: Record<string, unknown> = {};
@@ -181,19 +191,21 @@ function installHostFunctions(
       } catch {
         // Treat unparseable payloads as empty.
       }
-      const value = await input.hostCall(channel, payload);
-      return JSON.stringify(value === undefined ? null : value);
+      // hostCall already returns JSON text — pass it through unchanged.
+      return input.hostCall(channel, payload);
     })().then(
       (jsonStr) => {
         // The run may have been torn down (timeout/abort) while the host call
         // was in flight — touching a disposed context would throw.
         if (state.disposed) return;
+        state.pendingDeferreds.delete(deferred);
         const handle = ctx.newString(jsonStr);
         deferred.resolve(handle);
         handle.dispose();
       },
       (err: unknown) => {
         if (state.disposed) return;
+        state.pendingDeferreds.delete(deferred);
         const message = err instanceof Error ? err.message : String(err);
         // Reject with a guest Error so scripts can read `e.message`.
         const handle = ctx.newError(message);
@@ -202,9 +214,16 @@ function installHostFunctions(
       },
     );
 
-    // Drive the guest microtask queue whenever this promise settles.
+    // Drive the guest microtask queue whenever this promise settles. Guard
+    // against a torn-down context and swallow any teardown-race throw so it
+    // can't escape as an unhandled rejection.
     deferred.settled.then(() => {
-      if (!state.disposed) ctx.runtime.executePendingJobs();
+      if (state.disposed) return;
+      try {
+        ctx.runtime.executePendingJobs();
+      } catch {
+        // Context was disposed mid-flight — nothing left to drive.
+      }
     });
     return deferred.handle;
   });
@@ -240,20 +259,9 @@ export async function runScript(input: RunScriptInput): Promise<EngineResult> {
     truncated: false,
     captured: undefined as Captured | undefined,
     disposed: false,
+    pendingDeferreds: new Set<QuickJSDeferredPromise>(),
   };
   const abort = abortPromise(input.signal);
-
-  // Internal timer so the engine is self-bounding even when no external signal
-  // fires. The +50ms lets the interrupt handler's deadline win for CPU loops
-  // (clearer "timed out" semantics) before this host timer trips.
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const timeout = new Promise<never>((_resolve, reject) => {
-    timer = setTimeout(() => {
-      interrupted = true;
-      reject(new ScriptError('Script execution timed out'));
-    }, input.limits.timeoutMs + 50);
-  });
-  timeout.catch(() => {});
 
   try {
     installHostFunctions(ctx, input, state);
@@ -273,15 +281,23 @@ export async function runScript(input: RunScriptInput): Promise<EngineResult> {
     topPromise.dispose();
     runtime.executePendingJobs();
 
-    const settled = await Promise.race([native, abort.promise, timeout]);
+    const settled = await Promise.race([native, abort.promise]);
     if (settled.error) settled.error.dispose();
     else settled.value.dispose();
   } finally {
-    clearTimeout(timer);
     abort.cleanup();
     // Mark disposed before tearing down so any in-flight host-call
     // continuation skips touching the context.
     state.disposed = true;
+    // Dispose any still-pending deferreds (e.g. an in-flight call when the run
+    // timed out/aborted) so the context has no live promises to assert on.
+    for (const deferred of state.pendingDeferreds) {
+      try {
+        deferred.dispose();
+      } catch {
+        // Already settled/freed — ignore.
+      }
+    }
     ctx.dispose();
   }
 

--- a/packages/mcp/src/run/limits.test.ts
+++ b/packages/mcp/src/run/limits.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for run-script limits and feature gating.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { isRunScriptEnabled, resolveRunLimits } from './limits.js';
+
+const env = (overrides: Record<string, string>): NodeJS.ProcessEnv =>
+  overrides as NodeJS.ProcessEnv;
+
+describe('isRunScriptEnabled', () => {
+  it('is disabled by default', () => {
+    expect(isRunScriptEnabled(env({}))).toBe(false);
+  });
+
+  it('is enabled only for the exact string "true"', () => {
+    expect(isRunScriptEnabled(env({ PRODUCTIVE_MCP_ENABLE_RUN: 'true' }))).toBe(true);
+    expect(isRunScriptEnabled(env({ PRODUCTIVE_MCP_ENABLE_RUN: '1' }))).toBe(false);
+    expect(isRunScriptEnabled(env({ PRODUCTIVE_MCP_ENABLE_RUN: 'TRUE' }))).toBe(false);
+    expect(isRunScriptEnabled(env({ PRODUCTIVE_MCP_ENABLE_RUN: 'yes' }))).toBe(false);
+  });
+});
+
+describe('resolveRunLimits', () => {
+  it('returns documented defaults when no env vars are set', () => {
+    expect(resolveRunLimits(env({}))).toEqual({
+      timeoutMs: 5_000,
+      memoryBytes: 64 * 1024 * 1024,
+      maxApiCalls: 50,
+      maxOutputBytes: 256 * 1024,
+      maxCodeBytes: 128 * 1024,
+    });
+  });
+
+  it('applies env overrides', () => {
+    const limits = resolveRunLimits(
+      env({
+        PRODUCTIVE_MCP_RUN_TIMEOUT_MS: '10000',
+        PRODUCTIVE_MCP_RUN_MEMORY_MB: '32',
+        PRODUCTIVE_MCP_RUN_MAX_API_CALLS: '5',
+        PRODUCTIVE_MCP_RUN_MAX_OUTPUT_KB: '64',
+        PRODUCTIVE_MCP_RUN_MAX_CODE_KB: '16',
+      }),
+    );
+    expect(limits).toEqual({
+      timeoutMs: 10_000,
+      memoryBytes: 32 * 1024 * 1024,
+      maxApiCalls: 5,
+      maxOutputBytes: 64 * 1024,
+      maxCodeBytes: 16 * 1024,
+    });
+  });
+
+  it.each([['0'], ['-1'], ['abc'], ['1.5'], ['']])(
+    'falls back to default for invalid value %s',
+    (value) => {
+      const limits = resolveRunLimits(env({ PRODUCTIVE_MCP_RUN_MAX_API_CALLS: value }));
+      expect(limits.maxApiCalls).toBe(50);
+    },
+  );
+});

--- a/packages/mcp/src/run/limits.ts
+++ b/packages/mcp/src/run/limits.ts
@@ -1,0 +1,64 @@
+/**
+ * Resource limits and feature gating for the sandboxed `run_script` tool.
+ *
+ * The tool is disabled by default and must be explicitly enabled via
+ * `PRODUCTIVE_MCP_ENABLE_RUN=true` — same gating model as `api_write`. This
+ * keeps hosted HTTP deployments safe until an operator opts in.
+ *
+ * Every limit is configurable via an environment variable so operators can
+ * tune the sandbox for their deployment. Invalid values fall back to the
+ * default rather than throwing.
+ */
+
+/** Resolved resource limits for a single script run. */
+export interface RunLimits {
+  /** Wall-clock budget for the whole run, in milliseconds. */
+  timeoutMs: number;
+  /** Maximum heap the QuickJS runtime may allocate, in bytes. */
+  memoryBytes: number;
+  /** Maximum number of bridged API calls a single run may make. */
+  maxApiCalls: number;
+  /** Maximum serialized size of buffered output + result, in bytes. */
+  maxOutputBytes: number;
+  /** Maximum size of the submitted script source, in bytes. */
+  maxCodeBytes: number;
+}
+
+const DEFAULTS = {
+  timeoutMs: 5_000,
+  memoryMb: 64,
+  maxApiCalls: 50,
+  maxOutputKb: 256,
+  maxCodeKb: 128,
+} as const;
+
+/**
+ * Whether the `run_script` tool is enabled. Off unless explicitly turned on.
+ */
+export function isRunScriptEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.PRODUCTIVE_MCP_ENABLE_RUN === 'true';
+}
+
+/**
+ * Parse a positive integer from an env var, falling back when missing/invalid.
+ */
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? n : fallback;
+}
+
+/**
+ * Resolve the active resource limits from the environment.
+ */
+export function resolveRunLimits(env: NodeJS.ProcessEnv = process.env): RunLimits {
+  return {
+    timeoutMs: parsePositiveInt(env.PRODUCTIVE_MCP_RUN_TIMEOUT_MS, DEFAULTS.timeoutMs),
+    memoryBytes:
+      parsePositiveInt(env.PRODUCTIVE_MCP_RUN_MEMORY_MB, DEFAULTS.memoryMb) * 1024 * 1024,
+    maxApiCalls: parsePositiveInt(env.PRODUCTIVE_MCP_RUN_MAX_API_CALLS, DEFAULTS.maxApiCalls),
+    maxOutputBytes:
+      parsePositiveInt(env.PRODUCTIVE_MCP_RUN_MAX_OUTPUT_KB, DEFAULTS.maxOutputKb) * 1024,
+    maxCodeBytes: parsePositiveInt(env.PRODUCTIVE_MCP_RUN_MAX_CODE_KB, DEFAULTS.maxCodeKb) * 1024,
+  };
+}

--- a/packages/mcp/src/run/prelude.test.ts
+++ b/packages/mcp/src/run/prelude.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests for the guest prelude builder.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { buildPrelude, SCRIPT_RESOURCES } from './prelude.js';
+
+describe('SCRIPT_RESOURCES', () => {
+  it('includes common data resources', () => {
+    expect(SCRIPT_RESOURCES).toContain('tasks');
+    expect(SCRIPT_RESOURCES).toContain('projects');
+    expect(SCRIPT_RESOURCES).toContain('time');
+  });
+
+  it('excludes meta/aggregate resources', () => {
+    for (const meta of ['batch', 'search', 'summaries', 'workflows', 'reports']) {
+      expect(SCRIPT_RESOURCES).not.toContain(meta);
+    }
+  });
+});
+
+describe('buildPrelude', () => {
+  it('embeds args and flags as JSON literals', () => {
+    const src = buildPrelude({ args: ['a', 'b'], flags: { mine: true, n: 3 } });
+    expect(src).toContain('const args = ["a","b"]');
+    expect(src).toContain('const flags = {"mine":true,"n":3}');
+  });
+
+  it('exposes the expected globals', () => {
+    const src = buildPrelude({ args: [], flags: {} });
+    expect(src).toContain('Object.assign(globalThis, { productive, api, output, args, flags })');
+  });
+});

--- a/packages/mcp/src/run/prelude.ts
+++ b/packages/mcp/src/run/prelude.ts
@@ -42,24 +42,26 @@ const __channel = (channel, payload) =>
 
 const __out = (type, data) => __emit(JSON.stringify({ type, data }));
 
+// Routing keys (resource/action/id/filter/path) are applied LAST so a
+// user-supplied param of the same name can never silently change routing.
 const productive = (resource, action, params = {}) =>
-  __channel('productive', Object.assign({ resource, action }, params));
+  __channel('productive', Object.assign({}, params, { resource, action }));
 
 for (const __r of ${JSON.stringify(SCRIPT_RESOURCES)}) {
   productive[__r] = {
     list: (filter = {}, opts = {}) =>
-      __channel('productive', Object.assign({ resource: __r, action: 'list', filter }, opts)),
+      __channel('productive', Object.assign({}, opts, { resource: __r, action: 'list', filter })),
     get: (id, opts = {}) =>
-      __channel('productive', Object.assign({ resource: __r, action: 'get', id }, opts)),
+      __channel('productive', Object.assign({}, opts, { resource: __r, action: 'get', id })),
     create: (params = {}) =>
-      __channel('productive', Object.assign({ resource: __r, action: 'create' }, params)),
+      __channel('productive', Object.assign({}, params, { resource: __r, action: 'create' })),
     update: (id, params = {}) =>
-      __channel('productive', Object.assign({ resource: __r, action: 'update', id }, params)),
+      __channel('productive', Object.assign({}, params, { resource: __r, action: 'update', id })),
   };
 }
 
 const api = {
-  read: (path, opts = {}) => __channel('api_read', Object.assign({ path }, opts)),
+  read: (path, opts = {}) => __channel('api_read', Object.assign({}, opts, { path })),
   write: (method, path, body) => __channel('api_write', { method, path, body, confirm: true }),
 };
 

--- a/packages/mcp/src/run/prelude.ts
+++ b/packages/mcp/src/run/prelude.ts
@@ -1,0 +1,85 @@
+/**
+ * Guest-side JavaScript prelude injected into the sandbox before user code.
+ *
+ * It builds the `productive`, `api`, `output`, `args`, and `flags` globals on
+ * top of two host primitives provided by the engine:
+ *
+ * - `__hostCall(channel, payloadJson)` → Promise<resultJson> — bridged API call
+ * - `__emit(entryJson)` — synchronous output buffering
+ *
+ * The surface deliberately mirrors the `productive` tool's resource/action
+ * model (what agents already know) rather than the fluent SDK, since no SDK
+ * code runs inside the sandbox.
+ */
+
+import { RESOURCES } from '@studiometa/productive-core';
+
+/**
+ * Resources that don't map to a simple list/get/create/update shape. These are
+ * still reachable through the low-level `productive(resource, action, params)`
+ * call, just without a convenience accessor.
+ */
+const NON_DATA_RESOURCES = new Set(['batch', 'search', 'summaries', 'workflows', 'reports']);
+
+/** Resources that get a `productive.<resource>` convenience accessor. */
+export const SCRIPT_RESOURCES = RESOURCES.filter((r) => !NON_DATA_RESOURCES.has(r));
+
+export interface PreludeOptions {
+  args: string[];
+  flags: Record<string, unknown>;
+}
+
+/**
+ * Build the prelude source for a run.
+ *
+ * `args` and `flags` are embedded as JSON literals (safe — JSON is a subset of
+ * JS expression syntax).
+ */
+export function buildPrelude(opts: PreludeOptions): string {
+  return `
+const __channel = (channel, payload) =>
+  __hostCall(channel, JSON.stringify(payload)).then((s) => JSON.parse(s));
+
+const __out = (type, data) => __emit(JSON.stringify({ type, data }));
+
+const productive = (resource, action, params = {}) =>
+  __channel('productive', Object.assign({ resource, action }, params));
+
+for (const __r of ${JSON.stringify(SCRIPT_RESOURCES)}) {
+  productive[__r] = {
+    list: (filter = {}, opts = {}) =>
+      __channel('productive', Object.assign({ resource: __r, action: 'list', filter }, opts)),
+    get: (id, opts = {}) =>
+      __channel('productive', Object.assign({ resource: __r, action: 'get', id }, opts)),
+    create: (params = {}) =>
+      __channel('productive', Object.assign({ resource: __r, action: 'create' }, params)),
+    update: (id, params = {}) =>
+      __channel('productive', Object.assign({ resource: __r, action: 'update', id }, params)),
+  };
+}
+
+const api = {
+  read: (path, opts = {}) => __channel('api_read', Object.assign({ path }, opts)),
+  write: (method, path, body) => __channel('api_write', { method, path, body, confirm: true }),
+};
+
+const output = {
+  json: (d) => __out('json', d),
+  table: (d) => __out('table', d),
+  csv: (d) => __out('csv', d),
+  text: (t) => __out('text', String(t)),
+  print: (t) => __out('text', String(t)),
+  log: (...a) =>
+    __out('log', a.map((x) => (typeof x === 'string' ? x : JSON.stringify(x))).join(' ')),
+  info: (m) => __out('info', String(m)),
+  warn: (m) => __out('warn', String(m)),
+  error: (m) => __out('error', String(m)),
+  success: (m) => __out('success', String(m)),
+};
+
+const args = ${JSON.stringify(opts.args)};
+const flags = ${JSON.stringify(opts.flags)};
+
+Object.assign(globalThis, { productive, api, output, args, flags });
+`;
+}

--- a/packages/mcp/src/run/prelude.ts
+++ b/packages/mcp/src/run/prelude.ts
@@ -40,7 +40,17 @@ export function buildPrelude(opts: PreludeOptions): string {
 const __channel = (channel, payload) =>
   __hostCall(channel, JSON.stringify(payload)).then((s) => JSON.parse(s));
 
-const __out = (type, data) => __emit(JSON.stringify({ type, data }));
+const __out = (type, data) => {
+  let payload;
+  try {
+    payload = JSON.stringify({ type, data });
+  } catch (e) {
+    // A circular structure / BigInt would otherwise abort the whole script;
+    // emit a placeholder so output.* is best-effort instead.
+    payload = JSON.stringify({ type, data: '[unserializable: ' + String((e && e.message) || e) + ']' });
+  }
+  __emit(payload);
+};
 
 // Routing keys (resource/action/id/filter/path) are applied LAST so a
 // user-supplied param of the same name can never silently change routing.

--- a/packages/mcp/src/run/render.test.ts
+++ b/packages/mcp/src/run/render.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for Markdown rendering of run_script results.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { renderRunResult } from './render.js';
+
+const noStats = { apiCalls: 0, dryRun: false };
+
+describe('renderRunResult', () => {
+  it('renders a table entry as a Markdown table', () => {
+    const md = renderRunResult({
+      result: null,
+      output: [
+        {
+          type: 'table',
+          data: [
+            { id: 1, name: 'A' },
+            { id: 2, name: 'B' },
+          ],
+        },
+      ],
+      run: noStats,
+    });
+    expect(md).toContain('| id | name |');
+    expect(md).toContain('| --- | --- |');
+    expect(md).toContain('| 1 | A |');
+    expect(md).toContain('| 2 | B |');
+  });
+
+  it('uses the union of keys as table columns and escapes pipes', () => {
+    const md = renderRunResult({
+      result: null,
+      output: [{ type: 'table', data: [{ a: 'x|y' }, { b: 2 }] }],
+      run: noStats,
+    });
+    expect(md).toContain('| a | b |');
+    expect(md).toContain('x\\|y');
+  });
+
+  it('falls back to JSON for a non-tabular table payload', () => {
+    const md = renderRunResult({
+      result: null,
+      output: [{ type: 'table', data: 'not-an-array' }],
+      run: noStats,
+    });
+    expect(md).toContain('```json');
+    expect(md).toContain('"not-an-array"');
+  });
+
+  it('renders csv entries as a fenced csv block with quoting', () => {
+    const md = renderRunResult({
+      result: null,
+      output: [{ type: 'csv', data: [{ a: 'has,comma', b: 1 }] }],
+      run: noStats,
+    });
+    expect(md).toContain('```csv');
+    expect(md).toContain('a,b');
+    expect(md).toContain('"has,comma",1');
+  });
+
+  it('renders json entries as a fenced json block', () => {
+    const md = renderRunResult({
+      result: null,
+      output: [{ type: 'json', data: { hello: 'world' } }],
+      run: noStats,
+    });
+    expect(md).toContain('```json');
+    expect(md).toContain('"hello": "world"');
+  });
+
+  it('renders text/log entries as plain lines and labels log levels', () => {
+    const md = renderRunResult({
+      result: null,
+      output: [
+        { type: 'text', data: 'plain line' },
+        { type: 'warn', data: 'be careful' },
+        { type: 'success', data: 'done' },
+      ],
+      run: noStats,
+    });
+    expect(md).toContain('plain line');
+    expect(md).toContain('⚠️ be careful');
+    expect(md).toContain('✅ done');
+  });
+
+  it('renders a non-string result as a json block and a string result verbatim', () => {
+    expect(renderRunResult({ result: { n: 42 }, output: [], run: noStats })).toContain('"n": 42');
+    expect(renderRunResult({ result: 'just text', output: [], run: noStats })).toContain(
+      '**Result:**\n\njust text',
+    );
+  });
+
+  it('omits the result section for null/undefined and notes empty runs', () => {
+    const md = renderRunResult({ result: null, output: [], run: noStats });
+    expect(md).toContain('no output');
+    expect(md).not.toContain('**Result:**');
+  });
+
+  it('renders a footer with pluralized call count, dry run, and truncation', () => {
+    expect(
+      renderRunResult({ result: 1, output: [], run: { apiCalls: 1, dryRun: false } }),
+    ).toContain('_1 API call_');
+    const md = renderRunResult({
+      result: 1,
+      output: [],
+      run: { apiCalls: 3, dryRun: true, outputTruncated: true, recorded: [{}, {}] },
+    });
+    expect(md).toContain('3 API calls');
+    expect(md).toContain('dry run');
+    expect(md).toContain('output truncated');
+    expect(md).toContain('2 recorded mutations');
+  });
+});

--- a/packages/mcp/src/run/render.ts
+++ b/packages/mcp/src/run/render.ts
@@ -1,0 +1,144 @@
+/**
+ * Markdown rendering for `run_script` results.
+ *
+ * The tool returns two things (per the MCP structured-output convention):
+ * - `structuredContent` — the raw `{ result, output, _run }` object for hosts
+ *   that consume structured tool output;
+ * - a `text` content block — this human-facing Markdown rendering, so clients
+ *   that only display text still get formatted tables/JSON/logs rather than a
+ *   single opaque JSON blob.
+ *
+ * MCP has no "table" content type, so "rendering" here means producing Markdown
+ * (tables, fenced code blocks, labelled lines).
+ */
+
+import type { OutputEntry } from './engine.js';
+
+export interface RunStats {
+  apiCalls: number;
+  dryRun: boolean;
+  outputTruncated?: boolean;
+  recorded?: unknown[];
+}
+
+export interface RunRenderInput {
+  result: unknown;
+  output: OutputEntry[];
+  run: RunStats;
+}
+
+/** Labels for log-style output entries. */
+const LOG_LABELS: Record<string, string> = {
+  info: 'ℹ️',
+  warn: '⚠️',
+  error: '❌',
+  success: '✅',
+};
+
+/** Escape a value for use inside a Markdown table cell. */
+function cell(value: unknown): string {
+  const text =
+    value === null || value === undefined
+      ? ''
+      : typeof value === 'object'
+        ? JSON.stringify(value)
+        : String(value);
+  return text.replace(/\\/g, '\\\\').replace(/\|/g, '\\|').replace(/\n/g, ' ');
+}
+
+/** Whether a value is a plain (non-array, non-null) object. */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Render an array of objects as a Markdown table. */
+function markdownTable(rows: Record<string, unknown>[]): string {
+  const columns = [...new Set(rows.flatMap((row) => Object.keys(row)))];
+  if (columns.length === 0) return '_(no columns)_';
+  const header = `| ${columns.join(' | ')} |`;
+  const divider = `| ${columns.map(() => '---').join(' | ')} |`;
+  const body = rows.map((row) => `| ${columns.map((c) => cell(row[c])).join(' | ')} |`).join('\n');
+  return `${header}\n${divider}\n${body}`;
+}
+
+/** Build one row of CSV with RFC-4180-style quoting. */
+function csvRow(values: unknown[]): string {
+  return values
+    .map((v) => {
+      const text =
+        v === null || v === undefined ? '' : typeof v === 'object' ? JSON.stringify(v) : String(v);
+      return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+    })
+    .join(',');
+}
+
+/** Render an array of objects as CSV. */
+function toCsv(rows: Record<string, unknown>[]): string {
+  const columns = [...new Set(rows.flatMap((row) => Object.keys(row)))];
+  const lines = [csvRow(columns), ...rows.map((row) => csvRow(columns.map((c) => row[c])))];
+  return lines.join('\n');
+}
+
+/** Fenced code block. */
+function fence(lang: string, body: string): string {
+  return `\`\`\`${lang}\n${body}\n\`\`\``;
+}
+
+/** Render a single output entry to Markdown. */
+function renderEntry(entry: OutputEntry): string {
+  const { type, data } = entry;
+  switch (type) {
+    case 'table':
+      return Array.isArray(data) && data.length > 0 && data.every(isPlainObject)
+        ? markdownTable(data as Record<string, unknown>[])
+        : fence('json', JSON.stringify(data, null, 2));
+    case 'csv':
+      return Array.isArray(data) && data.length > 0 && data.every(isPlainObject)
+        ? fence('csv', toCsv(data as Record<string, unknown>[]))
+        : fence('json', JSON.stringify(data, null, 2));
+    case 'json':
+      return fence('json', JSON.stringify(data, null, 2));
+    case 'text':
+    case 'log':
+      return String(data);
+    default:
+      return `${LOG_LABELS[type] ?? `[${type}]`} ${String(data)}`;
+  }
+}
+
+/** Render the run footer (stats line). */
+function renderFooter(run: RunStats): string {
+  const bits = [`${run.apiCalls} API call${run.apiCalls === 1 ? '' : 's'}`];
+  if (run.dryRun) bits.push('dry run');
+  if (run.outputTruncated) bits.push('output truncated');
+  if (run.recorded && run.recorded.length > 0) {
+    bits.push(`${run.recorded.length} recorded mutation${run.recorded.length === 1 ? '' : 's'}`);
+  }
+  return `—\n_${bits.join(' · ')}_`;
+}
+
+/**
+ * Render a run result as human-facing Markdown.
+ */
+export function renderRunResult(input: RunRenderInput): string {
+  const sections: string[] = [];
+
+  if (input.output.length > 0) {
+    sections.push(input.output.map(renderEntry).join('\n\n'));
+  }
+
+  if (input.result !== null && input.result !== undefined) {
+    const body =
+      typeof input.result === 'string'
+        ? input.result
+        : fence('json', JSON.stringify(input.result, null, 2));
+    sections.push(`**Result:**\n\n${body}`);
+  }
+
+  if (sections.length === 0) {
+    sections.push('_Script completed with no output._');
+  }
+
+  sections.push(renderFooter(input.run));
+  return sections.join('\n\n');
+}

--- a/packages/mcp/src/run/strip.test.ts
+++ b/packages/mcp/src/run/strip.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Tests for TypeScript stripping.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { stripTypes } from './strip.js';
+
+describe('stripTypes', () => {
+  it('removes type annotations', () => {
+    const out = stripTypes('const x: number = 1;\nlet y: string = "a";');
+    expect(out).not.toContain(': number');
+    expect(out).not.toContain(': string');
+    expect(out).toContain('const x');
+  });
+
+  it('strips function parameter and return types', () => {
+    const out = stripTypes('function f(a: string, b: number): string { return a; }');
+    expect(out).toContain('function f(a, b)');
+    expect(out).not.toContain(': string');
+  });
+
+  it('lowers enums to runnable JavaScript', () => {
+    const out = stripTypes('enum E { A, B }');
+    expect(out).not.toContain('enum E');
+    expect(out).toContain('E["A"]');
+  });
+
+  it('passes plain JavaScript through unchanged in behaviour', () => {
+    const out = stripTypes('const x = 1; output.json(x);');
+    expect(out).toContain('const x = 1');
+    expect(out).toContain('output.json(x)');
+  });
+
+  it('returns the original source when it cannot be parsed as TypeScript', () => {
+    // A genuinely broken snippet — stripping throws, so we hand back the input.
+    const broken = 'const = = =;';
+    expect(stripTypes(broken)).toBe(broken);
+  });
+});

--- a/packages/mcp/src/run/strip.ts
+++ b/packages/mcp/src/run/strip.ts
@@ -1,0 +1,30 @@
+/**
+ * TypeScript type-stripping for submitted scripts.
+ *
+ * QuickJS executes JavaScript, so any TypeScript syntax in a submitted script
+ * must be transformed away first. We use Node's built-in
+ * {@link stripTypeScriptTypes} in `transform` mode, which also lowers `enum`
+ * and parameter properties (not just erasing annotations).
+ *
+ * Plain JavaScript passes through unchanged. If the source cannot be parsed as
+ * TypeScript at all, the original is returned untouched so the sandbox can
+ * surface the real syntax error to the caller.
+ */
+
+import { stripTypeScriptTypes } from 'node:module';
+
+/**
+ * Strip TypeScript types from a script, returning runnable JavaScript.
+ *
+ * @param code - The submitted script source (TypeScript or JavaScript).
+ * @returns JavaScript with type syntax removed.
+ */
+export function stripTypes(code: string): string {
+  try {
+    return stripTypeScriptTypes(code, { mode: 'transform' });
+  } catch {
+    // Not parseable as TypeScript — hand it to the sandbox as-is so the
+    // engine reports the genuine error rather than a stripping error.
+    return code;
+  }
+}

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -357,7 +357,9 @@ export type ApiWriteToolInput = z.infer<typeof ApiWriteToolInputSchema>;
  */
 export const RunScriptToolInputSchema = z.object({
   code: z.string().min(1, 'Code cannot be empty').describe('JavaScript/TypeScript source to run'),
-  args: z.array(z.string()).optional().describe('Positional arguments exposed as `args`'),
+  // Accept any array — the handler's normalizeArgs() is the single coercion
+  // point and stringifies each item, so the schema must not reject non-strings.
+  args: z.array(z.unknown()).optional().describe('Positional arguments exposed as `args`'),
   flags: z.record(z.string(), z.unknown()).optional().describe('Named values exposed as `flags`'),
   dry_run: z.boolean().optional().describe('Record mutations instead of executing them'),
 });

--- a/packages/mcp/src/schema.ts
+++ b/packages/mcp/src/schema.ts
@@ -352,6 +352,18 @@ export const ApiWriteToolInputSchema = z.object({
 
 export type ApiWriteToolInput = z.infer<typeof ApiWriteToolInputSchema>;
 
+/**
+ * Full input schema for the sandboxed run_script tool.
+ */
+export const RunScriptToolInputSchema = z.object({
+  code: z.string().min(1, 'Code cannot be empty').describe('JavaScript/TypeScript source to run'),
+  args: z.array(z.string()).optional().describe('Positional arguments exposed as `args`'),
+  flags: z.record(z.string(), z.unknown()).optional().describe('Named values exposed as `flags`'),
+  dry_run: z.boolean().optional().describe('Record mutations instead of executing them'),
+});
+
+export type RunScriptToolInput = z.infer<typeof RunScriptToolInputSchema>;
+
 // =============================================================================
 // Validation Helpers
 // =============================================================================
@@ -376,7 +388,7 @@ export function safeValidateToolInput(input: unknown): ZodSafeParseResult<Produc
  * Format Zod validation errors for LLM consumption
  */
 export function formatValidationErrors(
-  error: ZodError<ProductiveToolInput | ApiReadToolInput | ApiWriteToolInput>,
+  error: ZodError<ProductiveToolInput | ApiReadToolInput | ApiWriteToolInput | RunScriptToolInput>,
 ): string {
   const issues = error.issues.map((issue) => {
     const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : '';

--- a/packages/mcp/src/stdio.test.ts
+++ b/packages/mcp/src/stdio.test.ts
@@ -59,9 +59,9 @@ describe('stdio handlers', () => {
       expect(getConfig).toBeDefined();
     });
 
-    it('should have 5 total tools (3 main + 2 stdio-only)', () => {
+    it('should have 6 total tools (4 main + 2 stdio-only)', () => {
       const tools = getAvailableTools();
-      expect(tools.length).toBe(5);
+      expect(tools.length).toBe(6);
     });
   });
 

--- a/packages/mcp/src/stdio.test.ts
+++ b/packages/mcp/src/stdio.test.ts
@@ -59,9 +59,9 @@ describe('stdio handlers', () => {
       expect(getConfig).toBeDefined();
     });
 
-    it('should have 6 total tools (4 main + 2 stdio-only)', () => {
+    it('should have 7 total tools (5 main + 2 stdio-only)', () => {
       const tools = getAvailableTools();
-      expect(tools.length).toBe(6);
+      expect(tools.length).toBe(7);
     });
   });
 

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -12,6 +12,7 @@ describe('tools', () => {
         'api_read',
         'api_write',
         'run_script',
+        'run_script_search_docs',
       ]);
     });
 

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -7,7 +7,12 @@ describe('tools', () => {
   describe('TOOLS', () => {
     it('should export the productive and raw API tools', () => {
       expect(Array.isArray(TOOLS)).toBe(true);
-      expect(TOOLS.map((tool) => tool.name)).toEqual(['productive', 'api_read', 'api_write']);
+      expect(TOOLS.map((tool) => tool.name)).toEqual([
+        'productive',
+        'api_read',
+        'api_write',
+        'run_script',
+      ]);
     });
 
     it('should have valid tool structure', () => {
@@ -134,13 +139,13 @@ describe('tools', () => {
   describe('token optimization', () => {
     it('should have reasonable tool schema size', () => {
       const totalSize = JSON.stringify(TOOLS).length;
-      expect(totalSize).toBeLessThan(6500);
+      expect(totalSize).toBeLessThan(7500);
     });
 
     it('should estimate under 1700 tokens', () => {
       const totalSize = JSON.stringify(TOOLS).length;
       const estimatedTokens = Math.ceil(totalSize / 4);
-      expect(estimatedTokens).toBeLessThan(1700);
+      expect(estimatedTokens).toBeLessThan(1900);
     });
   });
 });

--- a/packages/mcp/src/tools.test.ts
+++ b/packages/mcp/src/tools.test.ts
@@ -139,13 +139,13 @@ describe('tools', () => {
   describe('token optimization', () => {
     it('should have reasonable tool schema size', () => {
       const totalSize = JSON.stringify(TOOLS).length;
-      expect(totalSize).toBeLessThan(7500);
+      expect(totalSize).toBeLessThan(8500);
     });
 
     it('should estimate under 1700 tokens', () => {
       const totalSize = JSON.stringify(TOOLS).length;
       const estimatedTokens = Math.ceil(totalSize / 4);
-      expect(estimatedTokens).toBeLessThan(1900);
+      expect(estimatedTokens).toBeLessThan(2200);
     });
   });
 });

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -196,6 +196,47 @@ export const TOOLS: Tool[] = [
       required: ['method', 'path', 'confirm'],
     },
   },
+  {
+    name: 'run_script',
+    description:
+      'Run a sandboxed JavaScript/TypeScript script for advanced multi-step logic in one call. ' +
+      'Globals: productive(resource, action, params) and productive.<resource>.list/get/create/update; ' +
+      'api.read(path, opts)/api.write(method, path, body); output.json/table/csv/log/...; args; flags. ' +
+      'Return a value to surface it as the result. dry_run=true records mutations without executing them. ' +
+      'No network/filesystem access; calls go through the same API pipeline. ' +
+      'Disabled by default, requires PRODUCTIVE_MCP_ENABLE_RUN=true.',
+    annotations: {
+      title: 'Run Script',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        code: {
+          type: 'string',
+          description: 'JavaScript/TypeScript source to execute in the sandbox.',
+        },
+        args: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Positional arguments exposed to the script as `args`.',
+        },
+        flags: {
+          type: 'object',
+          description: 'Named values exposed to the script as `flags`.',
+        },
+        dry_run: {
+          type: 'boolean',
+          description:
+            'Record mutating calls (create/update/delete/...) instead of executing them.',
+        },
+      },
+      required: ['code'],
+    },
+  },
 ];
 
 /**

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -237,6 +237,33 @@ export const TOOLS: Tool[] = [
       },
       required: ['code'],
     },
+    outputSchema: {
+      type: 'object',
+      properties: {
+        result: { description: 'The value the script returned (any JSON).' },
+        output: {
+          type: 'array',
+          description: 'Buffered output.* entries, in order.',
+          items: {
+            type: 'object',
+            properties: { type: { type: 'string' }, data: {} },
+            required: ['type'],
+          },
+        },
+        _run: {
+          type: 'object',
+          description: 'Run metadata.',
+          properties: {
+            apiCalls: { type: 'number' },
+            dryRun: { type: 'boolean' },
+            outputTruncated: { type: 'boolean' },
+            recorded: { type: 'array' },
+          },
+          required: ['apiCalls', 'dryRun'],
+        },
+      },
+      required: ['result', 'output', '_run'],
+    },
   },
 ];
 

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -200,11 +200,9 @@ export const TOOLS: Tool[] = [
     name: 'run_script',
     description:
       'Run a sandboxed JavaScript/TypeScript script for advanced multi-step logic in one call. ' +
-      'Globals: productive(resource, action, params) and productive.<resource>.list/get/create/update; ' +
-      'api.read(path, opts)/api.write(method, path, body); output.json/table/csv/log/...; args; flags. ' +
-      'Return a value to surface it as the result. dry_run=true records mutations without executing them. ' +
-      'No direct network/filesystem access (no fetch, no arbitrary URLs); Productive API access is provided ' +
-      'via the injected client, executed on the host through the same validated, rate-limited pipeline. ' +
+      'Globals: productive(resource, action, params), api.read/write, output.*, args, flags; `return` a value for the result. ' +
+      'Call `run_script_search_docs` for the full scripting API before writing a script. ' +
+      'dry_run=true previews mutations. No direct network/filesystem access (API calls run host-side). ' +
       'Disabled by default, requires PRODUCTIVE_MCP_ENABLE_RUN=true.',
     annotations: {
       title: 'Run Script',
@@ -263,6 +261,29 @@ export const TOOLS: Tool[] = [
         },
       },
       required: ['result', 'output', '_run'],
+    },
+  },
+  {
+    name: 'run_script_search_docs',
+    description:
+      'Reference for the run_script scripting API — globals (productive, api, output, args, flags), ' +
+      'available resources, output rendering, dry_run, limits, and examples. Call with no query for the ' +
+      'full reference, or a query (e.g. "table", "api", "dry_run") to filter. Use before writing a run_script.',
+    annotations: {
+      title: 'Run Script Docs',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Optional topic/keyword filter (e.g. "table", "api", "dry_run").',
+        },
+      },
     },
   },
 ];

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -267,8 +267,8 @@ export const TOOLS: Tool[] = [
     name: 'run_script_search_docs',
     description:
       'Reference for the run_script scripting API — globals (productive, api, output, args, flags), ' +
-      'available resources, output rendering, dry_run, limits, and examples. Call with no query for the ' +
-      'full reference, or a query (e.g. "table", "api", "dry_run") to filter. Use before writing a run_script.',
+      'available resources, output rendering, dry_run, limits, and examples. Call with no query for a ' +
+      'table of contents, or a query (e.g. "table", "api", "dry_run") to load a topic. Use before writing a run_script.',
     annotations: {
       title: 'Run Script Docs',
       readOnlyHint: true,

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -203,7 +203,8 @@ export const TOOLS: Tool[] = [
       'Globals: productive(resource, action, params) and productive.<resource>.list/get/create/update; ' +
       'api.read(path, opts)/api.write(method, path, body); output.json/table/csv/log/...; args; flags. ' +
       'Return a value to surface it as the result. dry_run=true records mutations without executing them. ' +
-      'No network/filesystem access; calls go through the same API pipeline. ' +
+      'No direct network/filesystem access (no fetch, no arbitrary URLs); Productive API access is provided ' +
+      'via the injected client, executed on the host through the same validated, rate-limited pipeline. ' +
       'Disabled by default, requires PRODUCTIVE_MCP_ENABLE_RUN=true.',
     annotations: {
       title: 'Run Script',

--- a/packages/mcp/vite.config.ts
+++ b/packages/mcp/vite.config.ts
@@ -24,6 +24,8 @@ export default defineConfig({
       '@studiometa/productive-api',
       '@studiometa/productive-core',
       'h3',
+      'quickjs-emscripten-core',
+      '@jitl/quickjs-singlefile-cjs-release-sync',
     ],
   }),
   test: createTestConfig({

--- a/tests/integration/helpers/mcp-client.ts
+++ b/tests/integration/helpers/mcp-client.ts
@@ -27,8 +27,11 @@ export interface McpStdioClient {
  * Spawn the real productive-mcp binary and connect via StdioClientTransport.
  * The child process gets a locked-down env — no real config/keychain access.
  */
-export async function createMcpStdioClient(mockApiUrl: string): Promise<McpStdioClient> {
-  const sandbox = await createSandbox({ mockApiUrl });
+export async function createMcpStdioClient(
+  mockApiUrl: string,
+  extraEnv?: Record<string, string>,
+): Promise<McpStdioClient> {
+  const sandbox = await createSandbox({ mockApiUrl, extraEnv });
 
   const transport = new StdioClientTransport({
     command: process.execPath,

--- a/tests/integration/helpers/sandbox.ts
+++ b/tests/integration/helpers/sandbox.ts
@@ -30,6 +30,8 @@ export interface CreateSandboxOptions {
   orgId?: string;
   userId?: string;
   mockApiUrl: string;
+  /** Extra environment variables merged into the locked-down child env. */
+  extraEnv?: Record<string, string>;
 }
 
 /**
@@ -45,6 +47,7 @@ export async function createSandbox(options: CreateSandboxOptions): Promise<Sand
     orgId = 'test-org-456',
     userId = 'test-user-789',
     mockApiUrl,
+    extraEnv = {},
   } = options;
 
   const dir = await mkdtemp(join(tmpdir(), 'productive-test-'));
@@ -82,6 +85,7 @@ export async function createSandbox(options: CreateSandboxOptions): Promise<Sand
     NO_COLOR: '1',
     FORCE_COLOR: '0',
     NODE_NO_WARNINGS: '1',
+    ...extraEnv,
   };
 
   async function cleanup() {

--- a/tests/integration/mcp/run-script.test.ts
+++ b/tests/integration/mcp/run-script.test.ts
@@ -1,0 +1,111 @@
+/**
+ * MCP integration tests — run_script tool
+ *
+ * Spawns the real productive-mcp binary and drives the sandboxed run_script
+ * tool end-to-end against the JSON:API mock server. The script reaches the
+ * mock API only through the host bridge.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+
+import { createMcpStdioClient, type McpStdioClient } from '../helpers/mcp-client.js';
+import { startMockServer, type MockServer } from '../helpers/mock-server.js';
+
+function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+  const first = result.content[0];
+  return first?.type === 'text' ? (first.text ?? '') : '';
+}
+
+describe('MCP: run_script tool', () => {
+  let mockServer: MockServer;
+  let enabled: McpStdioClient;
+  let disabled: McpStdioClient;
+
+  beforeAll(async () => {
+    mockServer = await startMockServer();
+    enabled = await createMcpStdioClient(mockServer.apiUrl, { PRODUCTIVE_MCP_ENABLE_RUN: 'true' });
+    disabled = await createMcpStdioClient(mockServer.apiUrl);
+  });
+
+  afterAll(async () => {
+    await enabled.client.close();
+    await disabled.client.close();
+    await enabled.sandbox.cleanup();
+    await disabled.sandbox.cleanup();
+    await mockServer.close();
+  });
+
+  it('exposes run_script in the tool list', async () => {
+    const { tools } = await enabled.client.listTools();
+    expect(tools.find((t) => t.name === 'run_script')).toBeDefined();
+  });
+
+  it('runs a script that fetches data through the bridge', async () => {
+    const result = (await enabled.client.callTool({
+      name: 'run_script',
+      arguments: {
+        code: `
+          const projects = await productive.projects.list();
+          output.json(projects);
+          return Array.isArray(projects) ? projects.length : 'not-array';
+        `,
+      },
+    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+
+    expect(result.isError).toBeFalsy();
+    const text = textOf(result);
+    expect(text).toContain('Alpha Website');
+    expect(text).toContain('"apiCalls": 1');
+  });
+
+  it('exposes args and flags to the script', async () => {
+    const result = (await enabled.client.callTool({
+      name: 'run_script',
+      arguments: {
+        code: `return { got: args, mine: flags.mine };`,
+        args: ['hello'],
+        flags: { mine: true },
+      },
+    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(textOf(result));
+    expect(body.result).toEqual({ got: ['hello'], mine: true });
+  });
+
+  it('records mutations in dry-run mode without calling the API', async () => {
+    const result = (await enabled.client.callTool({
+      name: 'run_script',
+      arguments: {
+        code: `await productive.tasks.create({ title: 'New', project_id: '101', task_list_id: '1' }); return 'done';`,
+        dry_run: true,
+      },
+    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse(textOf(result));
+    expect(body.result).toBe('done');
+    expect(body._run.dryRun).toBe(true);
+    expect(body._run.recorded).toHaveLength(1);
+  });
+
+  it('surfaces guest errors as an error result', async () => {
+    const result = (await enabled.client.callTool({
+      name: 'run_script',
+      arguments: { code: `throw new Error('script failed');` },
+    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('script failed');
+  });
+
+  it('is disabled by default', async () => {
+    const result = (await disabled.client.callTool({
+      name: 'run_script',
+      arguments: { code: `return 1;` },
+    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('PRODUCTIVE_MCP_ENABLE_RUN');
+  });
+});

--- a/tests/integration/mcp/run-script.test.ts
+++ b/tests/integration/mcp/run-script.test.ts
@@ -11,7 +11,13 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { createMcpStdioClient, type McpStdioClient } from '../helpers/mcp-client.js';
 import { startMockServer, type MockServer } from '../helpers/mock-server.js';
 
-function textOf(result: { content: Array<{ type: string; text?: string }> }): string {
+type RunResult = {
+  isError?: boolean;
+  content: Array<{ type: string; text?: string }>;
+  structuredContent?: { result?: unknown; output?: unknown; _run?: Record<string, unknown> };
+};
+
+function textOf(result: RunResult): string {
   const first = result.content[0];
   return first?.type === 'text' ? (first.text ?? '') : '';
 }
@@ -47,15 +53,17 @@ describe('MCP: run_script tool', () => {
         code: `
           const projects = await productive.projects.list();
           output.json(projects);
-          return Array.isArray(projects) ? projects.length : 'not-array';
+          return 'fetched';
         `,
       },
-    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+    })) as RunResult;
 
     expect(result.isError).toBeFalsy();
-    const text = textOf(result);
-    expect(text).toContain('Alpha Website');
-    expect(text).toContain('"apiCalls": 1');
+    // Markdown text block carries the rendered json output...
+    expect(textOf(result)).toContain('Alpha Website');
+    // ...and structuredContent carries the machine-readable result + stats.
+    expect(result.structuredContent?.result).toBe('fetched');
+    expect(result.structuredContent?._run?.apiCalls).toBe(1);
   });
 
   it('exposes args and flags to the script', async () => {
@@ -66,11 +74,10 @@ describe('MCP: run_script tool', () => {
         args: ['hello'],
         flags: { mine: true },
       },
-    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+    })) as RunResult;
 
     expect(result.isError).toBeFalsy();
-    const body = JSON.parse(textOf(result));
-    expect(body.result).toEqual({ got: ['hello'], mine: true });
+    expect(result.structuredContent?.result).toEqual({ got: ['hello'], mine: true });
   });
 
   it('records mutations in dry-run mode without calling the API', async () => {
@@ -80,20 +87,20 @@ describe('MCP: run_script tool', () => {
         code: `await productive.tasks.create({ title: 'New', project_id: '101', task_list_id: '1' }); return 'done';`,
         dry_run: true,
       },
-    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+    })) as RunResult;
 
     expect(result.isError).toBeFalsy();
-    const body = JSON.parse(textOf(result));
-    expect(body.result).toBe('done');
-    expect(body._run.dryRun).toBe(true);
-    expect(body._run.recorded).toHaveLength(1);
+    const sc = result.structuredContent;
+    expect(sc?.result).toBe('done');
+    expect((sc?._run as { dryRun?: boolean })?.dryRun).toBe(true);
+    expect((sc?._run as { recorded?: unknown[] })?.recorded).toHaveLength(1);
   });
 
   it('surfaces guest errors as an error result', async () => {
     const result = (await enabled.client.callTool({
       name: 'run_script',
       arguments: { code: `throw new Error('script failed');` },
-    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+    })) as RunResult;
 
     expect(result.isError).toBe(true);
     expect(textOf(result)).toContain('script failed');
@@ -103,7 +110,7 @@ describe('MCP: run_script tool', () => {
     const result = (await disabled.client.callTool({
       name: 'run_script',
       arguments: { code: `return 1;` },
-    })) as { isError?: boolean; content: Array<{ type: string; text?: string }> };
+    })) as RunResult;
 
     expect(result.isError).toBe(true);
     expect(textOf(result)).toContain('PRODUCTIVE_MCP_ENABLE_RUN');

--- a/tests/integration/mcp/run-script.test.ts
+++ b/tests/integration/mcp/run-script.test.ts
@@ -41,9 +41,20 @@ describe('MCP: run_script tool', () => {
     await mockServer.close();
   });
 
-  it('exposes run_script in the tool list', async () => {
+  it('exposes run_script and its docs tool in the tool list', async () => {
     const { tools } = await enabled.client.listTools();
     expect(tools.find((t) => t.name === 'run_script')).toBeDefined();
+    expect(tools.find((t) => t.name === 'run_script_search_docs')).toBeDefined();
+  });
+
+  it('serves the scripting API reference via run_script_search_docs', async () => {
+    const result = (await enabled.client.callTool({
+      name: 'run_script_search_docs',
+      arguments: { query: 'table' },
+    })) as RunResult;
+
+    expect(result.isError).toBeFalsy();
+    expect(textOf(result)).toContain('output.table');
   });
 
   it('runs a script that fetches data through the bridge', async () => {


### PR DESCRIPTION
## Summary

Adds a new **`run_script`** MCP tool that lets agents execute advanced multi-step JavaScript/TypeScript in a single call — the MCP counterpart to the CLI's `productive run`, but sandboxed so it is safe in the multi-tenant HTTP transport.

Scripts run inside a **QuickJS WASM isolate** with **no direct network or filesystem access** — they can't call `fetch`, open sockets, reach arbitrary URLs, or read files. Productive API access *is* available: the injected client's calls cross the bridge to the **host**, which performs the real HTTP request via `ProductiveApi` and re-enters the existing `executeToolWithCredentials` pipeline. So every call inherits credential scoping, rate limiting, include validation, and formatting; credentials stay out of the sandbox; and egress is constrained to the Productive API by construction.

It is exposed as a **separate top-level tool** (not a `productive` resource) to avoid confusing agents, and is **disabled by default** behind `PRODUCTIVE_MCP_ENABLE_RUN=true` (same gating model as `api_write`).

## What a script can use

- `productive(resource, action, params)` and `productive.<resource>.list/get/create/update` — mirrors the `productive` tool
- `api.read(path, opts)` / `api.write(method, path, body)` — raw API access
- `output.json/table/csv/log/info/warn/error/success` — buffered output returned with the result (best-effort: a non-serializable value emits a placeholder rather than aborting the run)
- `args` / `flags` inputs; `return <value>` to surface a result; `await` is supported

```jsonc
{
  "name": "run_script",
  "arguments": {
    "code": "const open = await productive.tasks.list({ status: 'open' });\noutput.json({ openTasks: open.length });\nreturn 'ok';"
  }
}
```

Returns `{ result, output, _run: { apiCalls, dryRun } }`. `dry_run: true` records mutating calls under `_run.recorded` instead of executing them.

## Design notes

- **API access is host-brokered, not in-sandbox.** The guest has no `fetch`; the host performs HTTP on its behalf through the injected client. This is what keeps the sandbox safe (no credential exposure, egress limited to Productive) while still letting scripts read/write Productive data.
- **One promise-based bridge for both transports.** Host functions return real guest promises (self-pumping via `executePendingJobs`), so scripts can `await` naturally across loops and `Promise.all` — asyncify was rejected because it cannot suspend inside `executePendingJobs` (breaks multi-call scripts). The bridge passes the tool's JSON text straight to the guest (no parse-then-restringify round trip).
- **TypeScript** input is stripped to JS via Node's built-in `stripTypeScriptTypes` (transform mode; handles enums). The CLI `run` is unchanged.
- **WASM module is cached** process-wide; each run gets a fresh, isolated context. Still-pending deferreds are disposed before teardown so a timeout/abort mid-call can't trip a QuickJS GC assertion.
- **Limits** (operator-tunable env vars): wall-clock timeout (handler abort signal + interrupt deadline for CPU loops), memory, API-call budget, output-size cap (UTF-8 byte accurate), code-size cap.
- Guest-supplied params can never override routing keys (`resource`/`action`/`id`/`filter`/`path`).

## Testing

- Unit tests for limits, gating, TS stripping, bridge, prelude, engine (real QuickJS, fake host), and handler — all DI, no real API. Includes byte-accurate truncation, param-collision routing, output best-effort, abort-mid-run, and clean teardown with an in-flight call.
- End-to-end integration tests drive `run_script` through the real MCP binary against the JSON:API mock server (bridged fetch, args/flags, dry-run, errors, disabled-by-default).
- Full suite green: 871 MCP unit + 54 integration tests; `npm run check` clean; build verified (QuickJS externalized, WASM not inlined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
