### PR TITLE
Allow run_script to run on a remote runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP**: Allow `run_script` to be delegated to a separate runner so script execution (memory/CPU/OOM) is isolated from the main server. When `PRODUCTIVE_MCP_RUN_RUNNER_URL` is set, the front forwards a stateless `{ code, args, flags, dry_run, credentials }` POST to the runner and relays its `ToolResult`; otherwise it runs locally as before. Adds a token-gated `/run` endpoint (`PRODUCTIVE_MCP_RUN_RUNNER_TOKEN`) on the HTTP transport. The contract is infrastructure-agnostic and load-balancer-ready (stateless, must not be proxy-retried since non-dry-run scripts can mutate) ([#182])
+
+[#182]: https://github.com/studiometa/productive-tools/pull/182
+
 ## [0.10.15] - 2026.06.10
 
 ### Added

--- a/packages/mcp/skills/SKILL.md
+++ b/packages/mcp/skills/SKILL.md
@@ -128,6 +128,19 @@ listed under `_run.recorded`.
 `PRODUCTIVE_MCP_RUN_MAX_API_CALLS` (50), `PRODUCTIVE_MCP_RUN_MAX_OUTPUT_KB` (256),
 `PRODUCTIVE_MCP_RUN_MAX_CODE_KB` (128).
 
+### Remote runner (operator-configurable)
+
+To isolate script execution (memory/CPU/OOM) from the main server, the front can
+delegate `run_script` to a separate runner over one stateless HTTP POST — agents see no
+difference. Set on the **front**: `PRODUCTIVE_MCP_RUN_RUNNER_URL` (the runner's `/run`
+endpoint; its presence enables `run_script` without the local `ENABLE_RUN` flag),
+`PRODUCTIVE_MCP_RUN_RUNNER_TOKEN` (shared secret), and optionally
+`PRODUCTIVE_MCP_RUN_RUNNER_TIMEOUT_MS` (30000). On the **runner** (HTTP transport): set
+`PRODUCTIVE_MCP_RUN_RUNNER_TOKEN` (activates the `/run` endpoint) and
+`PRODUCTIVE_MCP_ENABLE_RUN=true`. The `/run` contract is stateless and must not be retried
+at the proxy layer (a non-dry-run script may mutate), so any load balancer works in front
+of a runner pool.
+
 ## Common Parameters
 
 | Parameter  | Type    | Description                                                                              |

--- a/packages/mcp/src/handlers/run-endpoint.test.ts
+++ b/packages/mcp/src/handlers/run-endpoint.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for the /run endpoint core logic.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { RunEndpointExecutor } from './run-endpoint.js';
+import type { ToolResult } from './types.js';
+
+import { executeRunRequest } from './run-endpoint.js';
+
+const env = (o: Record<string, string>): NodeJS.ProcessEnv => o as NodeJS.ProcessEnv;
+const runnerEnv = env({ PRODUCTIVE_MCP_RUN_RUNNER_TOKEN: 'secret' });
+
+const credentials = { organizationId: 'o', apiToken: 't', userId: 'u' };
+
+function okResult(text: string): ToolResult {
+  return { content: [{ type: 'text', text }] };
+}
+
+const body = { code: 'return 1;', args: ['a'], flags: { x: 1 }, dry_run: true, credentials };
+
+describe('executeRunRequest', () => {
+  it('returns 404 when no runner token is configured', async () => {
+    const exec = vi.fn() as unknown as RunEndpointExecutor;
+    const res = await executeRunRequest(body, 'Bearer secret', exec, env({}));
+    expect(res.status).toBe(404);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 on a missing or wrong token', async () => {
+    const exec = vi.fn() as unknown as RunEndpointExecutor;
+    expect((await executeRunRequest(body, null, exec, runnerEnv)).status).toBe(401);
+    expect((await executeRunRequest(body, 'Bearer nope', exec, runnerEnv)).status).toBe(401);
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an invalid body', async () => {
+    const exec = vi.fn() as unknown as RunEndpointExecutor;
+    expect((await executeRunRequest(undefined, 'Bearer secret', exec, runnerEnv)).status).toBe(400);
+  });
+
+  it('returns 400 for missing/invalid credentials', async () => {
+    const exec = vi.fn() as unknown as RunEndpointExecutor;
+    const res = await executeRunRequest({ code: 'return 1;' }, 'Bearer secret', exec, runnerEnv);
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toContain('credentials');
+  });
+
+  it('returns 400 for missing code', async () => {
+    const exec = vi.fn() as unknown as RunEndpointExecutor;
+    const res = await executeRunRequest({ credentials }, 'Bearer secret', exec, runnerEnv);
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toContain('code');
+  });
+
+  it('runs the tool and returns 200 with the ToolResult', async () => {
+    const exec = vi.fn(async () => okResult('done')) as RunEndpointExecutor;
+    const res = await executeRunRequest(body, 'Bearer secret', exec, runnerEnv);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(okResult('done'));
+    expect(exec).toHaveBeenCalledWith(
+      'run_script',
+      { code: 'return 1;', args: ['a'], flags: { x: 1 }, dry_run: true },
+      credentials as ProductiveCredentials,
+    );
+  });
+});

--- a/packages/mcp/src/handlers/run-endpoint.ts
+++ b/packages/mcp/src/handlers/run-endpoint.ts
@@ -1,0 +1,100 @@
+/**
+ * `/run` HTTP endpoint — the runner side of remote `run_script` execution.
+ *
+ * A front server (with `PRODUCTIVE_MCP_RUN_RUNNER_URL` set) POSTs a stateless
+ * payload here; this endpoint authenticates the hop with a shared token and
+ * runs the script through the normal `run_script` pipeline (so the runner
+ * enforces its own `PRODUCTIVE_MCP_ENABLE_RUN` and limits). The result is the
+ * exact `ToolResult` the front relays back to the client.
+ *
+ * The endpoint only exists when `PRODUCTIVE_MCP_RUN_RUNNER_TOKEN` is set —
+ * otherwise it reports as not found, so a normal deployment never exposes it.
+ */
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { ToolResult } from './types.js';
+
+import { resolveRunnerConfig, runnerTokenMatches } from '../run/remote.js';
+
+/** Executor signature (executeToolWithCredentials), injected for testability. */
+export type RunEndpointExecutor = (
+  name: string,
+  args: Record<string, unknown>,
+  credentials: ProductiveCredentials,
+) => Promise<ToolResult>;
+
+export interface RunEndpointResult {
+  status: number;
+  body: unknown;
+}
+
+/** Extract a bearer token from an Authorization header. */
+function bearer(authHeader: string | null | undefined): string | undefined {
+  const match = authHeader?.match(/^Bearer\s+(.+)$/i);
+  return match?.[1];
+}
+
+/** Validate that a value is a usable credentials object. */
+function toCredentials(value: unknown): ProductiveCredentials | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const c = value as Record<string, unknown>;
+  if (typeof c.organizationId !== 'string' || typeof c.apiToken !== 'string') return undefined;
+  return {
+    organizationId: c.organizationId,
+    apiToken: c.apiToken,
+    userId: typeof c.userId === 'string' ? c.userId : undefined,
+  };
+}
+
+/**
+ * Core logic for the `/run` endpoint, decoupled from the HTTP framework.
+ *
+ * @returns the HTTP status and JSON body to send back.
+ */
+export async function executeRunRequest(
+  rawBody: unknown,
+  authHeader: string | null | undefined,
+  exec: RunEndpointExecutor,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<RunEndpointResult> {
+  const { token } = resolveRunnerConfig(env);
+
+  // No token configured → this server is not a runner; hide the endpoint.
+  if (!token) {
+    return { status: 404, body: { error: 'Not found' } };
+  }
+
+  if (!runnerTokenMatches(bearer(authHeader), token)) {
+    return { status: 401, body: { error: 'Unauthorized' } };
+  }
+
+  if (!rawBody || typeof rawBody !== 'object') {
+    return { status: 400, body: { error: 'Invalid JSON body' } };
+  }
+
+  const body = rawBody as Record<string, unknown>;
+  const credentials = toCredentials(body.credentials);
+  if (!credentials) {
+    return { status: 400, body: { error: 'Missing or invalid credentials' } };
+  }
+
+  if (typeof body.code !== 'string' || body.code.trim() === '') {
+    return { status: 400, body: { error: 'code is required' } };
+  }
+
+  // Reuse the normal tool pipeline: executeToolWithCredentials('run_script', …)
+  // routes to handleRunScript, which (no runner URL set on the runner) executes
+  // the sandbox locally and enforces PRODUCTIVE_MCP_ENABLE_RUN + limits.
+  const result = await exec(
+    'run_script',
+    {
+      code: body.code,
+      args: body.args,
+      flags: body.flags,
+      dry_run: body.dry_run,
+    },
+    credentials,
+  );
+
+  return { status: 200, body: result };
+}

--- a/packages/mcp/src/handlers/run.test.ts
+++ b/packages/mcp/src/handlers/run.test.ts
@@ -144,6 +144,53 @@ describe('handleRunScript', () => {
     expect(body.result).toEqual({ args: ['a', '1'], flags: { mine: true } });
   });
 
+  it('forwards to the remote runner when PRODUCTIVE_MCP_RUN_RUNNER_URL is set', async () => {
+    const exec = vi.fn() as unknown as ToolExecutor;
+    const remoteResult = { content: [{ type: 'text', text: 'from runner' }] };
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify(remoteResult), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    ) as unknown as typeof fetch;
+
+    // Note: ENABLE_RUN is NOT set — the runner URL alone enables forwarding.
+    const result = await handleRunScript(
+      { code: 'return 1;', args: ['x'], flags: { a: 1 }, dry_run: true },
+      credentials,
+      exec,
+      { PRODUCTIVE_MCP_RUN_RUNNER_URL: 'http://runner.internal/run' } as NodeJS.ProcessEnv,
+      { fetch: fetchImpl },
+    );
+
+    expect(result).toEqual(remoteResult);
+    // Did not execute locally.
+    expect(exec).not.toHaveBeenCalled();
+    const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('http://runner.internal/run');
+    expect(JSON.parse(init.body)).toMatchObject({
+      code: 'return 1;',
+      args: ['x'],
+      flags: { a: 1 },
+      dry_run: true,
+      credentials,
+    });
+  });
+
+  it('still requires code when forwarding to a runner', async () => {
+    const exec = vi.fn() as unknown as ToolExecutor;
+    const result = await handleRunScript(
+      { code: '  ' },
+      credentials,
+      exec,
+      { PRODUCTIVE_MCP_RUN_RUNNER_URL: 'http://runner.internal/run' } as NodeJS.ProcessEnv,
+      { fetch: vi.fn() as unknown as typeof fetch },
+    );
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('code is required');
+  });
+
   it('returns an error result when the script throws', async () => {
     const exec = vi.fn() as unknown as ToolExecutor;
     const result = await handleRunScript(

--- a/packages/mcp/src/handlers/run.ts
+++ b/packages/mcp/src/handlers/run.ts
@@ -17,6 +17,7 @@ import { UserInputError } from '../errors.js';
 import { createBridge } from '../run/bridge.js';
 import { runScript, ScriptError } from '../run/engine.js';
 import { isRunScriptEnabled, resolveRunLimits } from '../run/limits.js';
+import { resolveRunnerConfig, runScriptRemote } from '../run/remote.js';
 import { renderRunResult } from '../run/render.js';
 import { stripTypes } from '../run/strip.js';
 import { errorResult, inputErrorResult } from './utils.js';
@@ -26,6 +27,11 @@ export interface RunScriptArgs {
   args?: unknown;
   flags?: unknown;
   dry_run?: unknown;
+}
+
+/** Optional injected dependencies (for testing the remote path). */
+export interface RunScriptDeps {
+  fetch?: typeof fetch;
 }
 
 /** Coerce the `args` argument into a string array. */
@@ -50,11 +56,17 @@ export async function handleRunScript(
   credentials: ProductiveCredentials,
   exec: ToolExecutor,
   env: NodeJS.ProcessEnv = process.env,
+  deps: RunScriptDeps = {},
 ): Promise<ToolResult> {
-  if (!isRunScriptEnabled(env)) {
+  const runner = resolveRunnerConfig(env);
+
+  // A runner URL takes precedence over local execution and over the local
+  // enable flag — the front can be tiny and gated off while delegating runs to
+  // a separate, larger machine (which enforces its own PRODUCTIVE_MCP_ENABLE_RUN).
+  if (!runner.url && !isRunScriptEnabled(env)) {
     return inputErrorResult(
       new UserInputError(
-        'run_script is disabled. Set PRODUCTIVE_MCP_ENABLE_RUN=true to enable it.',
+        'run_script is disabled. Set PRODUCTIVE_MCP_ENABLE_RUN=true (or PRODUCTIVE_MCP_RUN_RUNNER_URL to delegate to a runner) to enable it.',
       ),
     );
   }
@@ -66,6 +78,21 @@ export async function handleRunScript(
         'Available globals: productive(resource, action, params), api.read/write, output.*, args, flags.',
         'Return a value to surface it as the result; use output.json(...) for additional data.',
       ]),
+    );
+  }
+
+  // Remote path: forward the call to the runner and relay its ToolResult.
+  if (runner.url) {
+    return runScriptRemote(
+      {
+        code: rawArgs.code,
+        args: normalizeArgs(rawArgs.args),
+        flags: normalizeFlags(rawArgs.flags),
+        dry_run: rawArgs.dry_run === true,
+        credentials,
+      },
+      runner,
+      deps.fetch,
     );
   }
 

--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -27,6 +27,7 @@ const OAUTH_PROTECTED_RESOURCE_PATH = '/.well-known/oauth-protected-resource/mcp
 
 import { parseAuthHeader, type ProductiveCredentials } from './auth.js';
 import { executeToolWithCredentials } from './handlers.js';
+import { executeRunRequest } from './handlers/run-endpoint.js';
 import { INSTRUCTIONS } from './instructions.js';
 import {
   oauthMetadataHandler,
@@ -273,6 +274,29 @@ export function createHttpApp(): H3 {
     '/health',
     defineHandler(() => {
       return { status: 'ok' };
+    }),
+  );
+
+  // Runner endpoint: a front server with PRODUCTIVE_MCP_RUN_RUNNER_URL forwards
+  // run_script calls here. Only active when PRODUCTIVE_MCP_RUN_RUNNER_TOKEN is
+  // set (otherwise it reports 404). Authenticated by that shared token.
+  app.post(
+    '/run',
+    defineHandler(async (event) => {
+      let parsedBody: unknown;
+      try {
+        parsedBody = await event.req.json();
+      } catch {
+        parsedBody = undefined;
+      }
+      const result = await executeRunRequest(
+        parsedBody,
+        event.req.headers.get('authorization'),
+        executeToolWithCredentials,
+      );
+      event.res.status = result.status;
+      event.res.headers.set('Content-Type', 'application/json');
+      return result.body;
     }),
   );
 

--- a/packages/mcp/src/run/remote.test.ts
+++ b/packages/mcp/src/run/remote.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for remote run_script execution.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+import type { ProductiveCredentials } from '../auth.js';
+
+import {
+  isRemoteRunner,
+  resolveRunnerConfig,
+  runnerTokenMatches,
+  runScriptRemote,
+  type RunScriptPayload,
+} from './remote.js';
+
+const env = (o: Record<string, string>): NodeJS.ProcessEnv => o as NodeJS.ProcessEnv;
+
+const credentials: ProductiveCredentials = {
+  apiToken: 't',
+  organizationId: 'o',
+  userId: 'u',
+};
+
+const payload: RunScriptPayload = {
+  code: 'return 1;',
+  args: [],
+  flags: {},
+  dry_run: false,
+  credentials,
+};
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('resolveRunnerConfig', () => {
+  it('returns undefined url/token and the default timeout when unset', () => {
+    expect(resolveRunnerConfig(env({}))).toEqual({
+      url: undefined,
+      token: undefined,
+      timeoutMs: 30_000,
+    });
+  });
+
+  it('reads url, token, and a custom timeout', () => {
+    expect(
+      resolveRunnerConfig(
+        env({
+          PRODUCTIVE_MCP_RUN_RUNNER_URL: 'http://runner/run',
+          PRODUCTIVE_MCP_RUN_RUNNER_TOKEN: 'secret',
+          PRODUCTIVE_MCP_RUN_RUNNER_TIMEOUT_MS: '5000',
+        }),
+      ),
+    ).toEqual({ url: 'http://runner/run', token: 'secret', timeoutMs: 5_000 });
+  });
+
+  it('falls back to the default timeout for invalid values', () => {
+    expect(
+      resolveRunnerConfig(env({ PRODUCTIVE_MCP_RUN_RUNNER_TIMEOUT_MS: 'nope' })).timeoutMs,
+    ).toBe(30_000);
+  });
+});
+
+describe('isRemoteRunner', () => {
+  it('is true only when a runner URL is set', () => {
+    expect(isRemoteRunner(env({}))).toBe(false);
+    expect(isRemoteRunner(env({ PRODUCTIVE_MCP_RUN_RUNNER_URL: 'http://r/run' }))).toBe(true);
+  });
+});
+
+describe('runnerTokenMatches', () => {
+  it('matches identical tokens and rejects everything else', () => {
+    expect(runnerTokenMatches('abc', 'abc')).toBe(true);
+    expect(runnerTokenMatches('abc', 'abd')).toBe(false);
+    expect(runnerTokenMatches('abc', 'abcd')).toBe(false); // length mismatch
+    expect(runnerTokenMatches(undefined, 'abc')).toBe(false);
+    expect(runnerTokenMatches('abc', undefined)).toBe(false);
+    expect(runnerTokenMatches(undefined, undefined)).toBe(false);
+  });
+});
+
+describe('runScriptRemote', () => {
+  const config = { url: 'http://runner.internal/run', token: 'secret', timeoutMs: 1_000 };
+
+  it('POSTs the payload with auth header and returns the runner ToolResult', async () => {
+    const toolResult = {
+      content: [{ type: 'text', text: 'ok' }],
+      structuredContent: { result: 1 },
+    };
+    const fetchImpl = vi.fn(async () => jsonResponse(toolResult)) as unknown as typeof fetch;
+
+    const result = await runScriptRemote(payload, config, fetchImpl);
+
+    expect(result).toEqual(toolResult);
+    const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe(config.url);
+    expect(init.method).toBe('POST');
+    expect(init.headers.authorization).toBe('Bearer secret');
+    expect(JSON.parse(init.body)).toMatchObject({ code: 'return 1;', credentials });
+  });
+
+  it('omits the auth header when no token is configured', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ content: [] })) as unknown as typeof fetch;
+    await runScriptRemote(payload, { url: 'http://r/run', timeoutMs: 1_000 }, fetchImpl);
+    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(init.headers.authorization).toBeUndefined();
+  });
+
+  it('returns an error result on a non-2xx response', async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response('boom', { status: 500 }),
+    ) as unknown as typeof fetch;
+    const result = await runScriptRemote(payload, config, fetchImpl);
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('500');
+  });
+
+  it('maps an abort to a timeout error result', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+    }) as unknown as typeof fetch;
+    const result = await runScriptRemote(payload, config, fetchImpl);
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('timed out');
+  });
+
+  it('maps a transport error to an error result', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    }) as unknown as typeof fetch;
+    const result = await runScriptRemote(payload, config, fetchImpl);
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('ECONNREFUSED');
+  });
+
+  it('errors when no url is configured', async () => {
+    const result = await runScriptRemote(payload, { timeoutMs: 1_000 });
+    expect(result.isError).toBe(true);
+  });
+});

