### PR TITLE
Clarify run_script productive client return shape in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MCP**: Clarify the `run_script` scripting docs (served by `search_docs`) — the injected `productive` client returns flattened records and `list` returns `{ data, meta }` (use `meta.total_count`); read field keys directly (`id`, `name`, `number`) rather than JSON:API `.type`/`.attributes`, and bound large queries with `opts` like `{ per_page: 50 }` ([#183])
+
+[#183]: https://github.com/studiometa/productive-tools/pull/183
+
 ## [0.10.16] - 2026.06.10
 
 ### Added

--- a/packages/mcp/src/run/docs.ts
+++ b/packages/mcp/src/run/docs.ts
@@ -53,7 +53,11 @@ export const DOC_SECTIONS: DocSection[] = [
       '- `productive.<resource>.create(params)`',
       '- `productive.<resource>.update(id, params)`',
       '',
-      "Example: `const tasks = await productive.tasks.list({ status: 'open' });`",
+      'Results mirror the `productive` tool: `list` returns `{ data, meta }` (e.g. `meta.total_count`),',
+      'and records are flattened — read field keys directly (e.g. `id`, `name`, `number`), not JSON:API',
+      '`.type`/`.attributes`. Pass `opts` like `{ per_page: 50 }` to bound large queries.',
+      '',
+      "Example: `const { data } = await productive.tasks.list({ status: 'open' }, { per_page: 50 });`",
     ].join('\n'),
   },
   {


### PR DESCRIPTION
Small docs follow-up from live testing of the runner-backed `run_script`.

The injected `productive` client returns **flattened** records (read `id`, `name`, `number` directly, not JSON:API `.type`/`.attributes`) and `list` returns `{ data, meta }` (e.g. `meta.total_count`). The scripting docs (surfaced by `search_docs`) now say so, and the example shows bounding large queries with `{ per_page: 50 }` (a slow unbounded `tasks.list({status:'open'})` was the one rough edge in testing).

Docs-only; no behavior change. 11 doc/search tests pass, `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)