--- a/packages/mcp/src/run/remote.ts
+++ b/packages/mcp/src/run/remote.ts
@@ -1,0 +1,117 @@
+/**
+ * Remote execution for `run_script`.
+ *
+ * When `PRODUCTIVE_MCP_RUN_RUNNER_URL` is set, the front server forwards a
+ * `run_script` call to a separate runner over a single stateless HTTP POST,
+ * instead of executing the QuickJS sandbox in-process. This keeps the front
+ * small and isolates a script's memory/CPU (and any OOM) on the runner.
+ *
+ * The contract is deliberately infrastructure-agnostic — any service that
+ * accepts the payload and returns a `ToolResult` works (a Fly machine pool, a
+ * load balancer in front of several runners, a serverless function, …). It is
+ * stateless (everything needed is in the body) and must NOT be retried at the
+ * proxy layer, since a non-dry-run script may mutate.
+ */
+
+import { timingSafeEqual } from 'node:crypto';
+
+import type { ProductiveCredentials } from '../auth.js';
+import type { ToolResult } from '../handlers/types.js';
+
+import { errorResult } from '../handlers/utils.js';
+
+export interface RunnerConfig {
+  /** Full URL of the runner's `/run` endpoint (front → runner). */
+  url?: string;
+  /** Shared secret the runner requires (defends the hop even on private nets). */
+  token?: string;
+  /** Front-side wall-clock timeout for the whole remote call, in ms. */
+  timeoutMs: number;
+}
+
+/** Request body sent to the runner's `/run` endpoint. */
+export interface RunScriptPayload {
+  code: string;
+  args: string[];
+  flags: Record<string, unknown>;
+  dry_run: boolean;
+  credentials: ProductiveCredentials;
+}
+
+const DEFAULT_RUNNER_TIMEOUT_MS = 30_000;
+
+/** Resolve runner configuration from the environment. */
+export function resolveRunnerConfig(env: NodeJS.ProcessEnv = process.env): RunnerConfig {
+  const raw = env.PRODUCTIVE_MCP_RUN_RUNNER_TIMEOUT_MS;
+  const parsed = raw === undefined ? NaN : Number(raw);
+  const timeoutMs = Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_RUNNER_TIMEOUT_MS;
+  return {
+    url: env.PRODUCTIVE_MCP_RUN_RUNNER_URL || undefined,
+    token: env.PRODUCTIVE_MCP_RUN_RUNNER_TOKEN || undefined,
+    timeoutMs,
+  };
+}
+
+/** Whether this server should forward run_script to a remote runner. */
+export function isRemoteRunner(env: NodeJS.ProcessEnv = process.env): boolean {
+  return !!resolveRunnerConfig(env).url;
+}
+
+/** Constant-time comparison of a provided runner token against the expected one. */
+export function runnerTokenMatches(
+  provided: string | undefined,
+  expected: string | undefined,
+): boolean {
+  if (!expected || !provided) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Forward a run_script call to the remote runner. Never throws: any transport
+ * or runner error is mapped to an error `ToolResult`.
+ */
+export async function runScriptRemote(
+  payload: RunScriptPayload,
+  config: RunnerConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ToolResult> {
+  if (!config.url) {
+    return errorResult('Remote runner URL is not configured.');
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), config.timeoutMs);
+
+  try {
+    const response = await fetchImpl(config.url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...(config.token ? { authorization: `Bearer ${config.token}` } : {}),
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      return errorResult(
+        `Remote runner returned ${response.status}${detail ? `: ${detail.slice(0, 500)}` : ''}`,
+      );
+    }
+
+    return (await response.json()) as ToolResult;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return errorResult(`Remote runner timed out after ${config.timeoutMs}ms.`);
+    }
+    return errorResult(
+      `Remote runner request failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary

Lets the MCP server delegate `run_script` execution to a separate **runner** so a script's memory/CPU (and any OOM) is isolated from the main server — important on small VMs (the hosted HTTP MCP runs on 256 MB, where a heavy in-process run could OOM-kill the whole server). Infrastructure-agnostic and load-balancer-ready.

## How it works

- **Front** (`PRODUCTIVE_MCP_RUN_RUNNER_URL` set): `handleRunScript` forwards a stateless `{ code, args, flags, dry_run, credentials }` POST to the runner and relays its `ToolResult`. The runner URL also enables `run_script` without the local `PRODUCTIVE_MCP_ENABLE_RUN` flag (the front can stay tiny + gated).
- **Runner** (HTTP transport, `PRODUCTIVE_MCP_RUN_RUNNER_TOKEN` set, `PRODUCTIVE_MCP_ENABLE_RUN=true`): a token-gated `POST /run` runs the script through the normal pipeline (its own limits + sandbox) and returns the `ToolResult`.
- **No runner configured**: runs locally exactly as before (graceful fallback). Agents see no difference either way.

## Infra-agnostic / LB-ready

The `/run` contract is a single stateless HTTP POST, so any backend works (Fly machine pool, k8s, serverless, …) and you can put a load balancer in front of a runner pool. It is:
- **stateless** — everything is in the body, no session/affinity;
- **token-authenticated** — `PRODUCTIVE_MCP_RUN_RUNNER_TOKEN` (constant-time compare), so the hop is safe even on a shared private network;
- **not to be proxy-retried** — a non-`dry_run` script can mutate, so retries must be disabled at the LB/proxy.

## Config

Front: `PRODUCTIVE_MCP_RUN_RUNNER_URL`, `PRODUCTIVE_MCP_RUN_RUNNER_TOKEN`, optional `PRODUCTIVE_MCP_RUN_RUNNER_TIMEOUT_MS` (30000).
Runner: `PRODUCTIVE_MCP_RUN_RUNNER_TOKEN` (activates `/run`), `PRODUCTIVE_MCP_ENABLE_RUN=true`, plus the existing `PRODUCTIVE_MCP_RUN_*` limits.

## Testing

- Unit tests: `remote.ts` (config parsing, token compare, forwarding success/non-2xx/timeout/transport-error, header/body), `/run` core (`run-endpoint.ts` — token gating 404/401, body/credential validation, happy path), and the `handleRunScript` remote branch (forwards, doesn't run locally, still validates code).
- 926 MCP unit tests pass; `npm run check` clean; build OK. The thin H3 wiring in `http.ts` is covered by the `executeRunRequest` core tests.

Depends on a release before the runner deployment can pin it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
